### PR TITLE
chore: gitignore worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ output/
 .archive/
 .worktree/
 .worktrees
+worktrees/
 .jj
 
 # ==========================================


### PR DESCRIPTION
## Summary
- Add `worktrees/` to `.gitignore` so locally created Git worktrees (e.g. `worktrees/ci-release-fix`) are not accidentally tracked/committed.
- Existing ignores covered only `.worktree/` and `.worktrees` (dot-prefixed); the no-dot `worktrees/` folder currently shows as untracked (`?? worktrees/`).

## Test plan
- `git status` no longer lists `worktrees/` as untracked.
- `git check-ignore -v worktrees/` resolves to the new `.gitignore` rule.

## Notes
This is a standalone PR, separate from the `actions/checkout@v7` workflow fix.

🤖 Generated with [Kilo](https://kilo.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore non-dot Git worktree directories by adding worktrees/ to .gitignore, preventing accidental tracking of local worktrees. Previously only .worktree/ and .worktrees were ignored, so worktrees/ showed as untracked.

- Old: worktrees/ appeared as untracked; New: worktrees/ is ignored like the dot-prefixed variants.
- No runtime, build, or CI impact; developer-only quality-of-life change.
- No migration required; if worktrees/ is already tracked, run: git rm -r --cached worktrees/.

<sup>Written for commit 74bc8397ff95fb351e049cb4b4dc0e7c754eb65f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

