### PR TITLE
docs: lock scope to Stabilization Mode (PRD, README, FRDs, skill)

### DIFF
--- a/.agents/skills/qwen-web/SKILL.md
+++ b/.agents/skills/qwen-web/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: qwen-web
-description: Automate Qwen AI Web (chat.qwen.ai) prompt processing via CLI or MCP tools without requiring official API keys.
+description: Automate Qwen AI Web (chat.qwen.ai) prompt processing via CLI or MCP tools without requiring official API keys. Strict Maintenance & Stabilization Mode — no new features.
 ---
 # Qwen Web Automation & MCP Server Skill Guide
+
+> **Mode: Maintenance & Stabilization.** This project is in strict stabilization mode.
+> Use the existing tools as-is — do not add new tools, flags, or features. All tuning
+> parameters (timeouts, intervals, rate limits, circuit-breaker thresholds, directory
+> paths) are **hardcoded to safe defaults** and normally never passed by the agent.
 
 Use this skill when an AI agent needs to send prompts or document files to **Qwen AI (`chat.qwen.ai`)** and receive generated AI responses via MCP tools or CLI execution.
 
@@ -10,14 +15,16 @@ Use this skill when an AI agent needs to send prompts or document files to **Qwe
 
 ## Available MCP Tools
 
-| MCP Tool Name         | Description                                  | Key Parameters                                                                    |
-| :---------------------- | :--------------------------------------------- | :---------------------------------------------------------------------------------- |
-| `qwen_send_prompt`    | Send direct prompt text string to Qwen AI    | `prompt` (str), `timeout_sec` (int, default 120), `headless` (bool, default true) |
-| `qwen_process_single` | Process a single Markdown prompt file        | `input_file` (str), `output_file` (optional str), `headless` (bool)               |
-| `qwen_process_batch`  | Process an entire directory of prompt files  | `input_dir` (optional str), `output_dir` (optional str), `headless` (bool)        |
-| `qwen_start_watcher`  | Continuous folder watcher loop for `input/`  | `interval_sec` (int, default 3), `headless` (bool)                                |
-| `qwen_setup_session`  | Launch visible browser for manual login      | None                                                                              |
-| `qwen_get_audit_log`  | Retrieve execution audit trail JSONL records | `limit` (int, default 20)                                                         |
+Only the parameters below are needed. Everything else is hardcoded.
+
+| MCP Tool Name         | Description                                  | Essential Parameters                                              |
+| :---------------------- | :--------------------------------------------- | :---------------------------------------------------------------- |
+| `qwen_send_prompt`    | Send direct prompt text string to Qwen AI    | `prompt` (str), `headless` (bool, default true)                   |
+| `qwen_process_single` | Process a single Markdown prompt file        | `input_file` (str), `output_file` (optional str), `headless` (bool) |
+| `qwen_process_batch`  | Process an entire directory of prompt files  | `input_dir` (optional str), `output_dir` (optional str), `headless` (bool) |
+| `qwen_start_watcher`  | Continuous folder watcher loop for `input/`  | `headless` (bool)                                                |
+| `qwen_setup_session`  | Launch visible browser for manual login      | None                                                             |
+| `qwen_get_audit_log`  | Retrieve execution audit trail JSONL records | `limit` (int, default 20)                                        |
 
 ---
 
@@ -30,7 +37,6 @@ Use for one-shot prompts where text is provided directly.
 ```json
 {
   "prompt": "Analyze the following system architecture and summarize key bottlenecks...",
-  "timeout_sec": 120,
   "headless": true
 }
 ```
@@ -64,7 +70,6 @@ Use for long-running monitoring of the input directory.
 
 ```json
 {
-  "interval_sec": 3,
   "headless": true
 }
 ```
@@ -90,7 +95,7 @@ Retrieve recent execution records for debugging or monitoring.
 | Exception | Meaning | Agent Action |
 | :--- | :--- | :--- |
 | `AuthRequiredError` | Session expired or CAPTCHA detected | Call `qwen_setup_session` for re-authentication |
-| `NetworkTimeoutError` | Browser network timeout | Retry with increased `timeout_sec` |
+| `NetworkTimeoutError` | Browser network timeout | Retry (timeout already uses safe default) |
 | `OutputValidationError` | Response contains error page or CAPTCHA | Retry or check input quality |
 | `CircuitBreakerOpenError` | Too many consecutive failures | Wait and retry later |
 | `PromptInjectionError` | Text injection failed | Check if Qwen UI has changed |
