### PR TITLE
fix(mcp): protect stdio and generate audit log tool

### DIFF
--- a/modules/mcp/FRD.md
+++ b/modules/mcp/FRD.md
@@ -1,67 +1,105 @@
-# FRD — MCP Surface
+# MCP Functional Requirements Document
 
 ## System Overview
-The MCP surface (`modules/mcp`) exposes the Core aggregate as a Model Context Protocol (MCP) server over stdio. It allows local AI agents (like Claude Desktop, Cursor, or custom agentic workflows) to invoke qwen-web capabilities as standardized tools without managing browser lifecycles or DOM selectors.
+
+The MCP surface (`modules/mcp`) exposes the Core aggregate as a Model Context Protocol (MCP) server over stdio. It allows local AI agents such as Claude Desktop, Cursor, or custom agentic workflows to invoke qwen-web capabilities as standardized tools without managing browser lifecycles or DOM selectors.
 
 ## Functional Requirements
 
-### FR-001: Tool Registration & Specification
-- **Description**: Registers core functionalities as MCP tools using the FastMCP framework.
-- **Input**: `MCP_TOOL_SPECS` definition table.
-- **Output**: Registered FastMCP tool handlers.
-- **Business Rules**: 
-  - Must map 1:1 with CLI capabilities (`qwen_send_prompt`, `qwen_process_single`, etc.).
-  - Must define strict type hints for all tool parameters.
-- **Edge Cases**: Missing `mcp` Python package dependency.
-- **Error Handling**: Gracefully degrades (skips registration) if FastMCP is unavailable, allowing the module to be imported for testing.
+### FR-001: Declarative Tool Registration and Specification
 
-### FR-002: Async Execution & Threading
+- **Description**: Registers all MCP capabilities as FastMCP tools from the `MCP_TOOL_SPECS` table.
+- **Input**: A specification entry containing the public tool name, core method name, documentation, and parameter metadata.
+- **Output**: One generated async FastMCP handler per specification entry.
+- **Business Rules**:
+  - The specification table is the single source of truth for MCP registration.
+  - The table must map one-to-one with the exposed capabilities: `qwen_send_prompt`, `qwen_process_single`, `qwen_process_batch`, `qwen_start_watcher`, `qwen_setup_session`, and `qwen_get_audit_log`.
+  - Each parameter must declare a supported type and, when optional, its default value.
+  - `qwen_get_audit_log` is declaratively specified with `limit: int = 20`; it must not have a separate manual registration path.
+  - Generated handlers expose the specification-derived name, docstring, annotations, and `inspect.Signature` so FastMCP can build the client-facing schema.
+- **Edge Cases**: Missing `mcp` Python package dependency.
+- **Error Handling**: The module remains importable for tests when FastMCP is unavailable; server startup raises a clear `ImportError` if the app is requested.
+
+### FR-002: Async Execution and Threading
+
 - **Description**: Bridges the synchronous Playwright Core aggregate with the asynchronous MCP stdio transport.
 - **Input**: Async tool invocation.
 - **Output**: Stringified `ResponseText`.
-- **Business Rules**: 
-  - Must use `asyncio.to_thread` to offload synchronous Playwright calls to a worker thread.
-  - Must isolate the thread's event loop to prevent Playwright sync_api collisions.
-- **Edge Cases**: Thread starvation, event loop closure during shutdown.
-- **Error Handling**: Catches thread exceptions and returns standardized MCP error payloads.
+- **Business Rules**:
+  - Every generated handler delegates synchronous core work through `asyncio.to_thread`.
+  - The worker-local execution context is marked while the core method runs, including its `print` output.
+  - The worker context is reset in a `finally` block even when the core method raises.
+- **Edge Cases**: Thread starvation and event-loop closure during shutdown.
+- **Error Handling**: Exceptions raised by the synchronous core method propagate through the async handler for FastMCP to report according to its normal error handling.
 
 ### FR-003: Stdio Transport Protection
