### PR TITLE
ci: add release automation and PR maintenance workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,73 @@
+# GitHub Labeler configuration (actions/labeler v7 format).
+# Labels are applied to PRs based on which files they change.
+
+# Python
+python:
+  - changed-files:
+      - any-glob-to-any-file: modules/**/*.py
+      - any-glob-to-any-file: tests/**/*.py
+
+# Module areas
+cli:
+  - changed-files:
+      - any-glob-to-any-file: modules/cli/**
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file: modules/mcp/**
+      - any-glob-to-any-file: .mcp.json
+      - any-glob-to-any-file: mcp.local.json
+
+core:
+  - changed-files:
+      - any-glob-to-any-file: modules/core/**
+      - any-glob-to-any-file: modules/shared/**
+
+# CI / Workflows
+ci:
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/**
+      - any-glob-to-any-file: .github/labeler.yml
+      - any-glob-to-any-file: .github/dependabot.yml
+
+# Documentation
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
+
+# Configuration
+configuration:
+  - changed-files:
+      - any-glob-to-any-file: "*.yaml"
+      - any-glob-to-any-file: "*.yml"
+      - any-glob-to-any-file: "*.toml"
+      - any-glob-to-any-file: "*.ini"
+      - any-glob-to-any-file: "*.json"
+      - any-glob-to-any-file: .codacy.yaml
+      - any-glob-to-any-file: lint_arwaky.config.yaml
+      - any-glob-to-any-file: pyrightconfig.json
+
+# Dependencies
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: pyproject.toml
+      - any-glob-to-any-file: uv.lock
+      - any-glob-to-any-file: requirements.txt
+      - any-glob-to-any-file: modules/**/pyproject.toml
+
+# Tests
+tests:
+  - changed-files:
+      - any-glob-to-any-file: tests/**
+
+# Fixtures (test inputs / recorded artifacts)
+fixtures:
+  - changed-files:
+      - any-glob-to-any-file: tests/fixtures/**
+      - any-glob-to-any-file: tests/artifacts/**
+
+# Deployment / ops
+deployment:
+  - changed-files:
+      - any-glob-to-any-file: deploy/**
+      - any-glob-to-any-file: scripts/**

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto-merge gated PRs
+
+# Merges a PR automatically once all required status checks pass.
+# Branch protection on main should require the CI quality gates
+# ("Format (ruff format)", "Lint (ruff check + mypy)", "Build package",
+# "Tests (pytest)" for each matrix Python, "Self-Lint (lint-arwaky-cli)").
+# GitHub's native auto-merge holds the PR until those checks succeed, then
+# merges. Repository setting "Allow auto-merge" is already enabled.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    # Only for PRs targeting main, not draft, and not already merged.
+    if: >
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.merged == false
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Values arrive via env vars (escaped by the runner), never inline
+          # interpolation, to prevent command injection through PR metadata.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # --auto holds the PR until the branch-protection/required checks
+          # pass, then merges with squash. Idempotent across re-runs.
+          gh pr merge "$PR_NUMBER" --auto --squash \
+            --subject "$PR_TITLE" || \
+            echo "Auto-merge not available yet (e.g. checks still pending) — a later event will retry."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,217 @@
+name: Auto-Release
+
+# Opens a versioned release PR automatically after CI passes on main.
+# Conventional commit types drive the version bump:
+#   feat! / fix! / BREAKING CHANGE footer -> MAJOR
+#   feat                                -> MINOR
+#   fix / other                         -> PATCH
+# The PR bumps pyproject.toml + uv.lock and prepends a CHANGELOG.md entry.
+# Once it merges, tag-release-prs.yml creates the v* tag and dispatches
+# release.yml for the actual build.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write       # push the release branch
+  pull-requests: write  # open + auto-merge the release PR
+  actions: write        # dispatch CI on the release branch
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Open release PR
+    runs-on: ubuntu-latest
+    # Only run when CI succeeded on a push to main; skip the version-bump
+    # merge commit itself (prevents an infinite release loop). Manual dispatch
+    # must target refs/heads/main — never run the privileged release path
+    # otherwise.
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_commit.message != 'Initial commit' &&
+       !startsWith(github.event.workflow_run.head_commit.message, 'chore(release):'))
+    steps:
+      # Checkout the static main ref (not the incoming workflow_run ref),
+      # which security scanners flag as a risk. Release integrity is still
+      # guaranteed by verifying the tip of main matches the exact SHA that
+      # CI tested — see the next step.
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Skip if the tested commit is no longer main's tip
+        # A later push may have landed while CI was running; releasing it
+        # would tag commits that were never gated. Only release when the
+        # SHA that passed CI is still the tip of main.
+        id: staleness
+        if: github.event_name == 'workflow_run'
+        run: |
+          TIP=$(git rev-parse refs/remotes/origin/main)
+          TESTED="${{ github.event.workflow_run.head_sha }}"
+          if [ "$TIP" != "$TESTED" ]; then
+            echo "main tip ($TIP) != tested SHA ($TESTED) — skipping release."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "Tested commit is still main's tip."
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Determine next version from commit history
+        id: version
+        if: steps.staleness.outputs.stale != 'true'
+        run: |
+          # Newest vX.Y.Z tag reachable from HEAD, descending version sort.
+          LAST_TAG=$(git tag --merged HEAD --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            # No tags yet — derive base version from pyproject.toml and inspect
+            # all commits. grep must fail through to the default when there is
+            # no root version.
+            CURRENT=$(grep -m1 -oP '^version\s*=\s*"\K[^"]+' pyproject.toml || true)
+            if [ -z "$CURRENT" ]; then
+              CURRENT="0.1.0"
+            fi
+            LAST_TAG="v${CURRENT}"
+            RANGE="HEAD"
+          else
+            RANGE="${LAST_TAG}..HEAD"
+          fi
+          echo "range=${RANGE}" >> "$GITHUB_OUTPUT"
+          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Conventional commit detection.
+          # Breaking change via subject: `feat!:`, `feat(scope)!:`, `fix!:` etc.
+          MAJOR_SUBJECT=$(git log "$RANGE" --oneline --grep='^[a-zA-Z]*(.*)!:' -E | head -1)
+          # Breaking change via footer: `BREAKING CHANGE: ...` in the body.
+          MAJOR_FOOTER=$(git log "$RANGE" --format=%B | grep -m1 '^BREAKING CHANGE:' || true)
+          # Minor: only `feat:` or `feat(scope):` — not e.g. `feature:`.
+          FEAT=$(git log "$RANGE" --oneline --grep='^feat(\([^)]+\))?:' -E | head -1)
+
+          BASE="${LAST_TAG#v}"
+          IFS='.' read -r MAJ_V MIN_V PAT_V <<< "$BASE"
+          MAJ_V=${MAJ_V:-0}; MIN_V=${MIN_V:-0}; PAT_V=${PAT_V:-0}
+
+          if [ -n "$MAJOR_SUBJECT" ] || [ -n "$MAJOR_FOOTER" ]; then
+            NEW="$((MAJ_V + 1)).0.0"
+          elif [ -n "$FEAT" ]; then
+            NEW="${MAJ_V}.$((MIN_V + 1)).0"
+          else
+            NEW="${MAJ_V}.${MIN_V}.$((PAT_V + 1))"
+          fi
+          echo "version=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "New version: ${NEW}"
+
+      - name: Bump version (pyproject.toml + uv.lock)
+        if: steps.staleness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # The root [project] version is the single source of truth (same
+          # convention as scripts/release.sh).
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          # Refresh ONLY the root package's locked version — dependency
+          # constraints are unchanged, so uv lock cannot pull untested
+          # dependency upgrades into the release.
+          uv lock
+
+      - name: Update CHANGELOG.md
+        if: steps.staleness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RANGE: ${{ steps.version.outputs.range }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          # Group conventional commit messages since the previous release.
+          FEATS=$(git log "$RANGE" --pretty=format:'- %s' --grep='^feat(\([^)]+\))?:' -E | head -20)
+          FIXES=$(git log "$RANGE" --pretty=format:'- %s' --grep='^fix(\([^)]+\))?:' -E | head -20)
+          CHORES=$(git log "$RANGE" --pretty=format:'- %s' --grep='^(chore|refactor|docs|test|perf|ci|build|style)(\([^)]+\))?:' -E | head -20)
+          python3 - "$VERSION" "$DATE" "$FEATS" "$FIXES" "$CHORES" <<'PYEOF'
+          import re
+          import sys
+
+          version, date, feats, fixes, chores = sys.argv[1:6]
+          sections = []
+          if feats.strip():
+              sections.append("### Added\n\n" + feats.strip())
+          if fixes.strip():
+              sections.append("### Fixed\n\n" + fixes.strip())
+          if chores.strip():
+              sections.append("### Changed\n\n" + chores.strip())
+          if not sections:
+              sections.append("- No significant changes")
+          body = "\n\n".join(sections)
+          entry = f"## [{version}] - {date}\n\n{body}\n\n"
+          with open("CHANGELOG.md") as f:
+              content = f.read()
+          # Keep a Changelog layout: header block first, then releases
+          # newest-first — insert before the first existing release heading.
+          m = re.search(r"^## \[", content, flags=re.M)
+          idx = m.start() if m else len(content)
+          with open("CHANGELOG.md", "w") as f:
+              f.write(content[:idx] + entry + content[idx:])
+          PYEOF
+
+      - name: Open release PR
+        if: steps.staleness.outputs.stale != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/v${VERSION}"
+
+          # Skip only when an open release PR for this version already exists
+          # (prevents duplicate release PRs after a merge). The branch itself
+          # may exist from a previous attempt and is overwritten below.
+          if gh pr list --head "$BRANCH" --state open --json number \
+            --jq 'length' 2>/dev/null | grep -q '[1-9]'; then
+            echo "Release PR for ${VERSION} already open — skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock CHANGELOG.md
+          git commit -m "chore(release): v${VERSION}"
+
+          # Create the release branch and push it. --force-with-lease
+          # overwrites a stale branch from a previous attempt but refuses to
+          # clobber anything pushed concurrently.
+          git switch -c "$BRANCH"
+          git push -u origin "$BRANCH" --force-with-lease
+
+          # Open a PR to main; a failure here must fail the job.
+          PR_BODY=$(cat <<BODY
+          Automated release PR for v${VERSION}.
+
+          ## Changelog
+
+          See the v${VERSION} entry in [CHANGELOG.md](CHANGELOG.md).
+          BODY
+          )
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(release): v${VERSION}" \
+            --body "$PR_BODY"
+
+          # PRs opened with GITHUB_TOKEN do not fire on:pull_request workflows
+          # (GitHub anti-recursion guard), so dispatch CI on the release branch
+          # explicitly — the checks attach to the same head SHA and gate the
+          # PR — then arm auto-merge so the PR lands once checks pass.
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge --auto --squash \
+            --subject "chore(release): v${VERSION}" "$BRANCH" || \
+            echo "Auto-merge not available yet (e.g. checks still pending) — the auto-merge workflow re-arms on later PR events."

--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,0 +1,82 @@
+name: Cleanup merged branches
+
+# Automatically deletes branches after their PR is merged, keeping the
+# remote branch list tidy.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete merged branch
+    runs-on: ubuntu-latest
+    # Only delete branches from this repository — never a fork. A fork PR's
+    # head.ref names a branch in the fork, which must not be deleted here
+    # (and could otherwise collide with a same-named branch in this repo).
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Delete remote branch
+        run: |
+          # The branch name arrives via an environment variable (safely
+          # escaped by the runner) instead of inline interpolation.
+          BRANCH="$BRANCH_NAME"
+          MERGED_SHA="$MERGED_SHA"
+
+          # Never delete protected branches
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "develop" ]; then
+            echo "Skipping protected branch: ${BRANCH}"
+            exit 0
+          fi
+
+          # Validate the branch name with git's own ref rules — this rejects
+          # anything that could be shell-injected or is not a legal ref name,
+          # while still allowing legal names (e.g. feature@v2). The --allow-onelevel
+          # default is fine here; release/v* style names pass as-is.
+          if ! git check-ref-format --branch "$BRANCH"; then
+            echo "Skipping invalid git ref name: ${BRANCH}"
+            exit 0
+          fi
+
+          # Only delete the exact branch state that was merged. If the branch
+          # was force-pushed or recreated after the merge while this job was
+          # queued, deleting would remove unmerged work — bail out instead.
+          CURRENT_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/${BRANCH}" \
+            --jq '.object.sha' 2>/dev/null || true)
+          if [ -z "$CURRENT_SHA" ]; then
+            echo "Branch ${BRANCH} already deleted."
+            exit 0
+          fi
+          if [ "$CURRENT_SHA" != "$MERGED_SHA" ]; then
+            echo "Branch ${BRANCH} moved since merge (${CURRENT_SHA:0:8} != ${MERGED_SHA:0:8}) — skipping."
+            exit 0
+          fi
+
+          # Delete the branch. GitHub's Delete a reference endpoint returns
+          # 204 on success, 422 when the ref no longer exists, and 409/other
+          # on conflicts. Treat 422 as "already deleted" (idempotent); any
+          # other failure fails the job so it is not silently swallowed.
+          RESPONSE=$(gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/heads/${BRANCH}" \
+            --include --silent 2>&1 || true)
+          STATUS=$(printf '%s' "$RESPONSE" | head -1 | grep -oE '[0-9]{3}' | head -1)
+          if [ -z "$STATUS" ]; then
+            echo "Failed to delete branch ${BRANCH}: no HTTP status returned."
+            exit 1
+          fi
+          if [ "$STATUS" = "204" ]; then
+            echo "Deleted branch ${BRANCH}."
+          elif [ "$STATUS" = "422" ]; then
+            echo "Branch ${BRANCH} already deleted."
+          else
+            echo "Failed to delete branch ${BRANCH} (HTTP ${STATUS})."
+            exit 1
+          fi
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          MERGED_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,25 @@
+name: PR Labeler
+
+# Applies labels to PRs based on changed files (see .github/labeler.yml).
+# Also syncs labels when a PR is updated.
+
+on:
+  # pull_request_target gives the token write access to label PRs opened
+  # from forks. This workflow only reads changed-file metadata (no checkout,
+  # no code execution), so the privileged event is safe here.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,137 @@
 name: Release
 
+# Builds and publishes the Python distributions (sdist + wheel) for a v* tag.
+# Chain: auto-release.yml opens a release PR -> auto-merge.yml lands it after
+# the required checks pass -> tag-release-prs.yml tags the merge commit and
+# dispatches this workflow (GITHUB_TOKEN tag pushes do not trigger workflows).
+
 on:
   push:
     tags:
-      - 'v*'
+      - "v*.*.*"
+  # Allows the tag-release-prs workflow to dispatch the release build after
+  # creating the tag. The checks below run on the tag ref.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (e.g. v4.0.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
-  test-before-release:
-    name: Run Test Suite
+  test:
+    # Final safety net: run the same test suite as CI before publishing.
+    name: Run test suite
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install project
+        run: uv sync --no-dev
+
+      - name: Install test deps
+        run: uv pip install pytest pytest-asyncio pytest-cov pytest-mock
+
+      - name: Install system dependencies (Playwright)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
+            libcups2 libdrm2 libdbus-1-3 libxkbcommon0 libxcomposite1 libxdamage1 \
+            libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
+            libatspi2.0-0
+
+      - name: Install Playwright browser
+        run: uv run python -m playwright install chromium
+
+      - name: Run tests
+        run: uv run python -m pytest tests/ --ignore=tests/test_e2e_pipeline.py -v
+
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - uses: actions/upload-artifact@v7
         with:
-          python-version: "3.11"
+          name: dist
+          path: dist/*
 
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov pytest-mock playwright
-          python -m playwright install --with-deps chromium
+  smoke-test:
+    name: Smoke test wheel
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
 
-      - name: Run Pytest Suite
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Set up Python and install the wheel in a clean venv
         run: |
-          pytest tests/ --ignore=tests/test_e2e_pipeline.py -v
+          uv python install 3.12
+          uv venv .venv
+          uv pip install --python .venv/bin/python dist/*.whl
+
+      - name: Verify CLI entry point
+        run: .venv/bin/qwen-web-cli --help | grep -q "Automate chat.qwen.ai"
+
+      - name: Verify MCP entry point imports
+        # The MCP server blocks on stdio, so verify import instead of running it.
+        run: .venv/bin/python -c "import modules.root_mcp_main_entry; print('MCP module import OK')"
+
+  provenance:
+    name: Generate SLSA provenance
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "dist/*"
 
   release:
     name: Create GitHub Release
-    needs: test-before-release
     runs-on: ubuntu-latest
+    needs: [smoke-test, provenance]
     permissions:
       contents: write
-
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v7
+      - uses: actions/download-artifact@v8
         with:
-          python-version: "3.11"
+          name: dist
+          path: dist
 
-      - name: Build Package
-        run: |
-          python -m pip install --upgrade pip build
-          python -m build
-
-      - name: Create Release
-        uses: softprops/action-gh-release@d1e66170d32c9ec7bbcb7fae044d3d686ce304d3
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/tag-release-prs.yml
+++ b/.github/workflows/tag-release-prs.yml
@@ -1,0 +1,76 @@
+name: Tag release PRs
+
+# Creates the v* tag for a merged release PR. The auto-release workflow
+# cannot push tags to main directly (main is protected), so it opens a
+# release PR instead. Once that PR is merged, this workflow creates the tag
+# from the squash-merge commit, then explicitly dispatches the release build
+# (a tag pushed with GITHUB_TOKEN does not trigger other workflows).
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write  # create + push the tag
+  actions: write   # dispatch release.yml
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    # Only for release PRs: merged into main, authored by the release bot,
+    # from a release/v* branch, with the chore(release): title prefix.
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'release/v') &&
+      startsWith(github.event.pull_request.title, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create and push tag
+        id: tag
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The squash-merge subject is the release PR title (armed by
+          # auto-merge --subject): "chore(release): vX.Y.Z".
+          VERSION=$(git log -1 --format=%s "$MERGE_SHA" \
+            | sed -E 's/^chore\(release\): v//' | xargs)
+          if [ -z "$VERSION" ]; then
+            echo "Could not resolve version from merge commit."
+            exit 1
+          fi
+          # Accept only a strict X.Y.Z version.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version from commit message: ${VERSION}"
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists."
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git tag "$TAG" "$MERGE_SHA"
+          # Checkout keeps no credentials (persist-credentials: false), so
+          # authenticate the push explicitly with the workflow token.
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TAG"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Pushed tag ${TAG}."
+
+      - name: Dispatch release build
+        # GITHUB_TOKEN cannot trigger workflows via tag push, so dispatch
+        # release.yml explicitly. release.yml declares on: workflow_dispatch
+        # with a required "tag" input — it must be passed here.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          gh workflow run release.yml --ref "v${RELEASE_VERSION}" -f "tag=v${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

Adds the GitHub-only automation layer (adapted to this Python/uv project):

- **`auto-release.yml`** — after CI passes on main, opens a `chore(release): vX.Y.Z`
  PR that bumps `pyproject.toml` + `uv.lock` (via `uv lock`, same convention as
  `scripts/release.sh`) and prepends a Keep-a-Changelog entry to `CHANGELOG.md`.
  Conventional commits drive the bump (`!:`/`BREAKING CHANGE` → major,
  `feat:` → minor, else patch). Dispatches CI on the release branch and arms
  auto-merge (PRs opened with GITHUB_TOKEN don't fire `on:pull_request`).
- **`auto-merge.yml`** — arms native auto-merge (squash) on non-draft PRs to
  main; GitHub holds the merge until required checks pass.
- **`tag-release-prs.yml`** — when a release PR merges, tags the squash-merge
  commit `vX.Y.Z` and dispatches `release.yml` (GITHUB_TOKEN tag pushes don't
  trigger workflows).
- **`release.yml`** (refreshed) — `test` (same pytest suite as CI) → `uv build`
  → wheel smoke test (`qwen-web-cli --help`, MCP module import) → SLSA
  provenance attestation → GitHub Release with `dist/*`. Now also supports
  `workflow_dispatch` with a required `tag` input.
- **`pr-labeler.yml` + `.github/labeler.yml`** — path-based PR labels using
  actions/labeler v7 (pinned SHA), globs matched to this repo (`modules/**`,
  `tests/**`, `deploy/**`, `pyproject.toml`, `uv.lock`, …).
- **`cleanup-merged-branches.yml`** — deletes the head branch after a merge,
  guarded against forks, protected branches, ref-name injection, and
  force-pushed branches.

## Catatan penyesuaian dari draft (Rust/lint-arwaky → Python/qwen-web)

- `Cargo.toml`/`Cargo.lock` → `pyproject.toml` + `uv lock`
- Rust toolchain/mold/sccache dihapus; build = `uv build` (sdist + wheel)
- Smoke test: install wheel ke venv bersih, cek `qwen-web-cli --help` dan
  import `modules.root_mcp_main_entry` (MCP server blocking di stdio)
- Semua versi/pin action diverifikasi terhadap GitHub (labeler v7 SHA,
  action-gh-release v3.0.2 SHA, checkout/upload-artifact/download-artifact/
  attest-build-provenance tags)
- Fix bug draft: duplikat key `env:` dalam satu step (YAML invalid),
  dispatch tanpa required input `tag`, `git push` tanpa kredensial saat
  `persist-credentials: false`, tambah permission `actions: write` untuk
  `gh workflow run`

## Prasyarat setelah merge

1. **Branch protection / ruleset di `main`** (disarankan): wajibkan check
   `Format (ruff format)`, `Lint (ruff check + mypy)`, `Build package`,
   `Tests (pytest)`, `Tests (pytest) (3.12)`, `Tests (pytest) (3.13)`,
   `Self-Lint (lint-arwaky-cli)` agar rantai auto-merge → tag → release
   berjalan otomatis penuh. Tanpa ini, auto-merge tetap bekerja tapi merge
   terjadi segera setelah check yang ada hijau.
2. Alur pertama kali: belum ada tag → auto-release menurunkan base `v4.0.0`
   dari `pyproject.toml` dan membuka PR `chore(release): v4.0.x` berikutnya.
3. Label-label untuk labeler sudah dibuat (python, cli, mcp, core, ci,
   configuration, dependencies, tests, fixtures, deployment).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates releases and PR maintenance with GitHub Actions for this `uv`-based Python project. Previously these steps were manual; now CI opens and gates versioned release PRs, tags the merge, builds and publishes artifacts with provenance, labels PRs by path, and deletes merged branches.

- Adds `auto-release.yml`: after CI succeeds on `main`, opens a `chore(release): vX.Y.Z` PR that bumps `pyproject.toml` and `uv.lock`, prepends Keep a Changelog, derives version from conventional commits, dispatches CI on the branch, and arms auto-merge.
- Adds `auto-merge.yml`: enables native auto-merge (squash) for non-draft PRs to `main` once required checks pass.
- Adds `tag-release-prs.yml`: creates the `vX.Y.Z` tag from the merged release PR and dispatches `release.yml`.
- Updates `release.yml`: runs tests, `uv build`, a wheel smoke test (`qwen-web-cli --help`, MCP import), generates SLSA provenance, and publishes a GitHub Release; also supports `workflow_dispatch` with a required `tag`.
- Adds `pr-labeler.yml` and `.github/labeler.yml`: applies and syncs path-based labels using `actions/labeler` v7.
- Adds `cleanup-merged-branches.yml`: deletes merged head branches from this repo with guards for forks, protected branches, invalid refs, and force-push races.

**Rollout**
- Protect `main` and require checks: Format, Lint, Build package, Tests (all matrix), Self-Lint, so auto-merge and release gating work end-to-end.
- Keep “Allow auto-merge” enabled.
- Create the labels used by the labeler: python, cli, mcp, core, ci, configuration, dependencies, tests, fixtures, deployment.
- First run without existing tags derives the base version from `pyproject.toml` and opens the next `chore(release): vX.Y.Z` PR.

<sup>Written for commit d7ba9ff54e904a3b05c0d4fed57914adbaa7b17e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