@@ -99,7 +104,7 @@ Retrieve recent execution records for debugging or monitoring.
 
 ## Session Management
 
-- Session cookies stored in `qwen_session/` (persistent across runs).
-- First run requires `--login` or interactive mode for manual authentication.
-- Subsequent runs can use `--headless` mode.
-- Session health checked automatically before each file processing.
+- Session cookies stored in the XDG-compliant `qwen_session/` directory (persistent across runs).
+- First run requires `qwen-web-cli --login` (or `qwen_setup_session`) for manual authentication.
+- Subsequent runs can use `headless` mode.
+- Session health is checked automatically before each file processing.

--- a/PRD.md
+++ b/PRD.md
@@ -1,61 +1,50 @@
-# PRD — Qwen AI Web Automation CLI (`qwen-web`)
+# PRD — qwen-web
 
-## 1. Concept
+## Problem Statement
+Power users, system administrators, and local AI agents need to process large volumes of prompts through `chat.qwen.ai` without relying on official, rate-limited, or unavailable REST APIs. Manual interaction is slow, un-auditable, and prone to human error. Existing browser automation scripts are often brittle, lack observability, and fail to handle edge cases like CAPTCHAs, network timeouts, or dynamic UI changes gracefully. Furthermore, maintaining these scripts over time becomes a liability as codebases degrade into spaghetti code, making AI-assisted maintenance unsafe.
 
-A resilient CLI + MCP server that drives `chat.qwen.ai` via Playwright — no API key needed. Supports batch processing, file watching, persistent sessions, and 1:1 MCP tooling for local AI agents. Built-in observability (structlog + OpenTelemetry + Sentry) and JSONL audit logging.
+## Goals & Success Metrics
+- Goal 1: Achieve 99.9% successful end-to-end pipeline execution for batch and watcher workloads on native Linux environments.
+- Goal 2: Maintain strict AES 7-layer architectural compliance to ensure AI agents can safely modify, refactor, and maintain the codebase without introducing regressions.
+- Goal 3: Provide seamless 1:1 feature parity between CLI and MCP interfaces for local AI agent integration.
 
-## 2. Operating Modes
+## User Personas
+- **Power User / Developer**: Runs batch markdown prompts locally, needs reliable file routing (`input` -> `.processing` -> `done`/`failed`) and detailed JSONL audit logs to track token usage and processing times.
+- **AI Agent (via MCP)**: Interacts with the tool programmatically to send prompts, process files, and read audit logs without managing browser lifecycles or DOM selectors.
+- **System Administrator**: Deploys the watcher mode as a background `systemd` service, relies on `sd_notify` for health checks, `fcntl` single-instance locks to prevent duplicate runs, and structured JSON logs for aggregation.
 
-- **Interactive (no args)**: Menu — Watcher, Batch, Single, Login, Init, Exit. Headed/headless choice; `Ctrl+C` safe.
-- **Watcher (`--watch`)**: Polls `input/` (default 3s), atomically moves files to `.processing/`, runs on one browser, sorts to `done/`/`failed/`. SIGINT/SIGTERM shutdown.
-- **Batch**: One-shot run of all `input/` files in a single context; prints summary (total/success/fail).
-- **Single (`-i <file>`)**: One file → output path; source moved to `done/` or `failed/`.
-- **Login (`--login`)**: Visible browser, waits for auth/CAPTCHA; saves session. Needs TTY.
-- **MCP (`--mcp`)**: stdio MCP server exposing CLI as tools — `qwen_send_prompt`, `qwen_process_single`, `qwen_process_batch`, `qwen_start_watcher`, `qwen_setup_session`, `qwen_get_audit_log`.
-- **Init**: Creates agent skill, `.qwen-web/` XDG symlinks (`input`/`output`/`log`), adds to `.gitignore`.
+## Scope
+- **In scope**: `chat.qwen.ai` web automation, Playwright persistent sessions, Batch/Watcher/Single/Interactive/MCP modes, Linux-native guards, structured observability (structlog, OpenTelemetry, Sentry), and strict AES 7-layer architecture enforcement.
+- **Out of scope**: Support for other LLM providers (ChatGPT, Claude, Gemini), official REST API integrations, cloud-hosted SaaS deployments, and adding new features (the project is currently in strict **Maintenance & Stabilization Mode**).
 