-- **Description**: Protects the JSON-RPC stdio stream from accidental stdout pollution.
-- **Input**: Application bootstrap.
-- **Output**: Clean stdio transport.
-- **Business Rules**: 
-  - Must redirect `sys.stdout` to `sys.stderr` during tool execution.
-  - Must restore `sys.__stdout__` before starting the FastMCP app loop.
-- **Edge Cases**: Third-party libraries printing directly to stdout.
-- **Error Handling**: Ensures `sys.stdout` is restored in a `finally` block to prevent transport corruption.
+
+- **Description**: Protects the JSON-RPC stdio stream from accidental stdout pollution during tool execution without suppressing FastMCP transport messages.
+- **Input**: MCP server bootstrap and tool execution.
+- **Output**: JSON-RPC transport remains on stdout; tool diagnostics are routed to stderr.
+- **Business Rules**:
+  - `run_mcp_server()` installs a proxy around the existing `sys.stdout` only for the lifetime of the server.
+  - Writes made while a generated tool is executing are sent to `sys.stderr` through a context-local execution flag.
+  - Writes made by FastMCP outside tool execution continue to use the original stdout stream.
+  - The previous stdout object is restored in a `finally` block when the server exits.
+- **Edge Cases**: Third-party libraries printing through `sys.stdout`, nested tool calls, and server shutdown after a tool exception.
+- **Error Handling**: Restoration of stdout is guaranteed even when registration or the FastMCP app loop raises.
 
 ## API Contract
 
 | Operation | Input | Output | Description |
 |-----------|-------|--------|-------------|
-| `qwen_send_prompt` | `prompt`, `timeout_sec`, `headless` | `str` | Sends raw text prompt. |
-| `qwen_process_single` | `input_file`, `output_file`, `headless` | `str` | Processes one markdown file. |
-| `qwen_process_batch` | `input_dir`, `output_dir`, `headless` | `str` | Processes a directory. |
-| `qwen_start_watcher` | `interval_sec`, `headless` | `str` | Starts the continuous watcher. |
+| `qwen_send_prompt` | `prompt`, `timeout_sec=120`, `headless=True` | `str` | Sends raw text prompt. |
+| `qwen_process_single` | `input_file`, `output_file=None`, `headless=True` | `str` | Processes one Markdown file. |
+| `qwen_process_batch` | `input_dir=None`, `output_dir=None`, `headless=True` | `str` | Processes a directory. |
+| `qwen_start_watcher` | `interval_sec=3`, `headless=True` | `str` | Starts the continuous watcher. |
 | `qwen_setup_session` | None | `str` | Validates an existing session or waits for visible browser login to complete. |
-| `qwen_get_audit_log` | `limit` | `str` | Fetches JSONL audit entries. |
+| `qwen_get_audit_log` | `limit=20` | `str` | Fetches JSONL audit entries. |
+
+## MCP File Map
+
+| File | Responsibility |
+|------|----------------|
+| `modules/root_mcp_main_entry.py` | FastMCP application bootstrap, `MCP_TOOL_SPECS`, generated async handlers, declarative registration, and stdout isolation. |
+| `modules/mcp/src/surface_mcp_tool_command.py` | MCP surface adapter that maps generated tool calls to the `ICoreAggregate` contract. |
+| `modules/shared/src/contract_core_aggregate.py` | Shared core interface, including the existing `get_audit_log(limit=20)` contract. |
+| `modules/core/src/agent_core_orchestrator.py` | Concrete core aggregate delegation; out of scope for issues #73–#75. |
+| `modules/core/src/capabilities_audit_repository.py` | Audit JSONL persistence and retrieval; unchanged for issues #73–#75. |
+| `tests/test_mcp_server.py` | Basic generated-tool and audit-log behavior tests. |
+| `tests/test_mcp_server_async.py` | Async wrapper and audit-log response tests. |
+| `tests/test_mcp_server_extended.py` | Registration-table, signature, server lifecycle, and stdout-isolation tests. |
 
 ## Integration Points
-- **3rd Party**: FastMCP (MCP framework), asyncio (Event loop management).
-- **Internal**: `modules/core` (CoreOrchestrator aggregate).
 
-## Non-functional Requirements (Detailed)
-- **Performance**: Tool invocation overhead (thread dispatch) must be <50ms.
-- **Security**: Must never leak stdio transport by printing raw Python tracebacks to stdout.
+- **Third Party**: FastMCP (MCP framework) and `asyncio` (event-loop and worker-thread management).
+- **Internal**: `modules/core` (CoreOrchestrator aggregate), `modules/shared` (aggregate contract), and the MCP surface adapter.
+
+## Non-functional Requirements
+
+- **Performance**: Tool invocation overhead from thread dispatch should remain below 50 ms excluding browser work.
+- **Security and Integrity**: The server must never leak raw Python diagnostics or tracebacks into the JSON-RPC stdout stream.
+- **Scope Constraint**: `AuditRepository.get_audit_log()` and `LinuxGuard` are not modified for issues #73–#75. Any future contract change must be coordinated with the owning implementation work.
 
 ## Test Scenarios / QA Checklist
