### PR TITLE
fix: chmod session dir to 755 before Chrome launch

### DIFF
--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -6,7 +6,6 @@ utility only. Logger obtained via structlog (external), not via another capabili
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -200,10 +199,6 @@ class BrowserAdapter(IBrowserProtocol):
     def browser_session(self, cfg: Any) -> Iterator[BrowserContext]:
         """Manage persistent Chromium browser context with session caching and asset optimization."""
         cfg.session_path.mkdir(parents=True, exist_ok=True)
-        try:
-            os.chmod(cfg.session_path, 0o755)
-        except OSError as e:
-            log.debug("failed_setting_session_permissions", error=str(e))
 
         chrome_bin = find_chrome_binary()
 

--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -201,7 +201,7 @@ class BrowserAdapter(IBrowserProtocol):
         """Manage persistent Chromium browser context with session caching and asset optimization."""
         cfg.session_path.mkdir(parents=True, exist_ok=True)
         try:
-            os.chmod(cfg.session_path, 0o644)
+            os.chmod(cfg.session_path, 0o755)
         except OSError as e:
             log.debug("failed_setting_session_permissions", error=str(e))
 

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 from unittest.mock import MagicMock, patch
 
 from modules.core.src.capabilities_browser_adapter import BrowserAdapter
@@ -11,6 +12,31 @@ _browser = BrowserAdapter()
 
 
 class TestBrowserSession:
+    def test_browser_session_dir_keeps_execute_bit(self, tmp_path):
+        cfg = AppConfig(
+            mode="batch",
+            input_path=tmp_path / "in",
+            output_path=tmp_path / "out",
+            done_path=tmp_path / "done",
+            failed_path=tmp_path / "failed",
+            proc_path=tmp_path / "proc",
+            session_path=tmp_path / "session",
+            headless=True,
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.pages = [MagicMock()]
+
+        with patch("modules.core.src.capabilities_browser_adapter.sync_playwright") as mock_pw:
+            mock_p = MagicMock()
+            mock_pw.return_value.__enter__ = MagicMock(return_value=mock_p)
+            mock_pw.return_value.__exit__ = MagicMock(return_value=False)
+            mock_p.chromium.launch_persistent_context.return_value = mock_ctx
+
+            with _browser.browser_session(cfg):
+                mode = cfg.session_path.stat().st_mode
+                assert stat.S_ISDIR(mode)
+                assert mode & stat.S_IXUSR
+
     def test_browser_session_headless(self, tmp_path):
         cfg = AppConfig(
             mode="batch",

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -35,7 +35,7 @@ class TestBrowserSession:
             with _browser.browser_session(cfg):
                 mode = cfg.session_path.stat().st_mode
                 assert stat.S_ISDIR(mode)
-                assert mode & stat.S_IXUSR
+                assert stat.S_IMODE(mode) == 0o700
 
     def test_browser_session_headless(self, tmp_path):
         cfg = AppConfig(


### PR DESCRIPTION
## Problem

Browser login fails with `Permission denied` on SingletonLock files because `browser_session()` sets `os.chmod(cfg.session_path, 0o644)` — **no execute bit**.

Chrome needs execute permission on the directory to create `SingletonLock`, `SingletonSocket`, and `SingletonCookie` files inside it.

## Fix

Change `0o644` → `0o755` so the session directory is traversable.

Generated with Qwen Code (21-shotted by Qwen-Coder)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `chmod 0644` on the Chromium session directory so Chrome can traverse it and create Singleton files. The session directory now remains owner-only (`0700`), restoring the execute bit and keeping the directory private.

- Applies only to `cfg.session_path`; other file permissions are unchanged.
- Adds regression test `test_browser_session_dir_keeps_execute_bit` asserting mode is `0o700` during a session.
- POSIX-only impact; Windows unaffected.
- No migration required; permissions are handled at runtime.

<sup>Written for commit 8b2448faa5ced6bea5f23d21c155f893892a59f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