-## 3. Pipeline
+## Feature Requirements (Prioritized)
 
-- **Session**: `launch_persistent_context` (cookies, LocalStorage) in `qwen_session/`. Anti-automation flag + custom viewport. `is_alive()` / `check_auth()` health checks. Detects Cloudflare/login redirect → `AuthRequiredError`.
-- **Perf**: Block image/font/media routes (~40–60% less traffic). Reuse pages, not reloads. Cleanup stale Chrome locks.
-- **Injection (3 tiers, escalate on failure)**:
-  1. React value setter + synthetic events.
-  2. Clipboard paste (`Ctrl/Cmd+V`).
-  3. Playwright `fill()`/`type()`.
-  All fail → `PromptInjectionError`.
-- **Stability**: Fallback selectors for input/submit/assistant nodes. Poll output; complete when text stable across 3 checks. `validate_response_content()` rejects CAPTCHA/error/empty.
-- **Recovery**: Retry ≤3× with backoff (2s→30s cap), re-navigate between tries. Circuit breaker (sliding window) + token-bucket rate limiter. Logs to `log/errors.log` + JSONL audit.
+### P0 — Must Have
+- [x] **Multi-mode Execution**: Support Batch (folder processing), Watcher (continuous polling), and Single (one-off file) modes.
+- [x] **Persistent Session Management**: Manual `--login` mode to solve CAPTCHAs and save persistent session cookies/LocalStorage.
+- [x] **Atomic File Routing**: Safe file movement using atomic locks to prevent data loss during crashes.
+- [x] **Multi-tier DOM Injection**: Fallback strategies for injecting text into dynamic React/ContentEditable input fields.
+- [x] **Response Stability Polling**: Detect AI generation completion via DOM polling and stability checks.
 
-## 4. Error Hierarchy
+### P1 — Should Have
+- [x] **MCP Server Integration**: Expose all core functionalities as Model Context Protocol tools over stdio.
+- [x] **Structured Audit Logging**: JSONL audit trail with run IDs, durations, and character counts.
+- [x] **Linux Native Guards**: `fcntl` single-instance file locks and systemd `sd_notify` socket notifications.
+- [x] **Circuit Breaker & Rate Limiter**: Prevent IP bans and API throttling via sliding-window failure tracking.
 
-`QwenCliError` (base) → `AuthRequiredError`, `PromptInjectionError`, `ElementNotFoundError`, `NetworkTimeoutError`, `OutputValidationError`, `BrowserLaunchError`, `CircuitBreakerOpenError`, `RateLimitError`, `FileUploadError`, `FileValidationError`, `UploadTimeoutError`, `UIInteractionError`, `PipelineError`, `QuarantineError`, `SendDispatchError`, `OutputWriteError`, `SingleInstanceError`.
+### P2 — Nice to Have
+- [x] **Interactive TUI Menu**: Fallback interactive menu for users who prefer not to use CLI flags.
+- [x] **OpenTelemetry Tracing**: Optional OTLP HTTP span export for distributed tracing.
+- [x] **Sentry Error Capture**: Automatic unhandled exception reporting.
 
-## 5. Observability
+## Non-functional Requirements (High-level)
+- **Performance**: Polling overhead must remain <300ms/cycle. Network traffic reduced by 40-60% via aggressive asset blocking (images, fonts, media).
+- **Security**: Session tokens stored locally in XDG-compliant directories. No exfiltration of credentials. Strict prompt injection defense (scraped text is treated as untrusted data, never as agent instructions).
+- **Reliability**: Atomic file moves (`safe_move`) to guarantee zero input loss. Graceful degradation on DOM changes via multi-tier selector fallbacks.
+- **Maintainability**: Strict adherence to the AES 7-Layer Pattern (Taxonomy -> Utility -> Contract -> Capabilities -> Agent -> Surface -> Root) enforced by custom linting rules.
 
