### PR TITLE
fix(cli): enforce surface precedence and LinuxGuard lifecycle

### DIFF
--- a/modules/cli/FRD.md
+++ b/modules/cli/FRD.md
@@ -1,64 +1,106 @@
-# FRD — CLI Surface
+# CLI Functional Requirements Document
 
 ## System Overview
-The CLI surface (`modules/cli`) translates command-line arguments and interactive TTY inputs into `AppConfig` objects, delegating execution to the Core aggregate. It acts as a "Smart Surface" in the AES architecture, handling only presentation and boundary concerns without containing business logic.
+
+The CLI surface (`modules/cli`) translates command-line arguments and interactive TTY inputs into `AppConfig` objects and delegates execution to the Core aggregate. It remains a **Smart Surface**: presentation, argument validation, dispatch, and lifecycle-boundary concerns belong here; business processing semantics remain in `modules/core`.
+
+The authoritative Linux lifecycle owner is `modules/root_cli_main_entry.py`. The CLI root acquires the optional `LinuxGuard` before dispatch, emits systemd readiness after container initialization and lock acquisition, and emits shutdown plus releases the lock in a `finally` block. The MCP root is a separate lifecycle and constructs `SharedContainer(use_linux_guard=False)`.
 
 ## Functional Requirements
 
 ### FR-001: Argument Parsing & Config Building
-- **Description**: Parses `sys.argv` and constructs a validated `AppConfig` Value Object.
-- **Input**: CLI flags (`--watch`, `--headless`, `-i`, `-o`, etc.).
-- **Output**: `AppConfig` instance.
-- **Business Rules**: 
-  - Must default to XDG-compliant paths if user paths are omitted.
-  - Must infer `mode` (batch vs single) based on whether the input path is a directory or file.
-- **Edge Cases**: Missing arguments, invalid directory paths, conflicting flags.
-- **Error Handling**: Exits with code 1 and prints standardized error envelope to `stderr`.
+
+The root parser reads `sys.argv` and constructs a validated `AppConfig` value object for run modes. Init is an action dispatched by the root and is not represented as an `AppConfig.mode`.
+
+| Precedence | Signal | Result | Validation |
+|---|---|---|---|
+| 1 | `--login` | `mode="login"` | Input path is not required; manual login is always headed. |
+| 2 | `init` subcommand or `--init` | Workspace initialization | Target directory is passed to the init surface. |
+| 3 | `--watch` | `mode="watcher"` | `-i/--input` must be an existing directory. |
+| 4 | No higher-priority signal and `input.is_dir()` | `mode="batch"` | Input must exist. |
+| 5 | No higher-priority signal and `input.is_file()` | `mode="single"` | Input must exist. |
+
+The effective precedence is therefore **`login > init > watch > is_dir()`**. If `--login` is combined with another action flag, login wins explicitly; if login is absent, init wins over watcher and path inference. An invalid run input is rejected with a non-success result and a clear diagnostic on `stderr`. Extensionless files are classified as single-file mode by filesystem type, never by filename suffix heuristics.
 
 ### FR-002: Interactive TUI Menu
-- **Description**: Provides a fallback interactive menu for users running the CLI without arguments.
-- **Input**: TTY `stdin`.
-- **Output**: `AppConfig` or `None` (exit).
-- **Business Rules**: 
-  - Must verify `sys.stdin.isatty()` before prompting.
-  - Must allow selection of Watcher, Batch, Single, Login, or Init modes.
-- **Edge Cases**: Piped input (non-TTY) must immediately reject interactive mode.
-- **Error Handling**: Returns error envelope if TTY check fails.
+
+The no-argument TTY fallback is owned by `InteractiveController`. The root calls the controller's production `run()` path after the menu selection, while the controller also retains a compatible combined prompt-and-run API for direct callers. Non-TTY input is rejected before prompting.
+
+The menu supports Watcher, Batch, Single, Manual Login, Init, and Exit. The selected configuration is executed exactly once. The Login branch uses the shared `wait_for_login_confirmation()` callback from the login surface, so the ENTER boundary is not duplicated between interactive and explicit login flows.
 
 ### FR-003: Manual Login Orchestration