-- [ ] Verify `asyncio.to_thread` successfully executes synchronous Playwright calls.
-- [ ] Verify `sys.stdout` redirection prevents JSON-RPC parsing errors.
-- [ ] Verify tool registration fails gracefully if `mcp` package is missing.
 
-## Assumptions & Constraints
-- Assumes the MCP client (e.g., AI Agent) supports the standard MCP stdio transport.
-- Constrained by Python's GIL; heavy DOM polling in the worker thread may block other async MCP tasks.
+- [ ] Verify every `MCP_TOOL_SPECS` entry produces exactly one generated handler.
+- [ ] Verify `qwen_get_audit_log` is present in `MCP_TOOL_SPECS`, uses the common generator, and has default `limit=20`.
+- [ ] Verify the async wrapper dispatches synchronous core calls through `asyncio.to_thread`.
+- [ ] Verify the audit-log handler returns the expected missing-file and JSON response strings.
+- [ ] Verify tool execution output is absent from JSON-RPC stdout while FastMCP transport output remains on stdout.
+- [ ] Verify stdout is restored after server shutdown or startup failure.
+- [ ] Verify tool registration fails clearly when the `mcp` package is unavailable.
+- [ ] Run `pytest`.
+- [ ] Run `ruff format --check modules/ tests/`.
+- [ ] Run `ruff check modules/ tests/`.
+- [ ] Run `mypy modules/`.
+
+## Assumptions and Constraints
+
+- The MCP client, such as an AI agent using the standard MCP stdio transport, owns the JSON-RPC protocol stream.
+- The synchronous browser automation remains delegated to worker threads; the Python GIL may limit concurrency for CPU-heavy work.
+- The audit repository contract and LinuxGuard implementation are outside the scope of this change.
 
 ## Reference
+
 - PRD: [Root PRD.md](../../PRD.md)

--- a/modules/mcp/FRD.md
+++ b/modules/mcp/FRD.md
@@ -40,6 +40,7 @@ The MCP surface (`modules/mcp`) exposes the Core aggregate as a Model Context Pr
 - **Business Rules**:
   - `run_mcp_server()` installs a proxy around the existing `sys.stdout` only for the lifetime of the server.
   - Writes made while a generated tool is executing are sent to `sys.stderr` through a context-local execution flag.
+  - The proxy isolates `write()`, `writelines()`, and `buffer.write()` so that tool output does not pollute the JSON-RPC stream.
   - Writes made by FastMCP outside tool execution continue to use the original stdout stream.
   - The previous stdout object is restored in a `finally` block when the server exits.
 - **Edge Cases**: Third-party libraries printing through `sys.stdout`, nested tool calls, and server shutdown after a tool exception.

--- a/modules/root_mcp_main_entry.py
+++ b/modules/root_mcp_main_entry.py
@@ -206,10 +206,7 @@ def _make_async_tool(spec: dict[str, Any]) -> Callable[..., Any]:
         name, type_name, required, *default_values = param
         if type_name not in _TYPE_ANNOTATIONS:
             raise ValueError(f"Unsupported MCP parameter type: {type_name}")
