### PR TITLE
fix: pass built config to run command in interactive mode

### DIFF
--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -123,6 +123,10 @@ def main(argv: list[str] | None = None) -> int:
         cfg = _interactive_prompt()
         if cfg is None:
             return 0
+        # Run command reads the built config from args._cfg; interactive mode
+        # never parsed argv, so synthesize a namespace carrying the config.
+        args = argparse.Namespace()
+        args._cfg = cfg
     else:
         if args is None:
             print("ERROR: missing CLI arguments", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Fix `Missing AppConfig — run command requires a built config.` raised when running the CLI interactively (e.g. selecting Single File / Batch / Watcher mode via the TUI menu).
- In interactive mode `main()` built an `AppConfig` via `_interactive_prompt()` but `args` was `None`, so the config was never attached to `args._cfg`. `surface_cli_run_command.handle` then read `getattr(args, "_cfg", None)` → `None` and raised.
- The interactive branch now synthesizes an `argparse.Namespace` carrying `args._cfg = cfg`, matching the non-interactive dispatch path.

## Validation
- `ruff check modules/root_cli_main_entry.py` — clean.
- `pytest tests/test_main_entry.py` — passed.

Fixes an issue discovered while exercising the interactive TUI (`qwc` → option 3 → Run headless? n).

🤖 Generated with [Kilo](https://kilo.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the built `AppConfig` to the run command in interactive CLI mode so TUI selections run without error. Previously interactive mode built a config but didn’t attach it to `args._cfg`, raising “Missing AppConfig — run command requires a built config”; now it synthesizes an `argparse.Namespace` with `_cfg` set, matching non-interactive behavior.

**Review notes**
- Interactive path now creates `args = argparse.Namespace()` and sets `args._cfg = cfg` before calling `surface_cli_run_command.handle`.
- Non-interactive parsing and dispatch are unchanged; no flag or interface changes.
- Verify TUI flows (Single File / Batch / Watcher) proceed without the missing-config error.

<sup>Written for commit 2d4edd5e559a847a20c9d73f6c767768c72390ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