-- **Description**: Orchestrates the visible browser login flow.
-- **Input**: `AppConfig` (headless=False).
-- **Output**: Success/Failure envelope.
-- **Business Rules**: 
-  - Must force `headless=False` for a new manual-login flow.
-  - Must validate an existing saved session before opening a visible browser.
-  - Must block execution and wait for user `ENTER` keypress while the browser remains open.
-  - Must verify the authenticated chat UI before reporting success.
-- **Edge Cases**: Existing session is valid, session is expired/corrupt, or the user closes the browser before pressing ENTER.
-- **Error Handling**: Catches `AuthRequiredError` and reports that the session was not verified.
+
+The login surface accepts an `AppConfig` and delegates session setup to the Core aggregate. It requires a TTY, forces headed mode at configuration construction, validates an existing session through the core, waits for the user to press ENTER while the browser remains open, and reports success only after the core verifies the authenticated chat UI.
+
+The shared `wait_for_login_confirmation()` helper is the single owner of the user-facing login prompt. Authentication and session errors are returned through the standardized response envelope.
+
+### FR-004: CLI LinuxGuard Lifecycle
+
+The CLI root is the only production caller of LinuxGuard.
+
+| Lifecycle point | Required behavior |
+|---|---|
+| Before dispatch | Acquire the non-blocking single-instance lock. A second instance returns a clear failure. |
+| After container initialization and lock acquisition | Send `READY=1`; invalid or missing `NOTIFY_SOCKET` is non-fatal. |
+| Normal completion or exception | Send `STOPPING=1`, then release the lock in `finally`. |
+| MCP startup | Do not acquire a CLI lock or send CLI lifecycle notifications. |
+
+No LinuxGuard logic is duplicated in the Core orchestrator. `SharedContainer` remains backward-compatible and exposes `linux=None` when `use_linux_guard=False`.
 
 ## API Contract
 
-| Operation | Input | Output | Description |
-|-----------|-------|--------|-------------|
-| `handle` (run) | `args`, `core` | `dict` | Dispatches processing based on `AppConfig.mode`. |
-| `handle` (login) | `args`, `core`, `cfg` | `dict` | Runs manual login flow. |
-| `handle` (init) | `args`, `core` | `dict` | Provisions workspace directories. |
+| Operation | Input | Output | Production caller |
+|---|---|---|---|
+| `_parse_args` | argv tokens | `argparse.Namespace` | `modules/root_cli_main_entry.py` |
+| `_build_config` | parsed namespace | validated `AppConfig` | `modules/root_cli_main_entry.py` |
+| `handle` (run) | args, core | response envelope | `modules/cli/src/surface_cli_run_command.py` |
+| `handle` (login) | args, core, cfg | response envelope | `modules/cli/src/surface_cli_login_command.py` |
+| `handle` (init) | args, core | response envelope | `modules/cli/src/surface_cli_init_command.py` |
+| `InteractiveController.run` | optional config, prompt flag | response envelope | `modules/root_cli_main_entry.py` and direct surface callers |
+| `_run_cli_lifecycle` | dispatch callback | process exit code | `modules/root_cli_main_entry.py` |
+
+## Production File Map and Traceability
+
+| Requirement / boundary | Production caller | Implementation file | Verification |
+|---|---|---|---|
+| CLI FR-001 parsing, precedence, and path validation | CLI root | `modules/root_cli_main_entry.py` | `tests/test_main_cli.py` |
+| CLI FR-002 TTY menu and one execution path | CLI root and interactive surface | `modules/root_cli_main_entry.py`, `modules/cli/src/surface_cli_interactive_controller.py` | `tests/test_main_extended.py` |
+| CLI FR-003 manual login and shared ENTER boundary | CLI root and login surface | `modules/cli/src/surface_cli_login_command.py` | `tests/test_login_session.py`, `tests/test_main_extended.py` |
+| CLI init action | CLI root | `modules/cli/src/surface_cli_init_command.py` | `tests/test_main_cli.py`, `tests/test_init_cmd.py` |
+| Linux lock and systemd notification capability | CLI lifecycle root | `modules/core/src/capabilities_linux_guard.py`, `modules/core/src/root_core_container.py` | `tests/test_linux.py`, `tests/test_cli_linux_guard.py` |
+| MCP lock-free composition | MCP root | `modules/root_mcp_main_entry.py` | `tests/test_cli_linux_guard.py`, `tests/test_mcp_server*.py` |
 
 ## Integration Points
-- **Internal**: `modules/core` (CoreOrchestrator aggregate), `modules/shared` (Taxonomy VOs).
 
-## Non-functional Requirements (Detailed)
-- **Usability**: Must support ANSI colors for TUI menus when attached to a TTY.
-- **Security**: Must never echo sensitive session paths or credentials to stdout.
+The CLI delegates processing and session orchestration to `modules/core`, uses shared `AppConfig` and error taxonomies from `modules/shared`, and uses `SharedContainer` for dependency composition. MCP remains a separate caller and does not enter the CLI lifecycle wrapper.
+
+## Non-functional Requirements
+
+The CLI must preserve standardized `stderr` diagnostics, avoid echoing credentials or sensitive session contents, and tolerate missing or invalid systemd notification sockets. Interactive prompts are available only on a TTY.
 
 ## Test Scenarios / QA Checklist
