### PR TITLE
fix(install): clean reinstall + repair browser session dir perms

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ cd "${PROJECT_ROOT}"
 # 0. Clean uninstall of any previous install so stale copies (with old code) do not linger
 echo "🧹 [install] Removing any previous qwen-web installation..."
 pip uninstall -y qwen-web 2>/dev/null || true
-/usr/bin/python3 -m pip uninstall -y qwen-web 2>/dev/null || true
+python3 -m pip uninstall -y qwen-web 2>/dev/null || true
 rm -f "${HOME}/.local/bin/qwen-web-cli" "${HOME}/.local/bin/qwc" 2>/dev/null || true
 
 # 1. Virtual environment setup

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,12 @@ echo "🚀 [install] Setting up qwen-web-cli environment..."
 
 cd "${PROJECT_ROOT}"
 
+# 0. Clean uninstall of any previous install so stale copies (with old code) do not linger
+echo "🧹 [install] Removing any previous qwen-web installation..."
+pip uninstall -y qwen-web 2>/dev/null || true
+/usr/bin/python3 -m pip uninstall -y qwen-web 2>/dev/null || true
+rm -f "${HOME}/.local/bin/qwen-web-cli" "${HOME}/.local/bin/qwc" 2>/dev/null || true
+
 # 1. Virtual environment setup
 VENV_DIR="${PROJECT_ROOT}/venv"
 if [ -z "${VIRTUAL_ENV:-}" ]; then
@@ -45,14 +51,26 @@ mkdir -p "${XDG_STATE}/log"
 mkdir -p "${XDG_CACHE}/.processing"
 mkdir -p "${XDG_CONFIG}"
 
+# 4b. Ensure the real browser session directory used by the app has correct
+#     permissions. Chromium needs the execute bit on the profile dir; a missing
+#     bit causes "Failed to create a ProcessSingleton ... Permission denied".
+APP_SESSION_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/qwen-web/qwen_session"
+echo "🔐 [install] Repairing browser session dir permissions: ${APP_SESSION_DIR}"
+mkdir -p "${APP_SESSION_DIR}"
+chmod 700 "${APP_SESSION_DIR}" 2>/dev/null || true
+
 if [ -f "${PROJECT_ROOT}/SKILL.md" ]; then
     echo "📄 [install] Copying SKILL.md template to XDG data directory (${XDG_DATA}/SKILL.md)..."
     cp "${PROJECT_ROOT}/SKILL.md" "${XDG_DATA}/SKILL.md"
 fi
 
-# 5. Make entrypoints executable
-echo "🔑 [install] Setting executable permissions..."
+# 5. Link entrypoints into ~/.local/bin (so the freshly installed venv copy runs,
+#    not a stale system-python copy left behind by a previous install)
+echo "🔑 [install] Linking entry points into ~/.local/bin..."
 chmod +x "${SCRIPT_DIR}/install.sh" 2>/dev/null || true
+mkdir -p "${HOME}/.local/bin"
+ln -sf "${VENV_DIR}/bin/qwen-web-cli" "${HOME}/.local/bin/qwen-web-cli"
+ln -sf "${VENV_DIR}/bin/qwc" "${HOME}/.local/bin/qwc" 2>/dev/null || true
 
 # 6. Ensure ~/.local/bin is in PATH in ~/.bashrc
 BASHRC="${HOME}/.bashrc"


### PR DESCRIPTION
## Summary
- Uninstall stale qwen-web copies (venv + system python) and remove old `~/.local/bin` entry points before installing, so a leftover system-python build with the old `0o644` chmod no longer runs.
- Symlink venv entry points into `~/.local/bin` so the freshly installed copy is the one executed.
- Ensure and `chmod 700` the real session dir (`~/.local/share/qwen-web/qwen_session`); a missing execute bit causes Chromium `Failed to create a ProcessSingleton ... Permission denied` on launch.

## Context
The browser launch failure (`Permission denied (13)` on `SingletonLock`) was caused by the profile dir losing its execute bit. `mkdir(exist_ok=True)` does not repair an already-broken existing dir, and a stale install re-corrupted it. This makes `scripts/install.sh` do a clean reinstall and repair the directory so the CLI launches Chrome.

🤖 Generated with [Kilo](https://kilo.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures a clean reinstall and repairs the browser session directory so the venv `qwen-web` runs and Chromium launches reliably. Previously the installer left stale system‑python copies and a non‑executable session dir, causing the CLI to run old code and Chromium to fail with “Failed to create a ProcessSingleton … Permission denied”; now it removes old installs, links venv entry points, and fixes permissions.

- Uninstalls `qwen-web` via both `pip` and `python3 -m pip`, and removes old `~/.local/bin` shims.
- Symlinks `${VENV_DIR}/bin/qwen-web-cli` and `${VENV_DIR}/bin/qwc` into `~/.local/bin` so the venv tools are always used.
- Ensures `${XDG_DATA_HOME:-~/.local/share}/qwen-web/qwen_session` exists and sets `chmod 700` to restore the execute bit and restrict access to the user.
- Migration: rerun `scripts/install.sh`. Ensure `~/.local/bin` is on PATH in new shells; no manual cleanup required.

<sup>Written for commit af2b142ab61a6de7e3fab5c08f35cc55c6aa30fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