-        if required:
-            default = inspect.Parameter.empty
-        else:
-            default = default_values[0] if default_values else None
+        default = inspect.Parameter.empty if required else default_values[0] if default_values else None
         parameters.append(
             inspect.Parameter(
                 name=name,

--- a/modules/root_mcp_main_entry.py
+++ b/modules/root_mcp_main_entry.py
@@ -1,17 +1,18 @@
-#!/usr/bin/env python3
 """qwen-web MCP server entry point.
 
 Root layer: bootstraps the FastMCP server over stdio with the wired MCP
-container. The 6 tools are generated from a specification table and
-registered on the FastMCP instance, delegating to the shared core aggregate.
+container. The tools are generated from a specification table and registered
+on the FastMCP instance, delegating to the shared core aggregate.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import inspect
 import sys
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TextIO, cast
 
 try:
     from fastmcp import FastMCP
@@ -72,12 +73,44 @@ MCP_TOOL_SPECS: list[dict[str, Any]] = [
         "doc": "Launch visible browser on chat.qwen.ai for manual login / session setup.",
         "params": [],
     },
+    {
+        "name": "qwen_get_audit_log",
+        "method": "get_audit_log",
+        "doc": "Fetch latest entries from the JSONL audit trail log.",
+        "params": [("limit", "int", False, 20)],
+    },
 ]
 
 # FastMCP application instance (module-level for tool registration + tests)
 mcp = FastMCP("Qwen-Web") if FastMCP is not None else None
 
 _container: SharedContainer | None = None
+_tool_execution: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_tool_execution", default=False)
+
+
+class _McpStdoutProxy:
+    """Keep FastMCP transport writes on stdout and tool diagnostics on stderr.
+
+    FastMCP owns the process stdout stream for JSON-RPC messages. Synchronous
+    core calls run in ``asyncio.to_thread`` workers, so a context-local flag can
+    route ordinary ``print`` calls made by a tool to stderr without redirecting
+    FastMCP's own transport output.
+    """
+
+    def __init__(self, transport: TextIO, diagnostics: TextIO) -> None:
+        self._transport = transport
+        self._diagnostics = diagnostics
+
+    def write(self, text: str) -> int:
+        target = self._diagnostics if _tool_execution.get() else self._transport
+        return target.write(text)
+
+    def flush(self) -> None:
+        self._transport.flush()
+        self._diagnostics.flush()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._transport, name)
 
 
 def _get_mcp_app() -> Any:
@@ -111,30 +144,63 @@ def _tools() -> Any:
 
 
 def _async_tool(name: str) -> Callable[..., Any]:
-    """Create an async MCP tool that delegates to a sync core method via asyncio.to_thread.
+    """Create an async MCP tool that delegates to a sync core method.
 
-    Eliminates the duplicated await asyncio.to_thread(_tools().method_name, ...) pattern.
+    The complete lookup and invocation happen inside ``asyncio.to_thread`` so
+    any output produced while a tool executes carries the tool context and is
+    routed away from the JSON-RPC stdout stream.
     """
 
     async def handler(*args: Any, **kwargs: Any) -> str:
-        return await asyncio.to_thread(getattr(_tools(), name), *args, **kwargs)
+        def invoke() -> str:
+            token = _tool_execution.set(True)
+            try:
+                return str(getattr(_tools(), name)(*args, **kwargs))
+            finally:
+                _tool_execution.reset(token)
+
+        return await asyncio.to_thread(invoke)
 
     return handler
+
+
+_TYPE_ANNOTATIONS: dict[str, object] = {
+    "str": str,
+    "int": int,
+    "bool": bool,
+    "str | None": str | None,
+}
 
 
 def _make_async_tool(spec: dict[str, Any]) -> Callable[..., Any]:
-    """Generate an async MCP tool function from a spec entry.
+    """Generate an async MCP tool function, including its public signature."""
+    handler: Any = _async_tool(spec["method"])
+    parameters: list[inspect.Parameter] = []
+    annotations: dict[str, object] = {"return": str}
 
-    Each spec defines the core method name, docstring, and parameter metadata.
-    The generated function delegates to _async_tool(spec["method"]).
-    """
-    handler = _async_tool(spec["method"])
+    for param in spec["params"]:
+        name, type_name, required, *default_values = param
+        if type_name not in _TYPE_ANNOTATIONS:
+            raise ValueError(f"Unsupported MCP parameter type: {type_name}")
+        default = inspect.Parameter.empty if required else default_values[0]
+        parameters.append(
+            inspect.Parameter(
+                name=name,
+                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=default,
+                annotation=_TYPE_ANNOTATIONS[type_name],
+            )
+        )
+        annotations[name] = _TYPE_ANNOTATIONS[type_name]
+
     handler.__name__ = spec["name"]
     handler.__doc__ = spec["doc"]
-    return handler
+    handler.__annotations__ = annotations
+    handler.__signature__ = inspect.Signature(parameters=parameters, return_annotation=str)
+    return cast(Callable[..., Any], handler)
 
 
-# Generate async tool functions from specification table
+# Generate async tool functions from specification table.
 GENERATED_TOOLS: dict[str, Callable[..., Any]] = {_spec["name"]: _make_async_tool(_spec) for _spec in MCP_TOOL_SPECS}
 
 # Expose generated tools as module-level callables for registration and tests.
@@ -142,37 +208,27 @@ GENERATED_TOOLS: dict[str, Callable[..., Any]] = {_spec["name"]: _make_async_too
 globals().update(GENERATED_TOOLS)
 
 
-def qwen_get_audit_log(limit: int = 20) -> str:
-    """Fetch latest entries from the JSONL audit trail log."""
-    return str(_tools().get_audit_log(limit))
-
-
 def _register_tools() -> None:
-    """Register all MCP tools on the FastMCP instance."""
+    """Register every MCP tool generated from ``MCP_TOOL_SPECS`` exactly once."""
     app = _get_mcp_app()
-    tool: Callable[..., Callable[..., Any]] = app.tool
-
     for spec in MCP_TOOL_SPECS:
-        tool()(GENERATED_TOOLS[spec["name"]])
-
-    tool()(qwen_get_audit_log)
+        app.tool()(GENERATED_TOOLS[spec["name"]])
 
 
 def run_mcp_server() -> None:
-    """Run the FastMCP server over stdio."""
+    """Run the FastMCP server over stdio without polluting JSON-RPC stdout."""
     from modules.core.src.capabilities_observability_setup import ObservabilitySetup
 
     ObservabilitySetup(DEFAULT_LOG).setup_observability()
 
-    # Redirect standard text prints & logging to stderr to protect JSON-RPC stdio
-    sys.stdout = sys.stderr
-
     app = _get_mcp_app()
-    _register_tools()
-
-    # Restore sys.stdout to sys.__stdout__ (FD 1) for FastMCP stdio transport
-    sys.stdout = sys.__stdout__
-    app.run()
+    previous_stdout = sys.stdout
+    sys.stdout = _McpStdoutProxy(cast(TextIO, previous_stdout), cast(TextIO, sys.stderr))
+    try:
+        _register_tools()
+        app.run()
+    finally:
+        sys.stdout = previous_stdout
 
 
 def main() -> None:

--- a/modules/root_mcp_main_entry.py
+++ b/modules/root_mcp_main_entry.py
@@ -88,6 +88,21 @@ _container: SharedContainer | None = None
 _tool_execution: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_tool_execution", default=False)
 
 
+class _McpBufferProxy:
+    """Binary buffer proxy that routes writes to the active execution-context stream."""
+
+    def __init__(self, transport_buffer: Any, diagnostics_buffer: Any) -> None:
+        self._transport_buffer = transport_buffer
+        self._diagnostics_buffer = diagnostics_buffer
+
+    def write(self, data: bytes) -> int:
+        target = self._diagnostics_buffer if _tool_execution.get() else self._transport_buffer
+        return target.write(data)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._transport_buffer, name)
+
+
 class _McpStdoutProxy:
     """Keep FastMCP transport writes on stdout and tool diagnostics on stderr.
 
@@ -105,9 +120,18 @@ class _McpStdoutProxy:
         target = self._diagnostics if _tool_execution.get() else self._transport
         return target.write(text)
 
+    def writelines(self, lines: list[str]) -> None:
+        target = self._diagnostics if _tool_execution.get() else self._transport
+        target.writelines(lines)
+
     def flush(self) -> None:
         self._transport.flush()
         self._diagnostics.flush()
+
+    @property
+    def buffer(self) -> Any:
+        """Return a binary buffer proxy that routes writes to the active context stream."""
+        return _McpBufferProxy(self._transport.buffer, self._diagnostics.buffer)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._transport, name)

--- a/modules/root_mcp_main_entry.py
+++ b/modules/root_mcp_main_entry.py
@@ -97,7 +97,7 @@ class _McpBufferProxy:
 
     def write(self, data: bytes) -> int:
         target = self._diagnostics_buffer if _tool_execution.get() else self._transport_buffer
-        return target.write(data)
+        return int(target.write(data))
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._transport_buffer, name)
@@ -206,7 +206,10 @@ def _make_async_tool(spec: dict[str, Any]) -> Callable[..., Any]:
         name, type_name, required, *default_values = param
         if type_name not in _TYPE_ANNOTATIONS:
             raise ValueError(f"Unsupported MCP parameter type: {type_name}")
-        default = inspect.Parameter.empty if required else default_values[0]
+        if required:
+            default = inspect.Parameter.empty
+        else:
+            default = default_values[0] if default_values else None
         parameters.append(
             inspect.Parameter(
                 name=name,

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -92,7 +92,7 @@ class TestMcpServerRemaining:
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = "Audit log file does not exist yet."
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            result = qwen_get_audit_log()
+            result = asyncio.run(qwen_get_audit_log())
             assert "does not exist" in result
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -45,7 +45,7 @@ class TestMCPServerTools(unittest.TestCase):
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = "Audit log file does not exist yet."
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            res = qwen_get_audit_log()
+            res = asyncio.run(qwen_get_audit_log())
             self.assertEqual(res, "Audit log file does not exist yet.")
 
     def test_qwen_get_audit_log_records(self) -> None:
@@ -54,7 +54,7 @@ class TestMCPServerTools(unittest.TestCase):
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = records
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            res = qwen_get_audit_log(limit=5)
+            res = asyncio.run(qwen_get_audit_log(limit=5))
             data = json.loads(res)
             self.assertEqual(len(data), 1)
             self.assertEqual(data[0]["run_id"], "test1234")

--- a/tests/test_mcp_server_async.py
+++ b/tests/test_mcp_server_async.py
@@ -86,13 +86,17 @@ class TestQwenGetAuditLogExtended:
         entries = json.dumps([{"run_id": str(i)} for i in range(5)])
         tools = _mock_tools(get_audit_log=entries)
         with patch("modules.root_mcp_main_entry._tools", return_value=tools):
-            result = qwen_get_audit_log(limit=3)
+            loop = asyncio.new_event_loop()
+            result = loop.run_until_complete(qwen_get_audit_log(limit=3))
+            loop.close()
             records = json.loads(result)
             assert len(records) == 5
 
     def test_empty_file(self):
         tools = _mock_tools(get_audit_log="[]")
         with patch("modules.root_mcp_main_entry._tools", return_value=tools):
-            result = qwen_get_audit_log()
+            loop = asyncio.new_event_loop()
+            result = loop.run_until_complete(qwen_get_audit_log())
+            loop.close()
             records = json.loads(result)
             assert len(records) == 0

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -11,6 +11,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+class _BufferStringIO(io.StringIO):
+    def __init__(self) -> None:
+        super().__init__()
+        self._binary_buffer = io.BytesIO()
+
+    @property
+    def buffer(self) -> io.BytesIO:
+        return self._binary_buffer
+
 from modules.root_mcp_main_entry import (
     GENERATED_TOOLS,
     MCP_TOOL_SPECS,
@@ -123,8 +133,8 @@ class TestRunMcpServer:
             mock_app.run.assert_called_once()
 
     def test_tool_output_is_isolated_from_json_rpc_stdout(self):
-        transport_stdout = io.StringIO()
-        diagnostics_stderr = io.StringIO()
+        transport_stdout = _BufferStringIO()
+        diagnostics_stderr = _BufferStringIO()
         tools = MagicMock()
 
         def send_prompt(*args, **kwargs):
@@ -162,8 +172,8 @@ class TestRunMcpServer:
         assert b"binary data" in diagnostics_stderr.buffer.getvalue()
 
     def test_stdout_restored_after_app_run_exception(self):
-        transport_stdout = io.StringIO()
-        diagnostics_stderr = io.StringIO()
+        transport_stdout = _BufferStringIO()
+        diagnostics_stderr = _BufferStringIO()
         mock_app = MagicMock()
         mock_app.tool.return_value = lambda fn: fn
         mock_app.run.side_effect = RuntimeError("app.run failed")

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -12,15 +12,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-class _BufferStringIO(io.StringIO):
-    def __init__(self) -> None:
-        super().__init__()
-        self._binary_buffer = io.BytesIO()
-
-    @property
-    def buffer(self) -> io.BytesIO:
-        return self._binary_buffer
-
 from modules.root_mcp_main_entry import (
     GENERATED_TOOLS,
     MCP_TOOL_SPECS,
@@ -30,6 +21,16 @@ from modules.root_mcp_main_entry import (
     qwen_get_audit_log,
     qwen_send_prompt,
 )
+
+
+class _BufferStringIO(io.StringIO):
+    def __init__(self) -> None:
+        super().__init__()
+        self._binary_buffer = io.BytesIO()
+
+    @property
+    def buffer(self) -> io.BytesIO:
+        return self._binary_buffer
 
 
 class TestGetMcpApp:

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+import io
 import json
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from modules.root_mcp_main_entry import (
+    GENERATED_TOOLS,
+    MCP_TOOL_SPECS,
     _get_mcp_app,
     _register_tool,
+    _register_tools,
     qwen_get_audit_log,
+    qwen_send_prompt,
 )
 
 
@@ -55,7 +62,7 @@ class TestGetAuditLog:
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = "Audit log file does not exist yet."
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            result = qwen_get_audit_log()
+            result = asyncio.run(qwen_get_audit_log())
             assert "does not exist" in result
 
     def test_with_log_entries(self, tmp_path):
@@ -66,7 +73,7 @@ class TestGetAuditLog:
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = "[" + ",".join(entries) + "]"
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            result = qwen_get_audit_log(limit=1)
+            result = asyncio.run(qwen_get_audit_log(limit=1))
             records = json.loads(result)
             assert len(records) == 2
 
@@ -74,9 +81,35 @@ class TestGetAuditLog:
         mock_tools = MagicMock()
         mock_tools.get_audit_log.return_value = "[]"
         with patch("modules.root_mcp_main_entry._tools", return_value=mock_tools):
-            result = qwen_get_audit_log()
+            result = asyncio.run(qwen_get_audit_log())
             records = json.loads(result)
             assert len(records) == 0
+
+
+class TestMcpRegistration:
+    def test_audit_log_is_declared_and_generated(self):
+        audit_spec = next(spec for spec in MCP_TOOL_SPECS if spec["name"] == "qwen_get_audit_log")
+        assert audit_spec["method"] == "get_audit_log"
+        assert audit_spec["params"] == [("limit", "int", False, 20)]
+        handler = GENERATED_TOOLS["qwen_get_audit_log"]
+        assert inspect.iscoroutinefunction(handler)
+        assert inspect.signature(handler).parameters["limit"].default == 20
+
+    def test_registers_every_spec_once(self):
+        mock_app = MagicMock()
+        registered = []
+
+        def register(fn):
+            registered.append(fn.__name__)
+            return fn
+
+        mock_app.tool.return_value = register
+        with patch("modules.root_mcp_main_entry._get_mcp_app", return_value=mock_app):
+            _register_tools()
+
+        expected = [spec["name"] for spec in MCP_TOOL_SPECS]
+        assert registered == expected
+        assert registered.count("qwen_get_audit_log") == 1
 
 
 class TestRunMcpServer:
@@ -88,3 +121,36 @@ class TestRunMcpServer:
 
             run_mcp_server()
             mock_app.run.assert_called_once()
+
+    def test_tool_output_is_isolated_from_json_rpc_stdout(self):
+        transport_stdout = io.StringIO()
+        diagnostics_stderr = io.StringIO()
+        tools = MagicMock()
+
+        def send_prompt(*args, **kwargs):
+            print("tool execution noise")
+            return "AI answer"
+
+        tools.send_prompt.side_effect = send_prompt
+        mock_app = MagicMock()
+        mock_app.tool.return_value = lambda fn: fn
+
+        def run_transport():
+            print("json-rpc transport output")
+            assert asyncio.run(qwen_send_prompt("hello")) == "AI answer"
+
+        mock_app.run.side_effect = run_transport
+        with (
+            patch("modules.root_mcp_main_entry._get_mcp_app", return_value=mock_app),
+            patch("modules.root_mcp_main_entry._tools", return_value=tools),
+            patch("modules.core.src.capabilities_observability_setup.ObservabilitySetup.setup_observability"),
+            patch.object(sys, "stdout", transport_stdout),
+            patch.object(sys, "stderr", diagnostics_stderr),
+        ):
+            from modules.root_mcp_main_entry import run_mcp_server
+
+            run_mcp_server()
+
+        assert "json-rpc transport output" in transport_stdout.getvalue()
+        assert "tool execution noise" not in transport_stdout.getvalue()
+        assert "tool execution noise" in diagnostics_stderr.getvalue()

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -152,6 +152,7 @@ class TestRunMcpServer:
             from modules.root_mcp_main_entry import run_mcp_server
 
             run_mcp_server()
+            assert sys.stdout is transport_stdout
 
         assert "json-rpc transport output" in transport_stdout.getvalue()
         assert "tool execution noise" not in transport_stdout.getvalue()
@@ -159,7 +160,6 @@ class TestRunMcpServer:
         assert "line1" in diagnostics_stderr.getvalue()
         assert "line2" in diagnostics_stderr.getvalue()
         assert b"binary data" in diagnostics_stderr.buffer.getvalue()
-        assert sys.stdout is transport_stdout
 
     def test_stdout_restored_after_app_run_exception(self):
         transport_stdout = io.StringIO()
@@ -178,5 +178,4 @@ class TestRunMcpServer:
 
             with pytest.raises(RuntimeError, match="app.run failed"):
                 run_mcp_server()
-
-        assert sys.stdout is transport_stdout
+            assert sys.stdout is transport_stdout

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -129,6 +129,8 @@ class TestRunMcpServer:
 
         def send_prompt(*args, **kwargs):
             print("tool execution noise")
+            sys.stdout.writelines(["line1\n", "line2\n"])
+            sys.stdout.buffer.write(b"binary data\n")
             return "AI answer"
 
         tools.send_prompt.side_effect = send_prompt
@@ -154,3 +156,27 @@ class TestRunMcpServer:
         assert "json-rpc transport output" in transport_stdout.getvalue()
         assert "tool execution noise" not in transport_stdout.getvalue()
         assert "tool execution noise" in diagnostics_stderr.getvalue()
+        assert "line1" in diagnostics_stderr.getvalue()
+        assert "line2" in diagnostics_stderr.getvalue()
+        assert b"binary data" in diagnostics_stderr.buffer.getvalue()
+        assert sys.stdout is transport_stdout
+
+    def test_stdout_restored_after_app_run_exception(self):
+        transport_stdout = io.StringIO()
+        diagnostics_stderr = io.StringIO()
+        mock_app = MagicMock()
+        mock_app.tool.return_value = lambda fn: fn
+        mock_app.run.side_effect = RuntimeError("app.run failed")
+
+        with (
+            patch("modules.root_mcp_main_entry._get_mcp_app", return_value=mock_app),
+            patch("modules.core.src.capabilities_observability_setup.ObservabilitySetup.setup_observability"),
+            patch.object(sys, "stdout", transport_stdout),
+            patch.object(sys, "stderr", diagnostics_stderr),
+        ):
+            from modules.root_mcp_main_entry import run_mcp_server
+
+            with pytest.raises(RuntimeError, match="app.run failed"):
+                run_mcp_server()
+
+        assert sys.stdout is transport_stdout

--- a/tests/test_mcp_server_extended.py
+++ b/tests/test_mcp_server_extended.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 from modules.root_mcp_main_entry import (
     GENERATED_TOOLS,
     MCP_TOOL_SPECS,


### PR DESCRIPTION
## Summary

This PR resolves MCP issues #73, #74, and #75 in one change set.

- Protects JSON-RPC stdout during synchronous tool execution while preserving FastMCP transport output.
- Adds `qwen_get_audit_log` to `MCP_TOOL_SPECS` and generates it through the shared async handler generator with `limit=20`.
- Derives generated handler signatures, annotations, defaults, and docstrings from the declarative specification.
- Updates MCP FRD, file map, QA checklist, and registration/async/stdout-isolation tests.

## Validation

- `pytest -q` — passed
- `ruff format --check modules/ tests/` — passed
- `ruff check modules/ tests/` — passed
- `mypy modules/` — passed

## Scope

`AuditRepository.get_audit_log()` and `LinuxGuard` were not changed.

Closes #73
Closes #74
Closes #75

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects JSON-RPC stdout during MCP tool execution and generates the audit log tool from the declarative spec. Previously, tool prints could leak to stdout and corrupt the transport; now tool diagnostics go to stderr while `fastmcp` transport output stays on stdout, including binary buffer writes.

- Installs a contextvars-gated stdout proxy for the server lifetime; routes write(), writelines(), and buffer.write() to stderr only while a tool runs; flushes both streams; always restores the original stdout even if app.run() fails.
- Generates qwen_get_audit_log from MCP_TOOL_SPECS with limit=20; removes manual registration; registers each spec entry exactly once with specification-derived inspect.Signature, annotations, and docstring.
- Delegates synchronous core work via `asyncio`.to_thread; marks the execution context during the call and resets it in a finally block to prevent leaks after errors.
- Keeps the module importable without `fastmcp`; raises a clear ImportError only when starting the server.
- Migration: If you import module-level MCP tool functions directly, they are async and must be awaited. No changes required for MCP clients.

<sup>Written for commit 8141165c476f36ac141c8be5e6d9da97bd1ad583. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