-- [ ] Verify `--watch` flag correctly sets `AppConfig.mode` to "watcher".
-- [ ] Verify non-TTY execution immediately rejects interactive prompts.
-- [ ] Verify `init` command creates `.qwen-web/` symlinks and `.gitignore` entries.
+
+- [x] `--login` takes precedence over `--watch` and path inference.
+- [x] `init` takes precedence over watcher and path inference when login is absent.
+- [x] `--watch` requires an existing input directory.
+- [x] Existing extensionless input files resolve to single-file mode.
+- [x] Missing input paths return a non-success result with a `stderr` diagnostic.
+- [x] No-argument TTY flow reaches `InteractiveController.run()` and executes the selected mode once.
+- [x] Non-TTY execution rejects interactive prompts immediately.
+- [x] Login and interactive login use one shared ENTER confirmation helper.
+- [x] `init` creates `.qwen-web/` symlinks and `.gitignore` entries.
+- [x] A second CLI instance using the same lock path fails immediately.
+- [x] CLI lock cleanup occurs after normal completion and after exceptions.
+- [x] CLI sends `READY=1` after successful initialization and `STOPPING=1` during shutdown.
+- [x] Fake `NOTIFY_SOCKET` integration verifies notification ordering.
+- [x] MCP constructs its container with `use_linux_guard=False` and remains lock-free.
 
 ## Assumptions & Constraints
-- Assumes the host OS supports standard POSIX terminal I/O.
 