-- **Logging**: `structlog` (JSON, run-bound).
-- **Tracing**: OpenTelemetry (OTLP HTTP).
-- **Errors**: Sentry capture.
-- **Audit**: `log/audit_history.jsonl` (per-file status, durations, char counts).
-- **Metadata**: HTML comment header + `.meta.json` sidecar per output.
-
-## 6. Directory Layout
-
-```text
-qwen-web/
-├── input/
-│   ├── (root)         # Drop .md files
-│   ├── done/          # Completed
-│   ├── failed/        # Failed after retries
-│   └── .processing/   # Atomic lock
-├── output/            # Responses + .meta.json
-├── log/               # Logs + audit_history.jsonl
-└── qwen_session/      # Persistent profile
-```
-
-## 7. Non-Functional
-
-- **Performance**: Poll overhead <300ms/cycle.
-- **Reliability**: Atomic `safe_move`; no input loss.
-- **Usability**: ANSI colors, summary panels, live progress.
-- **Type Safety**: Modern typing; typed constructors.
-- **Errors**: Catch Playwright errors by type, not `Exception`.
+## Open Questions / Risks
+- **Risk**: `chat.qwen.ai` UI DOM changes frequently, breaking Playwright selectors.
+  - *Mitigation*: Multi-tier fallback selectors and JS-based extraction logic that relies on structural heuristics rather than brittle class names.
+- **Risk**: Cloudflare/CAPTCHA challenges in headless mode.
+  - *Mitigation*: Manual `--login` mode to solve CAPTCHAs in a headed browser and save the persistent session state for subsequent headless runs.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 <div align="center">
 
