### PR TITLE
fix: print login error instead of silent exit

### DIFF
--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -137,8 +137,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if cfg.mode == "login":
-        _run_manual_login(cfg)
-        return 0
+        return _run_manual_login(cfg)
 
     args_with_cfg = args
     if args_with_cfg is not None:
@@ -156,12 +155,17 @@ def _interactive_prompt() -> AppConfig | None:
     return surface_cli_interactive_controller.InteractiveController(container.core).interactive_prompt()
 
 
-def _run_manual_login(cfg: AppConfig) -> None:
-    """Launch visible browser for interactive login (TTY flow in the surface)."""
+def _run_manual_login(cfg: AppConfig) -> int:
+    """Launch visible browser for interactive login (TTY flow in the surface).
+
+    Returns 0 on success, 1 on failure (error printed to stderr).
+    """
     container = _default_container()
     result = surface_cli_login_command.handle(None, container.core, cfg)
     if not result.get("success"):
         print(result.get("error", "Unknown error"), file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -159,7 +159,9 @@ def _interactive_prompt() -> AppConfig | None:
 def _run_manual_login(cfg: AppConfig) -> None:
     """Launch visible browser for interactive login (TTY flow in the surface)."""
     container = _default_container()
-    surface_cli_login_command.handle(None, container.core, cfg)
+    result = surface_cli_login_command.handle(None, container.core, cfg)
+    if not result.get("success"):
+        print(result.get("error", "Unknown error"), file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -144,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
         args_with_cfg._cfg = cfg
     result = surface_cli_run_command.handle(args_with_cfg, container.core)
     if not result.get("success"):
-        print(result.get("error", "Unknown error"), file=sys.stderr)
+        print(result.get("error") or "Unknown error", file=sys.stderr)
         return 1
     return 0
 
@@ -163,7 +163,7 @@ def _run_manual_login(cfg: AppConfig) -> int:
     container = _default_container()
     result = surface_cli_login_command.handle(None, container.core, cfg)
     if not result.get("success"):
-        print(result.get("error", "Unknown error"), file=sys.stderr)
+        print(result.get("error") or "Unknown error", file=sys.stderr)
         return 1
     return 0
 

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -64,7 +64,8 @@ class TestMainRemainingPaths:
                 proc_path=tmp_path / "proc",
                 session_path=tmp_path / "session",
             )
-            _run_manual_login(cfg)
+            result = _run_manual_login(cfg)
+            assert result == 0
 
 
 # ─── mcp_server.py remaining async functions ────────────────────────────────

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -214,15 +214,17 @@ class TestMain:
             assert result == 0
 
     def test_main_login_mode(self):
-        with patch("sys.argv", ["qwen-cli", "--login"]), patch(
-            "modules.root_cli_main_entry._run_manual_login", return_value=0
+        with (
+            patch("sys.argv", ["qwen-cli", "--login"]),
+            patch("modules.root_cli_main_entry._run_manual_login", return_value=0),
         ):
             result = main()
             assert result == 0
 
     def test_main_login_mode_failure(self):
-        with patch("sys.argv", ["qwen-cli", "--login"]), patch(
-            "modules.root_cli_main_entry._run_manual_login", return_value=1
+        with (
+            patch("sys.argv", ["qwen-cli", "--login"]),
+            patch("modules.root_cli_main_entry._run_manual_login", return_value=1),
         ):
             result = main()
             assert result == 1

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -147,8 +147,9 @@ class TestRunManualLogin:
             )
             from modules.root_cli_main_entry import _run_manual_login
 
-            _run_manual_login(cfg)
+            result = _run_manual_login(cfg)
             mock_handle.assert_called_once()
+            assert result == 1
 
     def test_login_opens_browser(self):
         with (
@@ -169,8 +170,30 @@ class TestRunManualLogin:
             )
             from modules.root_cli_main_entry import _run_manual_login
 
-            _run_manual_login(cfg)
+            result = _run_manual_login(cfg)
             mock_handle.assert_called_once()
+            assert result == 0
+
+    def test_failure_prints_error_to_stderr(self, capsys):
+        with patch(
+            "modules.cli.src.surface_cli_login_command.handle",
+            return_value={"success": False, "error": "Manual login requires an interactive terminal (TTY)"},
+        ):
+            cfg = AppConfig(
+                mode="login",
+                input_path=Path("/tmp/in"),
+                output_path=Path("/tmp/out"),
+                done_path=Path("/tmp/done"),
+                failed_path=Path("/tmp/failed"),
+                proc_path=Path("/tmp/proc"),
+                session_path=Path("/tmp/session"),
+            )
+            from modules.root_cli_main_entry import _run_manual_login
+
+            result = _run_manual_login(cfg)
+            captured = capsys.readouterr()
+            assert "Manual login requires an interactive terminal (TTY)" in captured.err
+            assert result == 1
 
 
 class TestMain:
@@ -191,9 +214,18 @@ class TestMain:
             assert result == 0
 
     def test_main_login_mode(self):
-        with patch("sys.argv", ["qwen-cli", "--login"]), patch("modules.root_cli_main_entry._run_manual_login"):
+        with patch("sys.argv", ["qwen-cli", "--login"]), patch(
+            "modules.root_cli_main_entry._run_manual_login", return_value=0
+        ):
             result = main()
             assert result == 0
+
+    def test_main_login_mode_failure(self):
+        with patch("sys.argv", ["qwen-cli", "--login"]), patch(
+            "modules.root_cli_main_entry._run_manual_login", return_value=1
+        ):
+            result = main()
+            assert result == 1
 
     def test_main_batch_mode(self, tmp_path):
         in_dir = tmp_path / "in"


### PR DESCRIPTION
## Problem

 ignored the return value from , causing silent exits when browser launch failed.

## Fix

Capture the result and print errors to stderr so users can see what went wrong (e.g., 'Manual login requires an interactive terminal (TTY)').

Generated with Qwen Code (17-shotted by Qwen-Coder)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prints manual login errors to stderr and exits non-zero when browser launch fails. Previously `--login` could exit silently with code 0; now failures return 1 and show an error, falling back to `Unknown error` if the handler provides a null/empty message.

- `_run_manual_login(cfg)` returns 0 on success and 1 on failure; `main()` in `--login` mode returns that value.
- On failure, prints the message from `modules.cli.src.surface_cli_login_command.handle()` to stderr; both login and non-login paths use `result.get("error") or "Unknown error"` when printing errors from `surface_cli_run_command.handle()`.
- If you script against `--login`, handle exit code 1 on failure.
- Adds tests for stderr output and exit code propagation, including `main()` returning 1 on login failure.

<sup>Written for commit 3dfe461ccf5f659800a2fe376a0a144c7e5ac834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