-## Reference
-- PRD: [Root PRD.md](../../PRD.md)
+The host OS supports POSIX terminal I/O, `fcntl.flock`, and Unix datagram sockets. Core processing semantics and MCP runtime implementation are outside this change set.
+
+## References
+
+- [Root PRD](../../PRD.md)
+- [Core FRD](../core/FRD.md)
+- Issues [#70](https://github.com/rakaarwaky/qwen-web/issues/70), [#71](https://github.com/rakaarwaky/qwen-web/issues/71), [#72](https://github.com/rakaarwaky/qwen-web/issues/72), and [#88](https://github.com/rakaarwaky/qwen-web/issues/88)

--- a/modules/cli/src/surface_cli_interactive_controller.py
+++ b/modules/cli/src/surface_cli_interactive_controller.py
@@ -19,7 +19,7 @@ from modules.shared.src.taxonomy_core_constant import (
     DEFAULT_TODO,
 )
 from modules.shared.src.utility_core_path import list_input_files
-from modules.shared.src.utility_core_response import safe_handle, success_response
+from modules.shared.src.utility_core_response import error_response, safe_handle, success_response
 
 
 def _base_config(mode: str, headless: bool = False) -> AppConfig:
@@ -107,6 +107,13 @@ class InteractiveController:
         The optional arguments preserve the controller's original public API
         for callers that want menu selection and execution in one call.
         """
+        if prompt and not sys.stdin.isatty():
+            return error_response(
+                RuntimeError("Interactive mode requires a TTY. Please provide CLI arguments."),
+                "validation_error",
+                "cli-400",
+            )
+
         selected = self.interactive_prompt() if prompt else cfg
         if selected is None:
             return success_response("Exited.")

--- a/modules/cli/src/surface_cli_interactive_controller.py
+++ b/modules/cli/src/surface_cli_interactive_controller.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Literal
 
+from modules.cli.src.surface_cli_login_command import wait_for_login_confirmation
 from modules.core.src.utility_core_config_factory import build_app_config
 from modules.shared.src.contract_core_aggregate import ICoreAggregate
 from modules.shared.src.taxonomy_config_vo import AppConfig
@@ -98,24 +99,23 @@ class InteractiveController:
         return _base_config(mode, headless=headless)
 
     @safe_handle
-    def run(self) -> dict[str, object]:
-        """Present the TUI menu and execute the selected mode."""
-        cfg = self.interactive_prompt()
-        if cfg is None:
+    def run(self, cfg: AppConfig | None = None, *, prompt: bool = True) -> dict[str, object]:
+        """Present the TUI menu and execute the selected mode.
+
+        ``main`` supplies a previously selected configuration with
+        ``prompt=False`` so the interactive selection has exactly one owner.
+        The optional arguments preserve the controller's original public API
+        for callers that want menu selection and execution in one call.
+        """
+        selected = self.interactive_prompt() if prompt else cfg
+        if selected is None:
             return success_response("Exited.")
-        if cfg.mode == "login":
-
-            def _wait_for_login() -> None:
-                """Keep the headed browser alive while the user completes login."""
-                print("Please log in or resolve CAPTCHA in the browser window.")
-                print("Press [ENTER] here once the chat page is ready:")
-                input()
-
+        if selected.mode == "login":
             result = self._core.setup_session(
-                wait_for_confirmation=_wait_for_login,
-                session_path=cfg.session_path,
+                wait_for_confirmation=wait_for_login_confirmation,
+                session_path=selected.session_path,
             )
             return success_response(result)
 
-        result = self._core.process_mode(cfg)
+        result = self._core.process_mode(selected)
         return success_response(result)

--- a/modules/cli/src/surface_cli_login_command.py
+++ b/modules/cli/src/surface_cli_login_command.py
@@ -1,16 +1,25 @@
-"""CLI surface: login command — manual browser login / session setup.
-
-Smart surface: TTY check + interactive ENTER prompt; delegates the browser
-session to the shared core aggregate.
-"""
+"""CLI surface for manual login/session setup."""
 
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 
 from modules.shared.src.contract_core_aggregate import ICoreAggregate
 from modules.shared.src.taxonomy_config_vo import AppConfig
 from modules.shared.src.utility_core_response import error_response, safe_handle, success_response
+
+
+def wait_for_login_confirmation() -> None:
+    """Keep the headed browser alive while the user completes login."""
+    print("Please log in or resolve CAPTCHA in the browser window.")
+    print("Press [ENTER] here once the chat page is ready:")
+    input()
+
+
+def _login_waiter() -> Callable[[], None]:
+    """Return the shared login confirmation callback for dependency injection."""
+    return wait_for_login_confirmation
 
 
 @safe_handle
@@ -21,14 +30,8 @@ def handle(_args: object, core: ICoreAggregate, cfg: AppConfig) -> dict[str, obj
             RuntimeError("Manual login requires an interactive terminal (TTY)."), "validation_error", "cli-400"
         )
 
-    def _wait_for_login() -> None:
-        """Keep the headed browser alive while the user completes login."""
-        print("Please log in or resolve CAPTCHA in the browser window.")
-        print("Press [ENTER] here once the chat page is ready:")
-        input()
-
     result = core.setup_session(
-        wait_for_confirmation=_wait_for_login,
+        wait_for_confirmation=_login_waiter(),
         session_path=cfg.session_path,
     )
     return success_response(result)

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -1,16 +1,17 @@
-#!/usr/bin/env python3
 """qwen-cli v4: Production-grade automation for chat.qwen.ai.
 
-Root layer: CLI entry point — argparse parsing, config building, and dispatch
-to the CLI surface commands via the auto-wired DI container.
+Root layer: CLI entry point — argument parsing, validation, lifecycle guards,
+and dispatch to the CLI surface commands via the auto-wired DI container.
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from modules.cli.src import (
     surface_cli_init_command,
@@ -29,9 +30,12 @@ from modules.shared.src.taxonomy_core_constant import (
     DEFAULT_SESSION,
     DEFAULT_TODO,
 )
+from modules.shared.src.taxonomy_domain_error import SingleInstanceError
+
+_ERROR_PREFIX = "[ERROR]"
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments for qwen-cli subcommands and options."""
     p = argparse.ArgumentParser(prog="qwen-cli", description="Automate chat.qwen.ai")
     p.add_argument("command", nargs="?", default=None, help="Subcommand (e.g. init)")
@@ -61,22 +65,37 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--cb-threshold", type=int, default=5, help="Consecutive failures to trip circuit breaker")
     p.add_argument("--cb-window", type=int, default=30, help="Circuit breaker sliding window in seconds")
     p.add_argument("--retry-failed", action="store_true", help="Process files in failed/ directory on next run")
-    return p.parse_args()
+    return p.parse_args(argv)
 
 
 def _build_config(args: argparse.Namespace) -> AppConfig:
-    """Build AppConfig from parsed CLI arguments."""
-    if args.login:
-        mode_val: str = "login"
-    elif args.watch:
+    """Build and validate AppConfig using the documented mode precedence.
+
+    The mode precedence is explicit: ``login > init > watch > is_dir()``.
+    ``init`` is dispatched as a command by :func:`main`, so this function
+    resolves the remaining execution modes and validates their input path.
+    """
+    login = bool(getattr(args, "login", False))
+    watch = bool(getattr(args, "watch", False))
+    input_path = Path(getattr(args, "input", str(DEFAULT_TODO)))
+
+    if login:
+        mode_val = "login"
+    elif watch:
+        if not input_path.is_dir():
+            raise ValueError(f"Watcher input path must be an existing directory: {input_path}")
         mode_val = "watcher"
+    elif input_path.is_dir():
+        mode_val = "batch"
+    elif input_path.is_file():
+        mode_val = "single"
     else:
-        input_path = Path(args.input)
-        mode_val = "batch" if (input_path.is_dir() or not input_path.suffix) else "single"
+        raise ValueError(f"Input path must be an existing file or directory: {input_path}")
+
     return AppConfig(
         mode=mode_val,
-        input_path=Path(args.input),
-        output_path=Path(args.output),
+        input_path=input_path,
+        output_path=Path(getattr(args, "output", str(DEFAULT_OUTPUT))),
         done_path=Path(getattr(args, "done_dir", str(DEFAULT_DONE))),
         failed_path=Path(getattr(args, "failed_dir", str(DEFAULT_FAILED))),
         proc_path=Path(getattr(args, "proc_dir", str(DEFAULT_PROC))),
@@ -84,7 +103,7 @@ def _build_config(args: argparse.Namespace) -> AppConfig:
         log_path=Path(getattr(args, "log_dir", str(DEFAULT_LOG))),
         interval=getattr(args, "interval", 3),
         timeout=getattr(args, "timeout", 300),
-        headless=bool(getattr(args, "headless", False)),
+        headless=False if login else bool(getattr(args, "headless", False)),
         request_timeout=getattr(args, "request_timeout", 120),
         poll_interval=float(getattr(args, "poll_interval", 1.0)),
         streaming_timeout=getattr(args, "streaming_timeout", 180),
@@ -101,75 +120,116 @@ def _default_container() -> SharedContainer:
     return SharedContainer()
 
 
+def _result_exit_code(result: dict[str, object]) -> int:
+    """Convert a surface response envelope to a CLI exit code."""
+    if result.get("success"):
+        return 0
+    print(str(result.get("error") or "Unknown error"), file=sys.stderr)
+    return 1
+
+
+def _run_cli_lifecycle(dispatch: Callable[[SharedContainer], int]) -> int:
+    """Own the CLI-only LinuxGuard lifecycle.
+
+    MCP does not call this function and constructs its container with
+    ``use_linux_guard=False``. A CLI lock is acquired before dispatch, READY is
+    emitted after container initialization, and STOPPING plus lock release are
+    guaranteed by the finalizer.
+    """
+    container = _default_container()
+    linux = container.linux
+    lock: Any = None
+    try:
+        if linux is not None:
+            lock = linux.acquire_lock()
+            linux.sd_notify_ready()
+        return dispatch(container)
+    finally:
+        if linux is not None and lock is not None:
+            try:
+                linux.sd_notify_stop()
+            finally:
+                linux.release_lock(lock)
+
+
+def _dispatch(
+    container: SharedContainer, raw_argv: list[str], args: argparse.Namespace | None, cfg: AppConfig | None
+) -> int:
+    """Dispatch one already-parsed CLI invocation."""
+    # Explicit precedence: login wins over init, including --login --init.
+    if args is not None and bool(getattr(args, "login", False)):
+        assert cfg is not None
+        return _run_manual_login(cfg, container)
+
+    # Init is an action rather than an AppConfig mode. It wins over watcher
+    # and path inference when login is absent.
+    if args is not None and (getattr(args, "command", None) == "init" or bool(getattr(args, "init", False))):
+        result = surface_cli_init_command.handle(args, container.core)
+        return _result_exit_code(result)
+
+    if not raw_argv:
+        cfg_interactive = _interactive_prompt(container.core)
+        if cfg_interactive is None:
+            return 0
+        result = surface_cli_interactive_controller.InteractiveController(container.core).run(
+            cfg_interactive,
+            prompt=False,
+        )
+        return _result_exit_code(result)
+
+    if args is None or cfg is None:
+        print(f"{_ERROR_PREFIX} Missing CLI configuration.", file=sys.stderr)
+        return 1
+    args._cfg = cfg
+    result = surface_cli_run_command.handle(args, container.core)
+    return _result_exit_code(result)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the main entrypoint for qwen-cli."""
-    args = _parse_args() if (argv is not None or len(sys.argv) > 1) else None
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    args = _parse_args(raw_argv) if raw_argv else None
 
-    # MCP server mode
+    # MCP is a separate runtime and must never enter the CLI LinuxGuard path.
     if args and getattr(args, "mcp", False):
         from modules.root_mcp_main_entry import run_mcp_server
 
         run_mcp_server()
         return 0
 
-    # Init subcommand
-    if args and (getattr(args, "command", None) == "init" or getattr(args, "init", False)):
-        container = _default_container()
-        result = surface_cli_init_command.handle(args, container.core)
-        return 0 if result.get("success") else 1
+    cfg: AppConfig | None = None
+    if args is not None:
+        is_init = getattr(args, "command", None) == "init" or bool(getattr(args, "init", False))
+        if not is_init or bool(getattr(args, "login", False)):
+            try:
+                cfg = _build_config(args)
+            except (OSError, ValueError) as exc:
+                print(f"{_ERROR_PREFIX} {exc}", file=sys.stderr)
+                return 1
 
-    # Interactive mode when no args
-    if len(sys.argv) == 1 and argv is None:
-        cfg = _interactive_prompt()
-        if cfg is None:
-            return 0
-        # Run command reads the built config from args._cfg; interactive mode
-        # never parsed argv, so synthesize a namespace carrying the config.
-        args = argparse.Namespace()
-        args._cfg = cfg
-    else:
-        if args is None:
-            print("ERROR: missing CLI arguments", file=sys.stderr)
-            return 1
-        cfg = _build_config(args)
-
-    # Observability first
     try:
+        return _run_cli_lifecycle(lambda container: _dispatch(container, raw_argv, args, cfg))
+    except SingleInstanceError as exc:
+        print(f"{_ERROR_PREFIX} {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # boundary: user-facing error after lifecycle cleanup
+        print(f"{_ERROR_PREFIX} {exc}", file=sys.stderr)
+        return 1
+
+
+def _interactive_prompt(core: Any | None = None) -> AppConfig | None:
+    """Display the interactive menu and build AppConfig from user selections."""
+    if core is None:
+        core = _default_container().core
+    return surface_cli_interactive_controller.InteractiveController(core).interactive_prompt()
+
+
+def _run_manual_login(cfg: AppConfig, container: SharedContainer | None = None) -> int:
+    """Launch visible browser for interactive login."""
+    if container is None:
         container = _default_container()
-    except Exception:  # boundary: container init failure → user-facing error + exit 1
-        print("[ERROR] Failed to initialize qwen-web. Run 'qwen-web-cli init' first.", file=sys.stderr)
-        return 1
-
-    if cfg.mode == "login":
-        return _run_manual_login(cfg)
-
-    args_with_cfg = args
-    if args_with_cfg is not None:
-        args_with_cfg._cfg = cfg
-    result = surface_cli_run_command.handle(args_with_cfg, container.core)
-    if not result.get("success"):
-        print(result.get("error") or "Unknown error", file=sys.stderr)
-        return 1
-    return 0
-
-
-def _interactive_prompt() -> AppConfig | None:
-    """Display interactive TUI menu and build AppConfig from user selections."""
-    container = _default_container()
-    return surface_cli_interactive_controller.InteractiveController(container.core).interactive_prompt()
-
-
-def _run_manual_login(cfg: AppConfig) -> int:
-    """Launch visible browser for interactive login (TTY flow in the surface).
-
-    Returns 0 on success, 1 on failure (error printed to stderr).
-    """
-    container = _default_container()
     result = surface_cli_login_command.handle(None, container.core, cfg)
-    if not result.get("success"):
-        print(result.get("error") or "Unknown error", file=sys.stderr)
-        return 1
-    return 0
+    return _result_exit_code(result)
 
 
 if __name__ == "__main__":

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -124,7 +124,7 @@ def _result_exit_code(result: dict[str, object]) -> int:
     """Convert a surface response envelope to a CLI exit code."""
     if result.get("success"):
         return 0
-    print(str(result.get("error") or "Unknown error"), file=sys.stderr)
+    print(f"{_ERROR_PREFIX} {result.get('error') or 'Unknown error'}", file=sys.stderr)
     return 1
 
 
@@ -158,8 +158,10 @@ def _dispatch(
     """Dispatch one already-parsed CLI invocation."""
     # Explicit precedence: login wins over init, including --login --init.
     if args is not None and bool(getattr(args, "login", False)):
-        assert cfg is not None
-        return _run_manual_login(cfg, container)
+        if cfg is None:
+            print(f"{_ERROR_PREFIX} Missing login configuration.", file=sys.stderr)
+            return 1
+        return _run_manual_login(cfg)
 
     # Init is an action rather than an AppConfig mode. It wins over watcher
     # and path inference when login is absent.
@@ -168,13 +170,7 @@ def _dispatch(
         return _result_exit_code(result)
 
     if not raw_argv:
-        cfg_interactive = _interactive_prompt(container.core)
-        if cfg_interactive is None:
-            return 0
-        result = surface_cli_interactive_controller.InteractiveController(container.core).run(
-            cfg_interactive,
-            prompt=False,
-        )
+        result = surface_cli_interactive_controller.InteractiveController(container.core).run()
         return _result_exit_code(result)
 
     if args is None or cfg is None:
@@ -224,10 +220,9 @@ def _interactive_prompt(core: Any | None = None) -> AppConfig | None:
     return surface_cli_interactive_controller.InteractiveController(core).interactive_prompt()
 
 
-def _run_manual_login(cfg: AppConfig, container: SharedContainer | None = None) -> int:
+def _run_manual_login(cfg: AppConfig) -> int:
     """Launch visible browser for interactive login."""
-    if container is None:
-        container = _default_container()
+    container = _default_container()
     result = surface_cli_login_command.handle(None, container.core, cfg)
     return _result_exit_code(result)
 

--- a/tests/test_cli_linux_guard.py
+++ b/tests/test_cli_linux_guard.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules import root_mcp_main_entry
+from modules.core.src.capabilities_linux_guard import LinuxGuard
+from modules.root_cli_main_entry import _run_cli_lifecycle, main
+from modules.shared.src.taxonomy_domain_error import SingleInstanceError
+
+
+class TestCliLinuxLifecycle:
+    def test_ready_then_stopping_and_release_after_dispatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        lock_path = tmp_path / "qwen.lock"
+        notify_path = tmp_path / "notify.sock"
+        receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        receiver.bind(str(notify_path))
+        receiver.settimeout(1)
+        monkeypatch.setenv("NOTIFY_SOCKET", str(notify_path))
+        container = SimpleNamespace(linux=LinuxGuard(lock_path), core=object())
+
+        try:
+            with patch("modules.root_cli_main_entry._default_container", return_value=container):
+                result = _run_cli_lifecycle(lambda _container: 7)
+            assert result == 7
+            assert receiver.recv(64) == b"READY=1"
+            assert receiver.recv(64) == b"STOPPING=1"
+            assert not lock_path.exists()
+        finally:
+            receiver.close()
+
+    def test_cleanup_after_dispatch_exception(self, tmp_path: Path) -> None:
+        events: list[str] = []
+
+        class FakeLinux:
+            def acquire_lock(self) -> object:
+                events.append("acquire")
+                return object()
+
+            def sd_notify_ready(self) -> None:
+                events.append("ready")
+
+            def sd_notify_stop(self) -> None:
+                events.append("stop")
+
+            def release_lock(self, _lock: object) -> None:
+                events.append("release")
+
+        container = SimpleNamespace(linux=FakeLinux(), core=object())
+        with (
+            patch("modules.root_cli_main_entry._default_container", return_value=container),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            _run_cli_lifecycle(lambda _container: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert events == ["acquire", "ready", "stop", "release"]
+
+    def test_second_instance_is_rejected(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / "qwen.lock"
+        first = LinuxGuard(lock_path).acquire_lock()
+        try:
+            container = SimpleNamespace(linux=LinuxGuard(lock_path), core=object())
+            with patch("modules.root_cli_main_entry._default_container", return_value=container):
+                with pytest.raises(SingleInstanceError):
+                    _run_cli_lifecycle(lambda _container: 0)
+        finally:
+            LinuxGuard(lock_path).release_lock(first)
+
+    def test_mcp_container_is_lock_free(self) -> None:
+        previous = root_mcp_main_entry._container
+        fake_container = SimpleNamespace(core=object(), wire=MagicMock())
+        try:
+            root_mcp_main_entry._container = None
+            with patch.object(root_mcp_main_entry, "SharedContainer", return_value=fake_container) as factory:
+                root_mcp_main_entry._tools()
+            factory.assert_called_once_with(use_linux_guard=False)
+            fake_container.wire.assert_called_once_with()
+        finally:
+            root_mcp_main_entry._container = previous
+
+    def test_main_reports_lock_failure(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        lock_path = tmp_path / "qwen.lock"
+        first = LinuxGuard(lock_path).acquire_lock()
+        try:
+            container = SimpleNamespace(linux=LinuxGuard(lock_path), core=object())
+            with patch("modules.root_cli_main_entry._default_container", return_value=container):
+                result = main(["--login"])
+            assert result == 1
+            assert "already running" in capsys.readouterr().err
+        finally:
+            LinuxGuard(lock_path).release_lock(first)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from modules.core.src.root_core_container import SharedContainer
 from modules.root_cli_main_entry import (
     _build_config,
@@ -87,7 +89,9 @@ class TestBuildConfig:
         args = MagicMock()
         args.login = False
         args.watch = True
-        args.input = str(tmp_path / "in")
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        args.input = str(input_dir)
         args.output = str(tmp_path / "out")
         args.done_dir = str(tmp_path / "done")
         args.failed_dir = str(tmp_path / "failed")
@@ -213,3 +217,53 @@ class TestRunInit:
             assert (dot_qwen / "input").exists()
             assert (dot_qwen / "output").exists()
             assert (dot_qwen / "log").exists()
+
+
+class TestCliValidation:
+    def test_login_precedes_watch_and_path_inference(self, tmp_path):
+        args = _namespace_for_config(tmp_path, login=True, watch=True, input_path=tmp_path / "missing")
+        cfg = _build_config(args)
+        assert cfg.mode == "login"
+        assert cfg.headless is False
+
+    def test_watch_requires_existing_directory(self, tmp_path):
+        args = _namespace_for_config(tmp_path, watch=True, input_path=tmp_path / "missing")
+        with pytest.raises(ValueError, match="existing directory"):
+            _build_config(args)
+
+    def test_extensionless_existing_file_is_single_mode(self, tmp_path):
+        input_file = tmp_path / "prompt"
+        input_file.write_text("prompt")
+        args = _namespace_for_config(tmp_path, input_path=input_file)
+        assert _build_config(args).mode == "single"
+
+    def test_missing_input_is_rejected(self, tmp_path):
+        args = _namespace_for_config(tmp_path, input_path=tmp_path / "missing")
+        with pytest.raises(ValueError, match="existing file or directory"):
+            _build_config(args)
+
+
+def _namespace_for_config(tmp_path, *, login=False, watch=False, input_path=None):
+    from argparse import Namespace
+
+    return Namespace(
+        login=login,
+        watch=watch,
+        input=str(input_path or tmp_path),
+        output=str(tmp_path / "out"),
+        done_dir=str(tmp_path / "done"),
+        failed_dir=str(tmp_path / "failed"),
+        proc_dir=str(tmp_path / "proc"),
+        data_dir=str(tmp_path / "session"),
+        log_dir=str(tmp_path / "log"),
+        headless=True,
+        timeout=300,
+        interval=3,
+        request_timeout=120,
+        poll_interval=1.0,
+        streaming_timeout=180,
+        rate_limit=60,
+        cb_threshold=5,
+        cb_window=30,
+        retry_failed=False,
+    )

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -228,16 +228,19 @@ class TestMain:
             patch(
                 "modules.cli.src.surface_cli_interactive_controller.InteractiveController.run",
                 return_value={"success": True, "message": "Exited."},
-            ),
+            ) as mock_run,
         ):
             result = main()
             assert result == 0
+            mock_run.assert_called_once_with()
 
-    def test_main_non_tty_interactive_fails(self):
+    def test_main_non_tty_interactive_fails(self, capsys):
         with patch("sys.argv", ["qwen-cli"]), patch("sys.stdin") as mock_stdin:
             mock_stdin.isatty.return_value = False
             result = main()
+            captured = capsys.readouterr()
             assert result == 1
+            assert "Interactive mode requires a TTY" in captured.err
 
     def test_main_login_mode(self):
         with (

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from modules.cli.src.surface_cli_interactive_controller import InteractiveController
 from modules.core.src.agent_core_orchestrator import CoreOrchestrator
 from modules.root_cli_main_entry import (
     _interactive_prompt,
@@ -126,6 +127,22 @@ class TestInteractivePrompt:
             assert result.mode == "watcher"
 
 
+class TestInteractiveControllerRun:
+    def test_non_tty_returns_validation_error(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            result = InteractiveController(MagicMock()).run()
+        assert result["success"] is False
+        assert result["category"] == "validation_error"
+        assert result["ref"] == "cli-400"
+
+    def test_explicit_exit_returns_success(self):
+        with patch("sys.stdin") as mock_stdin, patch("builtins.input", return_value="6"):
+            mock_stdin.isatty.return_value = True
+            result = InteractiveController(MagicMock()).run()
+        assert result == {"success": True, "message": "Exited."}
+
+
 class TestRunManualLogin:
     def test_not_tty_exits(self):
         with (
@@ -208,10 +225,19 @@ class TestMain:
     def test_main_interactive_exit(self):
         with (
             patch("sys.argv", ["qwen-cli"]),
-            patch("modules.root_cli_main_entry._interactive_prompt", return_value=None),
+            patch(
+                "modules.cli.src.surface_cli_interactive_controller.InteractiveController.run",
+                return_value={"success": True, "message": "Exited."},
+            ),
         ):
             result = main()
             assert result == 0
+
+    def test_main_non_tty_interactive_fails(self):
+        with patch("sys.argv", ["qwen-cli"]), patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            result = main()
+            assert result == 1
 
     def test_main_login_mode(self):
         with (


### PR DESCRIPTION
## Summary

This PR consolidates the CLI surface and LinuxGuard work for issues #70, #71, #72, and #88.

## Changes

- Enforced explicit CLI precedence: `login > init > watch > is_dir()`.
- Validated watcher and run input paths, including extensionless files, with clear stderr diagnostics.
- Routed the no-argument interactive flow through `InteractiveController.run()` and removed the duplicated login ENTER prompt by sharing one confirmation helper.
- Made the CLI root the authoritative LinuxGuard lifecycle owner: acquire lock, send `READY=1`, dispatch, send `STOPPING=1`, and release in `finally`.
- Preserved MCP lock-free behavior through `SharedContainer(use_linux_guard=False)`.
- Added temporary-lock and fake-`NOTIFY_SOCKET` integration coverage for ordering, cleanup, second-instance rejection, and MCP exemption.
- Updated `modules/cli/FRD.md` with precedence, lifecycle ownership, production file map, traceability, and QA checklist.

## Verification

- `pytest -q` — passed
- `ruff format --check modules/ tests/` — passed
- `ruff check modules/ tests/` — passed
- `mypy modules/` — passed

## Scope

No MCP runtime implementation or core processing semantics were changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces explicit CLI mode precedence and makes the CLI root the sole owner of the LinuxGuard lifecycle. Previously precedence was implicit and the login ENTER prompt was duplicated; now `login > init > watch > is_dir()` is enforced, a single shared login confirmation is used, non-TTY interactive attempts return a validation error, and the CLI sends `READY=1`/`STOPPING=1` while holding a single-instance lock.

- Parsing and validation live in `modules/root_cli_main_entry.py` (`_parse_args`, `_build_config`, `_dispatch`): watcher requires an existing directory, extensionless files resolve by filesystem type, invalid paths fail with clear `stderr`, and login forces `headless=False`.
- No-arg runs call `InteractiveController.run()`; when `prompt=True` and stdin is non-TTY, it returns a `validation_error` (`cli-400`). Both explicit and interactive login use the shared `wait_for_login_confirmation` from `modules/cli/src/surface_cli_login_command.py`.
- `_run_cli_lifecycle` acquires/releases the `LinuxGuard` lock and emits systemd notifications; MCP remains lock-free via `SharedContainer(use_linux_guard=False)`. Missing or invalid `NOTIFY_SOCKET` is tolerated. Second instances raise `SingleInstanceError` and exit 1.
- Tests add coverage for interactive TTY validation, single-execution interactive flow, notification ordering, cleanup on exceptions, second-instance rejection, and MCP exemption (`tests/test_cli_linux_guard.py`, `tests/test_main_cli.py`, `tests/test_main_extended.py`). FRD updated in `modules/cli/FRD.md`.

- Required: watcher runs must pass an existing directory to `-i/--input`. No other migration actions.

<sup>Written for commit 31b1fc494c14060a392d9784c835663da177ed2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