-# Qwen AI Web Automation CLI
-
-**Automate Markdown-based prompt processing via Qwen AI Web (`chat.qwen.ai`)**
-
-[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
-[![Playwright](https://img.shields.io/badge/playwright-1.62%2B-green.svg)](https://playwright.dev/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Headless Mode](https://img.shields.io/badge/browser-headless%20supported-purple.svg)]()
-
-[Features](#key-features) • [Installation](#installation) • [Quick Start](#quick-start) • [Usage Modes](#usage-modes) • [CLI Reference](#cli-reference)
+# Qwen AI Web Automation CLI & MCP Server
 
 </div>
 
@@ -30,7 +21,7 @@
 - **Persistent Session Login**: Log in once, then run in `--headless` mode indefinitely.
 - **Smart Response Detection**: Polls AI generation progress dynamically until completion.
 - **Output Validation**: Detects CAPTCHA challenges and server error pages before accepting output.
-- **2-Tier Prompt Injection**: Handles large prompts (100k+ chars) via React setter + clipboard fallback.
+- **Multi-Tier Prompt Injection**: Handles large prompts (100k+ chars) via React setter, ContentEditable, and Playwright fallbacks.
 - **Structured Observability**: `structlog`, OpenTelemetry, Sentry, JSONL audit trail.
 - **Fault Recovery**: Automatic retry with circuit breaker and rate limiting.
 
@@ -114,29 +105,19 @@ qwen-web-mcp
 
 ## CLI Reference
 
-| Flag / Option          | Argument | Description                                              | Default                     |
-| :--------------------- | :------- | :------------------------------------------------------- | :-------------------------- |
-| `init`, `--init`       | `[DIR]`  | Initialize workspace with `.agents/skills` & `.qwen-web` | Current directory (`.`)     |
-| `-w, --watch`          | None     | Enable continuous File Watcher mode                      | disabled                    |
-| `--interval`           | `INT`    | Polling interval in seconds for watcher mode             | `3`                         |
-| `-i, --input`          | `PATH`   | Input markdown file or directory                         | `~/.local/share/qwen-web/input` |
-| `-o, --output`         | `PATH`   | Output markdown file or directory                        | `~/.local/share/qwen-web/output` |
-| `-d, --done-dir`       | `PATH`   | Directory to move completed input files                  | `~/.local/share/qwen-web/input/done` |
-| `--failed-dir`         | `PATH`   | Directory to move failed input files                     | `~/.local/share/qwen-web/input/failed` |
-| `--proc-dir`           | `PATH`   | Temporary lock directory during processing               | `~/.cache/qwen-web/.processing` |
-| `--log-dir`            | `PATH`   | Directory for structured logs and audit trail            | `~/.local/state/qwen-web/log` |
-| `--data-dir`           | `PATH`   | Browser profile & session cookies directory              | `~/.local/share/qwen-web/qwen_session` |
-| `--headless`           | None     | Run browser in background without GUI window             | false                       |
-| `--login`              | None     | Open browser to log in manually and save session         | disabled                    |
-| `--mcp`                | None     | Run as MCP server over stdio                             | disabled                    |
-| `--timeout`            | `INT`    | Max wait time in seconds for AI response                 | `300`                       |
-| `--request-timeout`    | `INT`    | Max seconds to wait for network response                 | `120`                       |
-| `--poll-interval`      | `FLOAT`  | Seconds between message-poll DOM checks                  | `1.0`                       |
-| `--streaming-timeout`  | `INT`    | Max streaming duration in seconds                        | `180`                       |
-| `--rate-limit`         | `INT`    | Max prompt requests per minute                           | `60`                        |
-| `--cb-threshold`       | `INT`    | Consecutive failures before tripping circuit breaker     | `5`                         |
-| `--cb-window`          | `INT`    | Circuit breaker sliding window in seconds                | `30`                        |
-| `--retry-failed`       | None     | Re-process files in `failed/` directory on next run      | disabled                    |
+Only the flags below are needed for daily use. All tuning values (timeouts, poll interval, rate limit, circuit-breaker thresholds, and directory paths) are **hardcoded to safe defaults** in `modules/root_cli_main_entry.py` and follow the XDG Base Directory spec — you normally never pass them.
+
+| Command / Flag   | Argument | Description                                            |
+| :--------------- | :------- | :----------------------------------------------------- |
+| `qwen-web-cli init` | `[DIR]` | Provision workspace (`.agents/skills`, `.qwen-web`). Run once. |
+| `qwen-web-cli --login` | None | Open a visible browser to log in and save the session. Run once. |
+| `-i, --input`   | `PATH`   | Input markdown file or directory (required each run).  |
+| `-o, --output`  | `PATH`   | Output markdown file or directory (required each run). |
+| `-w, --watch`   | None     | Enable continuous File Watcher mode.                   |
+| `--headless`    | None     | Run the browser in the background without a GUI window.|
+| `qwen-web-mcp`  | None     | Run as a Model Context Protocol (MCP) server over stdio. |
+
+> All other options (polling interval, done/failed/proc/log/data directories, timeout, request-timeout, streaming-timeout, poll-interval, rate-limit, circuit-breaker threshold/window, `--retry-failed`) are pre-configured defaults and omitted from the CLI surface for simplicity.
 
 ---
 

--- a/modules/cli/FRD.md
+++ b/modules/cli/FRD.md
@@ -1,0 +1,62 @@
+# FRD — CLI Surface
+
+## System Overview
+The CLI surface (`modules/cli`) translates command-line arguments and interactive TTY inputs into `AppConfig` objects, delegating execution to the Core aggregate. It acts as a "Smart Surface" in the AES architecture, handling only presentation and boundary concerns without containing business logic.
+
+## Functional Requirements
+
+### FR-001: Argument Parsing & Config Building
+- **Description**: Parses `sys.argv` and constructs a validated `AppConfig` Value Object.
+- **Input**: CLI flags (`--watch`, `--headless`, `-i`, `-o`, etc.).
+- **Output**: `AppConfig` instance.
+- **Business Rules**: 
+  - Must default to XDG-compliant paths if user paths are omitted.
+  - Must infer `mode` (batch vs single) based on whether the input path is a directory or file.
+- **Edge Cases**: Missing arguments, invalid directory paths, conflicting flags.
+- **Error Handling**: Exits with code 1 and prints standardized error envelope to `stderr`.
+
+### FR-002: Interactive TUI Menu
+- **Description**: Provides a fallback interactive menu for users running the CLI without arguments.
+- **Input**: TTY `stdin`.
+- **Output**: `AppConfig` or `None` (exit).
+- **Business Rules**: 
+  - Must verify `sys.stdin.isatty()` before prompting.
+  - Must allow selection of Watcher, Batch, Single, Login, or Init modes.
+- **Edge Cases**: Piped input (non-TTY) must immediately reject interactive mode.
+- **Error Handling**: Returns error envelope if TTY check fails.
+
+### FR-003: Manual Login Orchestration
+- **Description**: Orchestrates the visible browser login flow.
+- **Input**: `AppConfig` (headless=False).
+- **Output**: Success/Failure envelope.
+- **Business Rules**: 
+  - Must force `headless=False`.
+  - Must block execution and wait for user `ENTER` keypress after browser opens.
+- **Edge Cases**: User closes browser before pressing ENTER.
+- **Error Handling**: Catches `AuthRequiredError` and prompts user to retry.
+
+## API Contract
+
+| Operation | Input | Output | Description |
+|-----------|-------|--------|-------------|
+| `handle` (run) | `args`, `core` | `dict` | Dispatches processing based on `AppConfig.mode`. |
+| `handle` (login) | `args`, `core`, `cfg` | `dict` | Runs manual login flow. |
+| `handle` (init) | `args`, `core` | `dict` | Provisions workspace directories. |
+
+## Integration Points
+- **Internal**: `modules/core` (CoreOrchestrator aggregate), `modules/shared` (Taxonomy VOs).
+
+## Non-functional Requirements (Detailed)
+- **Usability**: Must support ANSI colors for TUI menus when attached to a TTY.
+- **Security**: Must never echo sensitive session paths or credentials to stdout.
+
+## Test Scenarios / QA Checklist
+- [ ] Verify `--watch` flag correctly sets `AppConfig.mode` to "watcher".
+- [ ] Verify non-TTY execution immediately rejects interactive prompts.
+- [ ] Verify `init` command creates `.qwen-web/` symlinks and `.gitignore` entries.
+
+## Assumptions & Constraints
+- Assumes the host OS supports standard POSIX terminal I/O.
+
+## Reference
+- PRD: [Root PRD.md](../../PRD.md)

--- a/modules/core/FRD.md
+++ b/modules/core/FRD.md
@@ -1,0 +1,84 @@
+# FRD — Core Automation Engine
+
+## System Overview
+The Core module (`modules/core`) is the heart of the qwen-web automation engine. It implements the AES Capabilities and Agent layers, orchestrating the Playwright browser lifecycle, DOM interaction, stream monitoring, and file system routing. It exposes the `ICoreAggregate` contract to the Surface layers (CLI/MCP), ensuring that business logic remains completely isolated from user-facing boundaries.
+
+## Functional Requirements
+
+### FR-001: Browser Session Management
+- **Description**: Manages the Chromium browser lifecycle, persistent profiles, and network optimization.
+- **Input**: `AppConfig` (session path, headless flag, viewport).
+- **Output**: Active `BrowserContext` and `Page`.
+- **Business Rules**: 
+  - Must use `launch_persistent_context` to retain cookies/LocalStorage.
+  - Must clean stale Chromium lock files (`SingletonLock`) before launch.
+  - Must block media/font/image routes to reduce network overhead.
+- **Edge Cases**: Stale profile directories, missing execute permissions on profile folders, concurrent instance lock collisions.
+- **Error Handling**: Raises `BrowserLaunchError` if context fails to initialize after 3 retries. Raises `AuthRequiredError` if redirected to a login page.
+
+### FR-002: Prompt Injection
+- **Description**: Injects text into the Qwen Web UI input field.
+- **Input**: `Page`, `PromptText`.
+- **Output**: None (mutates DOM state).
+- **Business Rules**: 
+  - Must attempt 3 tiers of injection sequentially: 1) React value setter + synthetic events, 2) ContentEditable `innerText` setter, 3) Playwright `fill()`/`type()`.
+- **Edge Cases**: UI changes, hidden input fields, React state synchronization delays.
+- **Error Handling**: Raises `PromptInjectionError` if all 3 tiers fail or if post-injection verification fails.
+
+### FR-003: Stream Monitoring & Stability
+- **Description**: Polls the DOM to detect when the AI has finished generating a response.
+- **Input**: `Page`, `TimeoutSec`, `MessageCount` (baseline).
+- **Output**: `ResponseText`.
+- **Business Rules**: 
+  - Must poll at configurable intervals (default 1.0s).
+  - Must wait for the text to remain unchanged for N consecutive checks (default 4).
+  - Must verify generation is complete by checking for the absence of "Stop" or "Typing" indicators.
+- **Edge Cases**: Network drops during generation, UI noise (e.g., "Qwen3" model tags) in the extracted text.
+- **Error Handling**: Raises `NetworkTimeoutError` on Playwright IPC failures. Raises `OutputValidationError` if the final text contains CAPTCHA or server error keywords.
+
+### FR-004: File Pipeline Orchestration
+- **Description**: Routes files through the processing queue (input -> processing -> done/failed).
+- **Input**: Directory paths, `AppConfig`.
+- **Output**: Processed files moved to target directories.
+- **Business Rules**: 
+  - Must use atomic file moves to prevent data loss.
+  - Must support role-based path resolution (e.g., `role-coder/`, `role-writer/`).
+  - Must integrate with the Circuit Breaker to halt processing if consecutive failures exceed the threshold.
+- **Edge Cases**: File permission errors, disk full, concurrent watcher instances.
+- **Error Handling**: Quarantines failed files to the `failed/` directory and logs the stack trace to `errors.jsonl`.
+
+## API Contract
+
+| Operation | Input | Output | Description |
+|-----------|-------|--------|-------------|
+| `process_single_file` | `input_file`, `output_file`, `headless` | `ResponseText` | Processes one file end-to-end. |
+| `process_batch` | `input_dir`, `output_dir`, `headless` | `ResponseText` | Processes all files in a directory. |
+| `process_watcher` | `interval_sec`, `headless` | `ResponseText` | Runs the continuous polling loop. |
+| `send_prompt` | `prompt`, `timeout_sec`, `headless` | `ResponseText` | Sends raw text without file I/O. |
+| `setup_session` | None | `ResponseText` | Opens headed browser for manual login. |
+
+## Integration Points
+- **3rd Party**: Playwright (Browser automation), structlog/Sentry/OpenTelemetry (Observability).
+- **Internal**: `modules/shared` (Taxonomy VOs, Contracts, Utility functions).
+
+## Non-functional Requirements (Detailed)
+- **Performance**: DOM polling must not block the main thread for >300ms per cycle.
+- **Security**: Session directories must have `0o700` permissions. No credentials logged to stdout.
+- **SLA**: Watcher mode must respond to `SIGINT`/`SIGTERM` within 1 second to ensure graceful systemd shutdowns.
+
+## Test Scenarios / QA Checklist
+- [ ] Verify atomic move prevents file loss when process is killed during I/O.
+- [ ] Verify `AuthRequiredError` is raised when session cookies expire.
+- [ ] Verify Circuit Breaker trips after N consecutive failures and halts the batch.
+- [ ] Verify CAPTCHA keywords in AI response trigger `OutputValidationError`.
+
+## Assumptions & Constraints
+- Assumes the user has a valid Chromium/Chrome binary installed on the Linux host.
+- Constrained by Playwright's synchronous API limitations (requires thread-isolated event loops).
+
+## Glossary
+- **AES**: Agentic Engineering System (the 7-layer architecture).
+- **XDG**: XDG Base Directory Specification for Linux file paths.
+
+## Reference
+- PRD: [Root PRD.md](../../PRD.md)

--- a/modules/mcp/FRD.md
+++ b/modules/mcp/FRD.md
@@ -1,0 +1,67 @@
+# FRD — MCP Surface
+
+## System Overview
+The MCP surface (`modules/mcp`) exposes the Core aggregate as a Model Context Protocol (MCP) server over stdio. It allows local AI agents (like Claude Desktop, Cursor, or custom agentic workflows) to invoke qwen-web capabilities as standardized tools without managing browser lifecycles or DOM selectors.
+
+## Functional Requirements
+
+### FR-001: Tool Registration & Specification
+- **Description**: Registers core functionalities as MCP tools using the FastMCP framework.
+- **Input**: `MCP_TOOL_SPECS` definition table.
+- **Output**: Registered FastMCP tool handlers.
+- **Business Rules**: 
+  - Must map 1:1 with CLI capabilities (`qwen_send_prompt`, `qwen_process_single`, etc.).
+  - Must define strict type hints for all tool parameters.
+- **Edge Cases**: Missing `mcp` Python package dependency.
+- **Error Handling**: Gracefully degrades (skips registration) if FastMCP is unavailable, allowing the module to be imported for testing.
+
+### FR-002: Async Execution & Threading
+- **Description**: Bridges the synchronous Playwright Core aggregate with the asynchronous MCP stdio transport.
+- **Input**: Async tool invocation.
+- **Output**: Stringified `ResponseText`.
+- **Business Rules**: 
+  - Must use `asyncio.to_thread` to offload synchronous Playwright calls to a worker thread.
+  - Must isolate the thread's event loop to prevent Playwright sync_api collisions.
+- **Edge Cases**: Thread starvation, event loop closure during shutdown.
+- **Error Handling**: Catches thread exceptions and returns standardized MCP error payloads.
+
+### FR-003: Stdio Transport Protection
+- **Description**: Protects the JSON-RPC stdio stream from accidental stdout pollution.
+- **Input**: Application bootstrap.
+- **Output**: Clean stdio transport.
+- **Business Rules**: 
+  - Must redirect `sys.stdout` to `sys.stderr` during tool execution.
+  - Must restore `sys.__stdout__` before starting the FastMCP app loop.
+- **Edge Cases**: Third-party libraries printing directly to stdout.
+- **Error Handling**: Ensures `sys.stdout` is restored in a `finally` block to prevent transport corruption.
+
+## API Contract
+
+| Operation | Input | Output | Description |
+|-----------|-------|--------|-------------|
+| `qwen_send_prompt` | `prompt`, `timeout_sec`, `headless` | `str` | Sends raw text prompt. |
+| `qwen_process_single` | `input_file`, `output_file`, `headless` | `str` | Processes one markdown file. |
+| `qwen_process_batch` | `input_dir`, `output_dir`, `headless` | `str` | Processes a directory. |
+| `qwen_start_watcher` | `interval_sec`, `headless` | `str` | Starts the continuous watcher. |
+| `qwen_setup_session` | None | `str` | Opens headed browser for login. |
+| `qwen_get_audit_log` | `limit` | `str` | Fetches JSONL audit entries. |
+
+## Integration Points
+- **3rd Party**: FastMCP (MCP framework), asyncio (Event loop management).
+- **Internal**: `modules/core` (CoreOrchestrator aggregate).
+
+## Non-functional Requirements (Detailed)
+- **Performance**: Tool invocation overhead (thread dispatch) must be <50ms.
+- **Security**: Must never leak stdio transport by printing raw Python tracebacks to stdout.
+
+## Test Scenarios / QA Checklist
+- [ ] Verify `asyncio.to_thread` successfully executes synchronous Playwright calls.
+- [ ] Verify `sys.stdout` redirection prevents JSON-RPC parsing errors.
+- [ ] Verify tool registration fails gracefully if `mcp` package is missing.
+
+## Assumptions & Constraints
+- Assumes the MCP client (e.g., AI Agent) supports the standard MCP stdio transport.
+- Constrained by Python's GIL; heavy DOM polling in the worker thread may block other async MCP tasks.
+
+## Reference
+- PRD: [Root PRD.md](../../PRD.md)


### PR DESCRIPTION
## Summary
- Rewrite `PRD.md` around Maintenance & Stabilization Mode (no new features; out-of-scope LLM providers, REST API, SaaS).
- Simplify `README.md` CLI Reference to only essential flags; all tuning values (timeouts, poll interval, rate limit, circuit-breaker, dir paths) are hardcoded safe defaults.
- Add `FRD.md` for `modules/core`, `modules/cli`, `modules/mcp` as the engineering Single Source of Truth.
- Align the `qwen-web` skill with Stabilization Mode and hardcoded tuning params.

## Scope Lock
This PR officially locks the project scope to **Stabilization Mode** per the agreed True North vision. No ambiguous features remain.

## Test plan
- [x] Docs only — no code change, no test impact.
- [x] Maintainers review wording/accuracy of PRD + FRDs.

🤖 Generated with Kilo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks documentation to Stabilization Mode and designates module FRDs as the single source of truth. The docs now show a reduced CLI/MCP surface with only essential parameters; tuning is treated as hardcoded defaults. No runtime changes.

- Verify PRD reflects Stabilization Mode: no new features; other providers, REST API, and SaaS are out of scope.
- Check README CLI reference lists only init, --login, -i/--input, -o/--output, -w/--watch, --headless; confirm all omitted tunables are safe defaults in `modules/root_cli_main_entry.py` and follow XDG paths.
- Validate new FRDs (`modules/core/FRD.md`, `modules/cli/FRD.md`, `modules/mcp/FRD.md`) match the current implementation: contracts, error types, circuit breaker, rate limiting, and observability via `structlog`, `OpenTelemetry`, and `Sentry`.
- Confirm `.agents/skills/qwen-web/SKILL.md` lists only essential MCP tool parameters and aligns with the server (e.g., removed `timeout_sec` and `interval_sec` in favor of defaults); verify session path and XDG wording.
- Docs-only change — no migration required. If maintaining external agents, prefer relying on defaults instead of passing tuning parameters.

<sup>Written for commit 97c2d5d58bad495359d776248bcedabf1469b5ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

