### PR TITLE
fix(core): enforce pipeline routing outcomes and lifecycle gates

### DIFF
--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -14,8 +14,6 @@ import tempfile
 import threading
 import time
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 
 from playwright.sync_api import Page
@@ -43,7 +41,7 @@ from modules.shared.src.taxonomy_core_constant import (
     DEFAULT_OUTPUT,
     DEFAULT_TODO,
 )
-from modules.shared.src.taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, RateLimiter
+from modules.shared.src.taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, LifecycleState, RateLimiter
 from modules.shared.src.taxonomy_core_vo import (
     EVENT_DISPATCH_ACKNOWLEDGED,
     EVENT_DOCUMENT_PARSED,
@@ -56,6 +54,8 @@ from modules.shared.src.taxonomy_core_vo import (
     MessageCount,
     OutputChars,
     PollIntervalSec,
+    ProcessingOutcome,
+    ProcessingStatus,
     PromptText,
     ResponseText,
     RunContext,
@@ -75,39 +75,6 @@ from modules.shared.src.utility_core_path import (
 from modules.shared.src.utility_core_prompt import load_role_prompt, strip_input_from_output
 
 _watcher_shutdown: threading.Event = threading.Event()
-
-
-class ProcessingStatus(str, Enum):
-    """Terminal status for one queue item."""
-
-    SUCCESS = "SUCCESS"
-    FAILED = "FAILED"
-
-
-@dataclass(frozen=True)
-class ProcessingOutcome:
-    """Result of one processing attempt, including quarantine details."""
-
-    status: ProcessingStatus
-    error: str | None = None
-    failed_path: Path | None = None
-
-
-class LifecycleState:
-    """Run-local lifecycle gates driven by emitted event completion."""
-
-    def __init__(self) -> None:
-        self.web_loaded = False
-        self.document_parsed = False
-        self.dispatch_acknowledged = False
-
-    def mark(self, event_name: object) -> None:
-        if event_name == EVENT_WEB_LOADED:
-            self.web_loaded = True
-        elif event_name == EVENT_DOCUMENT_PARSED:
-            self.document_parsed = True
-        elif event_name == EVENT_DISPATCH_ACKNOWLEDGED:
-            self.dispatch_acknowledged = True
 
 
 def request_watcher_shutdown() -> None:
@@ -224,8 +191,11 @@ class CoreOrchestrator(ICoreAggregate):
         ctx = RunContext()
 
         def _fn() -> ResponseText:
-            proc_file, rel_path = next(iter(self._iter_todo(cfg)))
             with self._browser.browser_session(cfg):
+                try:
+                    proc_file, rel_path = next(iter(self._iter_todo(cfg)))
+                except StopIteration:
+                    return ResponseText(f"ERROR [NO_INPUT_FILE]: No processable input file found at {cfg.input_path}")
                 outcome = self._process_file(proc_file, rel_path, cfg, ctx)
             if outcome.status is ProcessingStatus.FAILED:
                 return ResponseText(f"ERROR [PROCESSING_FAILED]: {outcome.error}")
@@ -265,25 +235,32 @@ class CoreOrchestrator(ICoreAggregate):
         ctx = RunContext()
 
         def _fn() -> ResponseText:
+            processed = 0
+            failed = 0
             with self._browser.browser_session(cfg):
                 for proc_file, rel_path in self._iter_todo(cfg):
-                    self._process_file(proc_file, rel_path, cfg, ctx)
+                    try:
+                        outcome = self._process_file(proc_file, rel_path, cfg, ctx)
+                        if outcome.status is ProcessingStatus.SUCCESS:
+                            processed += 1
+                        else:
+                            failed += 1
+                    except AuthRequiredError:
+                        raise
+                    except Exception as exc:
+                        failed += 1
+                        self._observability.get_logger().error(
+                            "watcher_file_failed", file=str(rel_path), error=str(exc)
+                        )
                     _watcher_sleep(cfg.interval)
-            return ResponseText("Watcher loop completed.")
+            return ResponseText(f"Watcher loop completed. Successfully processed: {processed}, Failed: {failed}")
 
         return self._execute(_fn)
 
     def _apply_runtime_config(self, cfg: AppConfig) -> None:
-        """Apply config-owned rate and circuit-breaker limits for this execution."""
-        current_cb = getattr(self._cb, "_threshold", None)
-        current_window = getattr(self._cb, "_window_sec", None)
-        if current_cb != cfg.circuit_breaker_threshold or current_window != cfg.circuit_breaker_window:
-            self._cb = type(self._cb)(
-                FailureThreshold(cfg.circuit_breaker_threshold), WindowSec(cfg.circuit_breaker_window)
-            )
-        current_rate = getattr(self._rl, "_max_per_minute", None)
-        if current_rate != cfg.rate_limit_per_minute:
-            self._rl = type(self._rl)(MaxPerMinute(cfg.rate_limit_per_minute))
+        """Apply config-owned limits through the injected runtime collaborators."""
+        self._cb.configure(FailureThreshold(cfg.circuit_breaker_threshold), WindowSec(cfg.circuit_breaker_window))
+        self._rl.configure(MaxPerMinute(cfg.rate_limit_per_minute))
 
     def send_prompt(self, prompt: str, timeout_sec: int = 120, headless: bool = True) -> ResponseText:
         """Send a direct text prompt and return the AI response."""
@@ -435,10 +412,6 @@ class CoreOrchestrator(ICoreAggregate):
 
         self._browser.navigate_to_chat(page, emitter)
         if not state.web_loaded:
-            # The browser operation succeeded but a test/custom adapter did not
-            # emit the contract event; emit it here only as a successful fallback.
-            emitter.emit(EVENT_WEB_LOADED, {"url": getattr(page, "url", "")})
-        if not state.web_loaded:
             raise RuntimeError("Cannot upload attachment: web page loading (EVENT_WEB_LOADED) is incomplete")
         self._browser.check_auth(page)
 
@@ -454,14 +427,11 @@ class CoreOrchestrator(ICoreAggregate):
                 "File upload failed, proceeding with text-only prompt: %s", filepath.name
             )
             emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt), "fallback": True})
-        elif not state.document_parsed:
-            emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt)})
         if not state.document_parsed:
             raise RuntimeError("Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete")
 
         self._injector.inject_text(page, PromptText(prompt))
         self._sender.click_send(page, emitter, document_parsed=HeadlessFlag(state.document_parsed))
-        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"file": str(filepath)})
         if not state.dispatch_acknowledged:
             raise RuntimeError("Cannot wait for response: prompt dispatch (EVENT_DISPATCH_ACKNOWLEDGED) is incomplete")
 

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import contextlib
 import os
-import shutil
 import signal
 import tempfile
 import threading
 import time
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 from playwright.sync_api import Page
@@ -47,14 +48,19 @@ from modules.shared.src.taxonomy_core_vo import (
     EVENT_DISPATCH_ACKNOWLEDGED,
     EVENT_DOCUMENT_PARSED,
     EVENT_OUTPUT_COPIED,
+    EVENT_WEB_LOADED,
+    FailureThreshold,
     FilePath,
     HeadlessFlag,
+    MaxPerMinute,
     MessageCount,
     OutputChars,
+    PollIntervalSec,
     PromptText,
     ResponseText,
     RunContext,
     TimeoutSec,
+    WindowSec,
 )
 from modules.shared.src.taxonomy_domain_error import (
     AuthRequiredError,
@@ -69,6 +75,39 @@ from modules.shared.src.utility_core_path import (
 from modules.shared.src.utility_core_prompt import load_role_prompt, strip_input_from_output
 
 _watcher_shutdown: threading.Event = threading.Event()
+
+
+class ProcessingStatus(str, Enum):
+    """Terminal status for one queue item."""
+
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class ProcessingOutcome:
+    """Result of one processing attempt, including quarantine details."""
+
+    status: ProcessingStatus
+    error: str | None = None
+    failed_path: Path | None = None
+
+
+class LifecycleState:
+    """Run-local lifecycle gates driven by emitted event completion."""
+
+    def __init__(self) -> None:
+        self.web_loaded = False
+        self.document_parsed = False
+        self.dispatch_acknowledged = False
+
+    def mark(self, event_name: object) -> None:
+        if event_name == EVENT_WEB_LOADED:
+            self.web_loaded = True
+        elif event_name == EVENT_DOCUMENT_PARSED:
+            self.document_parsed = True
+        elif event_name == EVENT_DISPATCH_ACKNOWLEDGED:
+            self.dispatch_acknowledged = True
 
 
 def request_watcher_shutdown() -> None:
@@ -131,32 +170,17 @@ class CoreOrchestrator(ICoreAggregate):
         output_file: Path | str | None = None,
         headless: bool = True,
     ) -> ResponseText:
-        """Process a single prompt file end-to-end."""
+        """Process one prompt file using the standard move-based queue flow."""
         in_p = Path(input_file).resolve()
         if not in_p.exists():
             raise FileNotFoundError(f"Input file not found: {input_file}")
-
-        out_p = Path(output_file).resolve() if output_file else DEFAULT_OUTPUT / in_p.name
         cfg = build_app_config(
             mode="single",
             input_path=in_p,
-            output_path=out_p,
+            output_path=Path(output_file).resolve() if output_file else DEFAULT_OUTPUT / in_p.name,
             headless=headless,
         )
-
-        ctx = RunContext()
-        self._audit.log_step(ctx, "START_PROCESSING", FilePath(str(in_p.name)), "STARTED", {"input_chars": 0})
-
-        proc_file = cfg.proc_path / in_p.name
-        ensure_dir(proc_file)
-        shutil.copy2(in_p, proc_file)
-
-        def _fn() -> ResponseText:
-            with self._browser.browser_session(cfg):
-                self._process_file(proc_file, Path(in_p.name), cfg, ctx)
-            return ResponseText(f"Successfully processed {in_p.name} -> {out_p}")
-
-        return self._execute(_fn)
+        return self._process_single_with_config(cfg)
 
     def process_batch(
         self,
@@ -165,33 +189,13 @@ class CoreOrchestrator(ICoreAggregate):
         headless: bool = True,
     ) -> ResponseText:
         """Process all prompt files inside an input directory."""
-        in_p = Path(input_dir).resolve() if input_dir else DEFAULT_TODO
-        out_p = Path(output_dir).resolve() if output_dir else DEFAULT_OUTPUT
-
         cfg = build_app_config(
             mode="batch",
-            input_path=in_p,
-            output_path=out_p,
+            input_path=Path(input_dir).resolve() if input_dir else DEFAULT_TODO,
+            output_path=Path(output_dir).resolve() if output_dir else DEFAULT_OUTPUT,
             headless=headless,
         )
-
-        ctx = RunContext()
-        processed = 0
-        failed = 0
-
-        def _fn() -> ResponseText:
-            nonlocal processed, failed
-            with self._browser.browser_session(cfg):
-                for proc_file, rel_path in self._iter_todo(cfg):
-                    try:
-                        self._process_file(proc_file, rel_path, cfg, ctx)
-                        processed += 1
-                    except Exception as e:  # per-file isolation: a failure must not abort the batch
-                        failed += 1
-                        self._observability.get_logger().error("batch_file_failed", file=str(rel_path), error=str(e))
-            return ResponseText(f"Batch processing complete. Successfully processed: {processed}, Failed: {failed}")
-
-        return self._execute(_fn)
+        return self._process_batch_with_config(cfg)
 
     def process_watcher(self, interval_sec: int = 3, headless: bool = True) -> ResponseText:
         """Run the continuous folder watcher."""
@@ -202,7 +206,62 @@ class CoreOrchestrator(ICoreAggregate):
             interval=interval_sec,
             headless=headless,
         )
+        return self._process_watcher_with_config(cfg)
 
+    def process_mode(self, cfg: AppConfig) -> ResponseText:
+        """Dispatch an already-built AppConfig without reconstructing it."""
+        if cfg.mode == "watcher":
+            return self._process_watcher_with_config(cfg)
+        if cfg.mode == "single":
+            return self._process_single_with_config(cfg)
+        return self._process_batch_with_config(cfg)
+
+    def _process_single_with_config(self, cfg: AppConfig) -> ResponseText:
+        """Acquire, process, and report one file using the exact supplied config."""
+        if not cfg.input_path.exists():
+            raise FileNotFoundError(f"Input file not found: {cfg.input_path}")
+        self._apply_runtime_config(cfg)
+        ctx = RunContext()
+
+        def _fn() -> ResponseText:
+            proc_file, rel_path = next(iter(self._iter_todo(cfg)))
+            with self._browser.browser_session(cfg):
+                outcome = self._process_file(proc_file, rel_path, cfg, ctx)
+            if outcome.status is ProcessingStatus.FAILED:
+                return ResponseText(f"ERROR [PROCESSING_FAILED]: {outcome.error}")
+            return ResponseText(f"Successfully processed {rel_path.name} -> {cfg.output_path}")
+
+        return self._execute(_fn)
+
+    def _process_batch_with_config(self, cfg: AppConfig) -> ResponseText:
+        """Process a batch while counting each terminal outcome exactly once."""
+        self._apply_runtime_config(cfg)
+        ctx = RunContext()
+        processed = 0
+        failed = 0
+
+        def _fn() -> ResponseText:
+            nonlocal processed, failed
+            with self._browser.browser_session(cfg):
+                for proc_file, rel_path in self._iter_todo(cfg):
+                    try:
+                        outcome = self._process_file(proc_file, rel_path, cfg, ctx)
+                        if outcome.status is ProcessingStatus.SUCCESS:
+                            processed += 1
+                        else:
+                            failed += 1
+                    except AuthRequiredError:
+                        raise
+                    except Exception as exc:  # preserve per-file isolation for acquisition/runtime failures
+                        failed += 1
+                        self._observability.get_logger().error("batch_file_failed", file=str(rel_path), error=str(exc))
+            return ResponseText(f"Batch processing complete. Successfully processed: {processed}, Failed: {failed}")
+
+        return self._execute(_fn)
+
+    def _process_watcher_with_config(self, cfg: AppConfig) -> ResponseText:
+        """Run the continuous folder watcher with the supplied AppConfig."""
+        self._apply_runtime_config(cfg)
         ctx = RunContext()
 
         def _fn() -> ResponseText:
@@ -214,23 +273,17 @@ class CoreOrchestrator(ICoreAggregate):
 
         return self._execute(_fn)
 
-    def process_mode(self, cfg: AppConfig) -> ResponseText:
-        """Dispatch processing based on AppConfig.mode (watcher/single/batch)."""
-        if cfg.mode == "watcher":
-            return self.process_watcher(interval_sec=cfg.interval, headless=cfg.headless)
-
-        if cfg.mode == "single":
-            return self.process_single_file(
-                cfg.input_path,
-                cfg.output_path,
-                cfg.headless,
+    def _apply_runtime_config(self, cfg: AppConfig) -> None:
+        """Apply config-owned rate and circuit-breaker limits for this execution."""
+        current_cb = getattr(self._cb, "_threshold", None)
+        current_window = getattr(self._cb, "_window_sec", None)
+        if current_cb != cfg.circuit_breaker_threshold or current_window != cfg.circuit_breaker_window:
+            self._cb = type(self._cb)(
+                FailureThreshold(cfg.circuit_breaker_threshold), WindowSec(cfg.circuit_breaker_window)
             )
-
-        return self.process_batch(
-            cfg.input_path,
-            cfg.output_path,
-            cfg.headless,
-        )
+        current_rate = getattr(self._rl, "_max_per_minute", None)
+        if current_rate != cfg.rate_limit_per_minute:
+            self._rl = type(self._rl)(MaxPerMinute(cfg.rate_limit_per_minute))
 
     def send_prompt(self, prompt: str, timeout_sec: int = 120, headless: bool = True) -> ResponseText:
         """Send a direct text prompt and return the AI response."""
@@ -357,14 +410,20 @@ class CoreOrchestrator(ICoreAggregate):
         timeout_sec: int,
         custom_prompt_path: Path | None = None,
         rel_path: Path | None = None,
+        cfg: AppConfig | None = None,
     ) -> str:
-        """Send a prompt file to chat.qwen.ai and return the full AI response as text.
-
-        Pure orchestration: navigate → auth check → inject → upload → send →
-        stream. The caller provides the Playwright page (from browser_session or
-        a test fixture).
-        """
+        """Send a prompt file while enforcing event-backed lifecycle gates."""
+        active_cfg = cfg or build_app_config(
+            mode="single",
+            input_path=filepath,
+            output_path=DEFAULT_OUTPUT,
+            headless=True,
+        )
         emitter = self._emitter()
+        state = LifecycleState()
+        emitter.on(EVENT_WEB_LOADED, lambda _event: state.mark(EVENT_WEB_LOADED))
+        emitter.on(EVENT_DOCUMENT_PARSED, lambda _event: state.mark(EVENT_DOCUMENT_PARSED))
+        emitter.on(EVENT_DISPATCH_ACKNOWLEDGED, lambda _event: state.mark(EVENT_DISPATCH_ACKNOWLEDGED))
         try:
             prompt = filepath.read_text(encoding="utf-8").strip()
         except OSError as e:
@@ -375,35 +434,52 @@ class CoreOrchestrator(ICoreAggregate):
             prompt = f"{role_prompt}\n\n{prompt}"
 
         self._browser.navigate_to_chat(page, emitter)
+        if not state.web_loaded:
+            # The browser operation succeeded but a test/custom adapter did not
+            # emit the contract event; emit it here only as a successful fallback.
+            emitter.emit(EVENT_WEB_LOADED, {"url": getattr(page, "url", "")})
+        if not state.web_loaded:
+            raise RuntimeError("Cannot upload attachment: web page loading (EVENT_WEB_LOADED) is incomplete")
         self._browser.check_auth(page)
 
         self._observability.get_logger().info("Sending prompt to chat.qwen.ai (%d chars)", len(prompt))
         msg_count_before = self._sender.count_messages(page)
 
         self._injector.find_input(page)
-        attached = self._uploader.upload_attachment(page, filepath, emitter=emitter, web_loaded=HeadlessFlag(True))
+        attached = self._uploader.upload_attachment(
+            page, filepath, emitter=emitter, web_loaded=HeadlessFlag(state.web_loaded)
+        )
         if not attached:
             self._observability.get_logger().warning(
                 "File upload failed, proceeding with text-only prompt: %s", filepath.name
             )
+            emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt), "fallback": True})
+        elif not state.document_parsed:
             emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt)})
-        self._injector.inject_text(page, PromptText(prompt))
-        self._sender.click_send(page, emitter, document_parsed=HeadlessFlag(True))
-        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"file": str(filepath)})
+        if not state.document_parsed:
+            raise RuntimeError("Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete")
 
+        self._injector.inject_text(page, PromptText(prompt))
+        self._sender.click_send(page, emitter, document_parsed=HeadlessFlag(state.document_parsed))
+        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"file": str(filepath)})
+        if not state.dispatch_acknowledged:
+            raise RuntimeError("Cannot wait for response: prompt dispatch (EVENT_DISPATCH_ACKNOWLEDGED) is incomplete")
+
+        stream_timeout_sec = min(timeout_sec, active_cfg.streaming_timeout)
         response = self._streamer.wait_for_response(
             page,
-            TimeoutSec(timeout_sec),
+            TimeoutSec(stream_timeout_sec),
             MessageCount(msg_count_before),
             emitter,
-            dispatch_acknowledged=HeadlessFlag(True),
+            polling_interval_sec=PollIntervalSec(active_cfg.poll_interval),
+            dispatch_acknowledged=HeadlessFlag(state.dispatch_acknowledged),
         )
 
         if response and len(response.strip()) > 0:
             self._observability.get_logger().info("Received response (%d chars)", len(response))
             emitter.emit(EVENT_OUTPUT_COPIED, {"file": str(filepath), "char_count": len(response.strip())})
             return response.strip()
-        raise TimeoutError(f"Timeout after {timeout_sec}s: no response detected")
+        raise TimeoutError(f"Timeout after {stream_timeout_sec}s: no response detected")
 
     # ─── Private orchestration helpers (Block 3) ─────────────────
     def _execute(self, fn: Callable[[], ResponseText]) -> ResponseText:
@@ -451,7 +527,7 @@ class CoreOrchestrator(ICoreAggregate):
 
         with self._browser.browser_session(active_cfg) as bctx:
             page = bctx.pages[0] if bctx.pages else bctx.new_page()
-            return self.send_file(page, filepath, timeout_sec, custom_prompt_path, rel_path)
+            return self.send_file(page, filepath, timeout_sec, custom_prompt_path, rel_path, active_cfg)
 
     def _emitter(self) -> LifecycleEmitter:
         return LifecycleEmitter(self._observability.get_logger())
@@ -462,8 +538,8 @@ class CoreOrchestrator(ICoreAggregate):
         rel_path: Path,
         cfg: AppConfig,
         ctx: RunContext,
-    ) -> None:
-        """Process a single file with retry and quarantine handling."""
+    ) -> ProcessingOutcome:
+        """Process one file and return its terminal success or quarantine outcome."""
         out_path, done_path, fail_path, _ = resolve_role_paths(rel_path, cfg)
 
         if self._cb.is_tripped:
@@ -480,10 +556,11 @@ class CoreOrchestrator(ICoreAggregate):
 
         try:
             self._execute_single_attempt(proc_file, rel_path, cfg, ctx, t0, prompt, out_path, done_path)
+            return ProcessingOutcome(ProcessingStatus.SUCCESS)
         except AuthRequiredError:
             raise
         except Exception as exc:  # boundary: quarantine the file on any unexpected failure
-            self._handle_processing_failure(proc_file, rel_path, cfg, ctx, t0, prompt, out_path, fail_path, exc)
+            return self._handle_processing_failure(proc_file, rel_path, cfg, ctx, t0, prompt, out_path, fail_path, exc)
 
     def _execute_single_attempt(
         self,
@@ -542,7 +619,7 @@ class CoreOrchestrator(ICoreAggregate):
         out_path: Path,
         fail_path: Path,
         exc: Exception,
-    ) -> None:
+    ) -> ProcessingOutcome:
         """Record failure metrics, update circuit breaker, and quarantine file."""
         dur = time.time() - t0
         self._cb.record_failure()
@@ -568,6 +645,7 @@ class CoreOrchestrator(ICoreAggregate):
 
         cleanup_empty_dirs(proc_file.parent, cfg.proc_path)
         self._observability.get_logger().error("file_quarantined", fail_path=str(fail_path), error=str(exc))
+        return ProcessingOutcome(ProcessingStatus.FAILED, err_msg, fail_path)
 
     def _iter_todo(self, cfg: AppConfig) -> Iterator[tuple[Path, Path]]:
         """Yield (proc_file, relative_path) tuples for the processing queue."""

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -14,6 +14,7 @@ from modules.shared.src.contract_core_protocol import ISendProtocol
 from modules.shared.src.taxonomy_config_vo import SenderConfig
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter
 from modules.shared.src.taxonomy_core_vo import (
+    EVENT_DISPATCH_ACKNOWLEDGED,
     EVENT_SEND_CLICKED,
     ClickTimeoutMs,
     MessageCount,
@@ -54,7 +55,9 @@ class SendDispatcher(ISendProtocol):
             )
 
         _dom_click_send(page)
-        emitter.emit(EVENT_SEND_CLICKED, {"selector": "SendDispatcher"})
+        details: dict[str, object] = {"selector": "SendDispatcher"}
+        emitter.emit(EVENT_SEND_CLICKED, details)
+        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, details)
 
     def count_messages(self, page: Page) -> MessageCount:
         """Count chat turns using JS evaluate."""

--- a/modules/core/src/utility_core_config_factory.py
+++ b/modules/core/src/utility_core_config_factory.py
@@ -1,5 +1,4 @@
-"""Config factory utilities.
-
+"""
 Utility layer (utility_core_config_factory): build AppConfig and derive paths.
 Stateless functions consumed by Agent orchestrator and StatusFileWriter.
 """
@@ -16,6 +15,7 @@ from modules.shared.src.taxonomy_core_constant import (
     DEFAULT_OUTPUT,
     DEFAULT_PROC,
     DEFAULT_SESSION,
+    DEFAULT_TODO,
 )
 
 
@@ -30,41 +30,23 @@ def build_app_config(
     proc_path: Path | None = None,
     session_path: Path | None = None,
     log_path: Path | None = None,
+    timeout: int = 300,
+    prompt_file: Path | None = None,
+    chrome_profile: str = "qwen-cli-profile",
+    storage_state_file: Path | None = None,
+    disable_sandbox: bool = True,
+    request_timeout: int = 120,
+    poll_interval: float = 1.0,
+    streaming_timeout: int = 180,
+    rate_limit_per_minute: int = 60,
+    circuit_breaker_threshold: int = 5,
+    circuit_breaker_window: int = 30,
+    retry_failed: bool = False,
 ) -> AppConfig:
-    """Build an AppConfig with sensible defaults.
-
-    Parameters
-    ----------
-    mode : str
-        Application mode ("single", "watcher", etc.).
-    input_path : optional
-        Override for the input directory path.
-    output_path : optional
-        Override for the output directory path.
-    headless : bool
-        Whether to run the browser in headless mode.
-    interval : int
-        Polling interval in seconds (watcher mode).
-    done_path : optional
-        Override for the done directory path.
-    failed_path : optional
-        Override for the failed directory path.
-    proc_path : optional
-        Override for the processing directory path.
-    session_path : optional
-        Override for the session directory path.
-    log_path : optional
-        Override for the log directory path.
-
-    Returns
-    -------
-    AppConfig
-        Fully constructed application configuration.
-
-    """
+    """Build a complete AppConfig while preserving every runtime override."""
     return AppConfig(
         mode=mode,
-        input_path=input_path or DEFAULT_SESSION,
+        input_path=input_path or DEFAULT_TODO,
         output_path=output_path or DEFAULT_OUTPUT,
         done_path=done_path or DEFAULT_DONE,
         failed_path=failed_path or DEFAULT_FAILED,
@@ -72,5 +54,17 @@ def build_app_config(
         session_path=session_path or DEFAULT_SESSION,
         log_path=log_path or DEFAULT_LOG,
         interval=interval,
+        timeout=timeout,
         headless=headless,
+        prompt_file=prompt_file,
+        chrome_profile=chrome_profile,
+        storage_state_file=storage_state_file,
+        disable_sandbox=disable_sandbox,
+        request_timeout=request_timeout,
+        poll_interval=poll_interval,
+        streaming_timeout=streaming_timeout,
+        rate_limit_per_minute=rate_limit_per_minute,
+        circuit_breaker_threshold=circuit_breaker_threshold,
+        circuit_breaker_window=circuit_breaker_window,
+        retry_failed=retry_failed,
     )

--- a/modules/core/src/utility_core_config_factory.py
+++ b/modules/core/src/utility_core_config_factory.py
@@ -21,6 +21,7 @@ from modules.shared.src.taxonomy_core_constant import (
 
 def build_app_config(
     mode: str,
+    *,
     input_path: Path | None = None,
     output_path: Path | None = None,
     headless: bool = True,

--- a/modules/core/src/utility_core_file_mover.py
+++ b/modules/core/src/utility_core_file_mover.py
@@ -1,44 +1,77 @@
-"""File mover utilities.
-
+"""
 Utility layer (utility_core_file_mover): stateless functions for file movement.
 Consumed by Agent orchestrator for proc/done/failed file routing.
 """
 
 from __future__ import annotations
 
+import errno
+import os
 import shutil
+import tempfile
 from pathlib import Path
 
 
+def _fsync_directory(directory: Path) -> None:
+    """Flush directory metadata when the platform supports directory fsync."""
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _copy_then_replace(source: Path, destination: Path) -> None:
+    """Copy a source to a destination-side temp file before committing it."""
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=destination.parent, prefix=f".{destination.name}.", suffix=".tmp", delete=False
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            with source.open("rb") as source_file:
+                shutil.copyfileobj(source_file, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, destination)
+        _fsync_directory(destination.parent)
+        source.unlink()
+        _fsync_directory(source.parent)
+    except Exception:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
+
+
 def move_file(source: Path, destination: Path) -> None:
-    """Move a file from source to destination.
+    """Move a file atomically whenever possible.
 
-    Creates the parent directory if needed.
-
-    Parameters
-    ----------
-    source : Path
-        Source file path.
-    destination : Path
-        Destination file path.
-
+    Same-device moves use ``os.replace``.  When the source and destination are
+    on different devices, the function copies to a temporary file located next
+    to the destination, fsyncs it, atomically replaces the destination, and
+    only then unlinks the source.  A failed copy never removes the source or
+    exposes a partial destination.
     """
+    source = Path(source)
+    destination = Path(destination)
+    if source.resolve() == destination.resolve():
+        return
+    if not source.is_file():
+        raise FileNotFoundError(source)
+
     destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(source), str(destination))
+    try:
+        os.replace(source, destination)
+        _fsync_directory(destination.parent)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+        _copy_then_replace(source, destination)
 
 
 def move_to_processing(source: Path, proc_dest: Path) -> None:
-    """Move a file into the processing directory.
-
-    Creates the parent directory if needed.
-
-    Parameters
-    ----------
-    source : Path
-        Source file path (e.g. from input/todo).
-    proc_dest : Path
-        Target path inside the .processing directory.
-
-    """
-    proc_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(source), str(proc_dest))
+    """Move a queue file into the processing directory atomically."""
+    move_file(source, proc_dest)

--- a/modules/core/src/utility_core_file_mover.py
+++ b/modules/core/src/utility_core_file_mover.py
@@ -36,6 +36,9 @@ def _copy_then_replace(source: Path, destination: Path) -> None:
                 shutil.copyfileobj(source_file, temp_file)
             temp_file.flush()
             os.fsync(temp_file.fileno())
+        shutil.copystat(source, temp_path)
+        with temp_path.open("rb") as copied_file:
+            os.fsync(copied_file.fileno())
         os.replace(temp_path, destination)
         _fsync_directory(destination.parent)
         source.unlink()

--- a/modules/shared/src/__init__.py
+++ b/modules/shared/src/__init__.py
@@ -81,7 +81,7 @@ from .taxonomy_core_constant import (
 
 # ─── Taxonomy: entities ───────────────────────────────────────
 # ─── Taxonomy: events ─────────────────────────────────────────
-from .taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, RateLimiter
+from .taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, LifecycleState, RateLimiter
 
 # ─── Taxonomy: core VOs ───────────────────────────────────────
 from .taxonomy_core_vo import (
@@ -123,6 +123,8 @@ from .taxonomy_core_vo import (
     OutputChars,
     OutputPath,
     PollIntervalSec,
+    ProcessingOutcome,
+    ProcessingStatus,
     PromptText,
     QwenEventType,
     ResponseText,
@@ -220,6 +222,8 @@ __all__ = [
     "OutputChars",
     "OutputPath",
     "PollIntervalSec",
+    "ProcessingOutcome",
+    "ProcessingStatus",
     "PromptText",
     "ResponseText",
     "RunContext",
@@ -323,6 +327,7 @@ __all__ = [
     # Entities
     "CircuitBreaker",
     "RateLimiter",
+    "LifecycleState",
     # Events
     "LifecycleEmitter",
     # Contracts

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -52,6 +52,15 @@ class CircuitBreaker:
         self._failures: deque[float] = deque()
         self._trip: bool = False
 
+    def configure(self, threshold: FailureThreshold, window_sec: WindowSec) -> None:
+        """Update limits while preserving accumulated failure history."""
+        if threshold < 1:
+            raise ValueError(f"threshold must be >= 1, got {threshold}")
+        if window_sec < 1:
+            raise ValueError(f"window_sec must be >= 1, got {window_sec}")
+        self._threshold = threshold
+        self._window_sec = window_sec
+
     def record_success(self) -> None:
         """Reset the breaker on a successful request."""
         self._failures.clear()
@@ -65,6 +74,16 @@ class CircuitBreaker:
             self._failures.popleft()
         if len(self._failures) >= self._threshold:
             self._trip = True
+
+    @property
+    def threshold(self) -> int:
+        """Configured consecutive-failure threshold."""
+        return int(self._threshold)
+
+    @property
+    def window_sec(self) -> int:
+        """Configured failure observation window in seconds."""
+        return int(self._window_sec)
 
     @property
     def is_tripped(self) -> bool:
@@ -90,6 +109,17 @@ class RateLimiter:
         self._max_per_minute = max_per_minute
         self._timestamps: deque[float] = deque()
 
+    def configure(self, max_per_minute: MaxPerMinute) -> None:
+        """Update the request limit while preserving timestamp history."""
+        if max_per_minute < MaxPerMinute(1):
+            raise ValueError(f"max_per_minute must be >= 1, got {max_per_minute}")
+        self._max_per_minute = max_per_minute
+
+    @property
+    def max_per_minute(self) -> int:
+        """Configured maximum requests per minute."""
+        return int(self._max_per_minute)
+
     def acquire(self) -> None:
         """Wait until a request slot is available."""
         now = time.time()
@@ -105,6 +135,24 @@ class RateLimiter:
             now = time.time()
             window_start = now - 60.0
         self._timestamps.append(time.time())
+
+
+class LifecycleState:
+    """Mutable run-local gates driven only by emitted lifecycle events."""
+
+    def __init__(self) -> None:
+        self.web_loaded = False
+        self.document_parsed = False
+        self.dispatch_acknowledged = False
+
+    def mark(self, event_name: QwenEventType | str) -> None:
+        """Advance exactly the gate represented by an emitted event."""
+        if event_name == QwenEventType.WEB_LOADED:
+            self.web_loaded = True
+        elif event_name == QwenEventType.DOCUMENT_PARSED:
+            self.document_parsed = True
+        elif event_name == QwenEventType.DISPATCH_ACKNOWLEDGED:
+            self.dispatch_acknowledged = True
 
 
 class LifecycleEmitter:

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -60,6 +60,14 @@ class CircuitBreaker:
             raise ValueError(f"window_sec must be >= 1, got {window_sec}")
         self._threshold = threshold
         self._window_sec = window_sec
+        self._refresh_state()
+
+    def _refresh_state(self, now: float | None = None) -> None:
+        """Discard expired failures and recompute the trip state."""
+        current = time.time() if now is None else now
+        while self._failures and (current - self._failures[0]) > self._window_sec:
+            self._failures.popleft()
+        self._trip = len(self._failures) >= self._threshold
 
     def record_success(self) -> None:
         """Reset the breaker on a successful request."""
@@ -68,12 +76,8 @@ class CircuitBreaker:
 
     def record_failure(self) -> None:
         """Record a failure and trip if threshold exceeded within window."""
-        now = time.time()
-        self._failures.append(now)
-        while self._failures and (now - self._failures[0]) > self._window_sec:
-            self._failures.popleft()
-        if len(self._failures) >= self._threshold:
-            self._trip = True
+        self._failures.append(time.time())
+        self._refresh_state()
 
     @property
     def threshold(self) -> int:
@@ -88,6 +92,7 @@ class CircuitBreaker:
     @property
     def is_tripped(self) -> bool:
         """True when the breaker has tripped."""
+        self._refresh_state()
         return self._trip
 
 

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -62,9 +62,9 @@ class CircuitBreaker:
         self._window_sec = window_sec
         self._refresh_state()
 
-    def _refresh_state(self, now: float | None = None) -> None:
+    def _refresh_state(self) -> None:
         """Discard expired failures and recompute the trip state."""
-        current = time.time() if now is None else now
+        current = time.time()
         while self._failures and (current - self._failures[0]) > self._window_sec:
             self._failures.popleft()
         self._trip = len(self._failures) >= self._threshold

--- a/modules/shared/src/taxonomy_core_vo.py
+++ b/modules/shared/src/taxonomy_core_vo.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Any, NewType
 
 PromptText = NewType("PromptText", str)
@@ -28,6 +29,23 @@ TimeoutSec = NewType("TimeoutSec", int)
 PollIntervalSec = NewType("PollIntervalSec", float)
 HeadlessFlag = NewType("HeadlessFlag", bool)
 Mode = NewType("Mode", str)
+
+
+class ProcessingStatus(str, Enum):
+    """Terminal status for one queue item."""
+
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class ProcessingOutcome:
+    """Result of one processing attempt, including quarantine details."""
+
+    status: ProcessingStatus
+    error: str | None = None
+    failed_path: Path | None = None
+
 
 # ─── Brand types: timing & limits ─────────────────────────────
 TypingDelayMs = NewType("TypingDelayMs", int)

--- a/modules/shared/src/utility_core_path.py
+++ b/modules/shared/src/utility_core_path.py
@@ -1,5 +1,4 @@
-"""Path-algebra and file-state pure utilities.
-
+"""
 Taxonomy layer (utility): stateless functions, taxonomy imports only.
 """
 
@@ -8,11 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from modules.shared.src.taxonomy_config_vo import AppConfig
-from modules.shared.src.taxonomy_core_constant import (
-    DEFAULT_TODO,
-    ROLE_PATH_SKIP_DIRS,
-    SKIP_DIRS,
-)
+from modules.shared.src.taxonomy_core_constant import ROLE_PATH_SKIP_DIRS, SKIP_DIRS
 
 
 def _normalize_sub_parts(parts: tuple[str, ...], fallback_name: str) -> Path:
@@ -24,29 +19,45 @@ def _normalize_sub_parts(parts: tuple[str, ...], fallback_name: str) -> Path:
 
 
 def _compute_output_path(cfg: AppConfig, sub_path: Path) -> Path:
-    """Resolve the output destination for a sub-path (single-file file-target or dir join)."""
+    """Resolve the output destination for a sub-path (single-file target or directory join)."""
     if cfg.mode == "single" and cfg.output_path.suffix:
         return cfg.output_path
     return cfg.output_path / sub_path.name
 
 
-def resolve_role_paths(rel_path: Path, cfg: AppConfig) -> tuple[Path, Path, Path, Path]:
-    """Resolve role-based paths for output, done, failed, and processing.
+def _role_destination(
+    root: Path, role_folder: str, sub_path: Path, marker: str, input_root: Path | None = None
+) -> Path:
+    """Join a role below a workspace root without breaking role-local defaults."""
+    if root.name == marker and root.parent.name == role_folder:
+        return root / sub_path
+    if input_root is not None and root.name == marker and root.parent.resolve() == input_root.resolve():
+        return root.parent / role_folder / marker / sub_path
+    return root / role_folder / sub_path
 
-    Returns (out_path, done_path, fail_path, proc_file).
+
+def resolve_role_paths(rel_path: Path, cfg: AppConfig) -> tuple[Path, Path, Path, Path]:
+    """Resolve output, done, failed, and processing paths from one relative path.
+
+    ``rel_path`` may contain a role folder and any queue marker (``todo``,
+    ``done``, ``failed``, ``proc`` or ``.processing``).  Configured roots are
+    always respected; if a configured root already points at a role directory,
+    the role is not appended a second time.
     """
     parts = rel_path.parts
-    is_single_file_input = cfg.mode == "single" or bool(cfg.input_path.suffix) or cfg.input_path.is_file()
-    base = DEFAULT_TODO if is_single_file_input else cfg.input_path
+    role_idx = next((i for i, part in enumerate(parts) if part.startswith("role-")), None)
 
-    role_idx = next((i for i, p in enumerate(parts) if p.startswith("role-")), None)
     if role_idx is not None:
         role_folder = parts[role_idx]
         sub_path = _normalize_sub_parts(parts[role_idx + 1 :], rel_path.name)
         out_path = _compute_output_path(cfg, sub_path)
-        done_path = base / role_folder / "done" / sub_path
-        fail_path = base / role_folder / "failed" / sub_path
-        proc_file = cfg.proc_path / role_folder / sub_path
+        done_path = _role_destination(cfg.done_path, role_folder, sub_path, "done", cfg.input_path)
+        fail_path = _role_destination(cfg.failed_path, role_folder, sub_path, "failed", cfg.input_path)
+        proc_file = (
+            _role_destination(cfg.proc_path, role_folder, sub_path, ".processing")
+            if cfg.mode == "single"
+            else cfg.proc_path / role_folder / sub_path
+        )
     else:
         sub_path = _normalize_sub_parts(parts, rel_path.name)
         out_path = _compute_output_path(cfg, sub_path)
@@ -68,7 +79,7 @@ def should_process_file(f: Path, base_src: Path) -> bool:
 
     if len(rel_parts) < 2 or not rel_parts[0].startswith("role-"):
         return False
-    return not any(p in SKIP_DIRS or p.startswith(".") for p in rel_parts[:-1])
+    return not any(part in SKIP_DIRS or part.startswith(".") for part in rel_parts[:-1])
 
 
 def list_input_files(base_path: Path) -> list[tuple[Path, Path]]:

--- a/modules/shared/src/utility_core_path.py
+++ b/modules/shared/src/utility_core_path.py
@@ -53,11 +53,7 @@ def resolve_role_paths(rel_path: Path, cfg: AppConfig) -> tuple[Path, Path, Path
         out_path = _compute_output_path(cfg, sub_path)
         done_path = _role_destination(cfg.done_path, role_folder, sub_path, "done", cfg.input_path)
         fail_path = _role_destination(cfg.failed_path, role_folder, sub_path, "failed", cfg.input_path)
-        proc_file = (
-            _role_destination(cfg.proc_path, role_folder, sub_path, ".processing")
-            if cfg.mode == "single"
-            else cfg.proc_path / role_folder / sub_path
-        )
+        proc_file = _role_destination(cfg.proc_path, role_folder, sub_path, ".processing", cfg.input_path)
     else:
         sub_path = _normalize_sub_parts(parts, rel_path.name)
         out_path = _compute_output_path(cfg, sub_path)

--- a/tests/test_core_pipeline_routing_gates.py
+++ b/tests/test_core_pipeline_routing_gates.py
@@ -11,7 +11,13 @@ from modules.core.src import agent_core_orchestrator as orchestrator_module
 from modules.core.src.agent_core_orchestrator import CoreOrchestrator
 from modules.core.src.utility_core_file_mover import move_file
 from modules.shared.src.taxonomy_config_vo import AppConfig
-from modules.shared.src.taxonomy_core_entity import CircuitBreaker, RateLimiter
+from modules.shared.src.taxonomy_core_entity import CircuitBreaker, LifecycleState, RateLimiter
+from modules.shared.src.taxonomy_core_vo import (
+    EVENT_DOCUMENT_PARSED,
+    EVENT_WEB_LOADED,
+    ProcessingOutcome,
+    ProcessingStatus,
+)
 
 
 def _make_orchestrator() -> CoreOrchestrator:
@@ -76,6 +82,8 @@ def test_move_file_cross_device_copies_flushes_replaces_then_unlinks(
     source = tmp_path / "source.md"
     destination = tmp_path / "nested" / "destination.md"
     source.write_text("payload")
+    source.chmod(0o744)
+    os.utime(source, (1000, 2000))
     real_replace = os.replace
     calls = 0
 
@@ -92,6 +100,9 @@ def test_move_file_cross_device_copies_flushes_replaces_then_unlinks(
     assert calls == 2
     assert not source.exists()
     assert destination.read_text() == "payload"
+    destination_stat = destination.stat()
+    assert destination_stat.st_mode & 0o777 == 0o744
+    assert destination_stat.st_mtime == pytest.approx(2000)
     assert not list(destination.parent.glob(".*.tmp"))
 
 
@@ -140,19 +151,25 @@ def test_batch_counts_quarantine_as_failed_and_continues(tmp_path: Path) -> None
     assert not list(input_root.rglob("*.md"))
 
 
-def test_process_mode_passes_complete_config_and_runtime_limits() -> None:
+def test_process_mode_passes_complete_config_and_runtime_limits(tmp_path: Path) -> None:
     orch = _make_orchestrator()
-    cfg = _config(Path("/tmp"), mode="batch")
+    cfg = _config(tmp_path, mode="batch")
     dispatch = MagicMock(return_value="dispatched")
     orch._process_batch_with_config = dispatch
 
     assert orch.process_mode(cfg) == "dispatched"
     dispatch.assert_called_once_with(cfg)
 
+    original_cb = orch._cb
+    original_rl = orch._rl
+    original_cb.record_failure()
+    original_rl.acquire()
     orch._apply_runtime_config(cfg)
-    assert orch._cb._threshold == cfg.circuit_breaker_threshold
-    assert orch._cb._window_sec == cfg.circuit_breaker_window
-    assert orch._rl._max_per_minute == cfg.rate_limit_per_minute
+    assert orch._cb is original_cb
+    assert orch._rl is original_rl
+    assert orch._cb.threshold == cfg.circuit_breaker_threshold
+    assert orch._cb.window_sec == cfg.circuit_breaker_window
+    assert orch._rl.max_per_minute == cfg.rate_limit_per_minute
 
 
 def test_lifecycle_flags_are_event_backed_and_passed_to_capabilities(tmp_path: Path) -> None:
@@ -160,7 +177,19 @@ def test_lifecycle_flags_are_event_backed_and_passed_to_capabilities(tmp_path: P
     prompt_file.write_text("prompt")
     orch = _make_orchestrator()
     page = MagicMock()
-    orch._uploader.upload_attachment.return_value = False
+
+    def navigate(_page: object, emitter: object) -> None:
+        emitter.emit(orchestrator_module.EVENT_WEB_LOADED, {"url": "test"})
+
+    def upload(_page: object, _filepath: Path, **_kwargs: object) -> bool:
+        return False
+
+    def send(_page: object, emitter: object, **_kwargs: object) -> None:
+        emitter.emit(orchestrator_module.EVENT_DISPATCH_ACKNOWLEDGED, {"source": "test"})
+
+    orch._browser.navigate_to_chat.side_effect = navigate
+    orch._uploader.upload_attachment.side_effect = upload
+    orch._sender.click_send.side_effect = send
     orch._streamer.wait_for_response.return_value = "answer"
 
     assert orch.send_file(page, prompt_file, timeout_sec=5) == "answer"
@@ -168,6 +197,56 @@ def test_lifecycle_flags_are_event_backed_and_passed_to_capabilities(tmp_path: P
     assert orch._sender.click_send.call_args.kwargs["document_parsed"] is True
     assert orch._streamer.wait_for_response.call_args.kwargs["dispatch_acknowledged"] is True
     assert orch._streamer.wait_for_response.call_args.kwargs["polling_interval_sec"] == 1.0
+
+
+def test_missing_web_loaded_event_blocks_upload(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+
+    with pytest.raises(RuntimeError, match="EVENT_WEB_LOADED"):
+        orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
+
+    orch._uploader.upload_attachment.assert_not_called()
+    orch._sender.click_send.assert_not_called()
+
+
+def test_missing_document_parsed_event_blocks_send(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+
+    def navigate(_page: object, emitter: object) -> None:
+        emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
+
+    orch._browser.navigate_to_chat.side_effect = navigate
+    orch._uploader.upload_attachment.return_value = True
+
+    with pytest.raises(RuntimeError, match="EVENT_DOCUMENT_PARSED"):
+        orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
+
+    orch._sender.click_send.assert_not_called()
+
+
+def test_missing_dispatch_acknowledgement_blocks_stream(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+
+    def navigate(_page: object, emitter: object) -> None:
+        emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
+
+    def upload(_page: object, _filepath: Path, **_kwargs: object) -> bool:
+        return False
+
+    orch._browser.navigate_to_chat.side_effect = navigate
+    orch._uploader.upload_attachment.side_effect = upload
+    orch._sender.click_send.return_value = None
+
+    with pytest.raises(RuntimeError, match="EVENT_DISPATCH_ACKNOWLEDGED"):
+        orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
+
+    orch._streamer.wait_for_response.assert_not_called()
 
 
 def test_navigation_failure_blocks_upload_and_send(tmp_path: Path) -> None:
@@ -184,10 +263,58 @@ def test_navigation_failure_blocks_upload_and_send(tmp_path: Path) -> None:
     orch._streamer.wait_for_response.assert_not_called()
 
 
+def test_single_file_stays_available_when_session_setup_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "role-demo" / "todo" / "task.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("prompt")
+    cfg = _config(tmp_path, mode="single", input_path=source)
+    orch = _make_orchestrator()
+    orch._browser.browser_session.side_effect = RuntimeError("browser setup failed")
+    monkeypatch.setattr(orchestrator_module, "build_app_config", lambda **_kwargs: cfg)
+
+    result = orch.process_single_file(source, cfg.output_path, headless=True)
+
+    assert result.startswith("ERROR [RuntimeError]")
+    assert source.exists()
+    assert not list(cfg.proc_path.rglob("task.md"))
+
+
+def test_watcher_counts_terminal_outcomes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _config(tmp_path, mode="watcher")
+    orch = _make_orchestrator()
+    orch._browser.browser_session.return_value.__enter__.return_value.pages = [MagicMock()]
+    items = [(tmp_path / "one.md", Path("role-demo/one.md")), (tmp_path / "two.md", Path("role-demo/two.md"))]
+    orch._iter_todo = MagicMock(return_value=iter(items))
+    orch._process_file = MagicMock(
+        side_effect=[
+            ProcessingOutcome(ProcessingStatus.SUCCESS),
+            ProcessingOutcome(ProcessingStatus.FAILED, "failed"),
+        ]
+    )
+    monkeypatch.setattr(orchestrator_module, "_watcher_sleep", lambda _interval: None)
+
+    result = orch._process_watcher_with_config(cfg)
+
+    assert result == "Watcher loop completed. Successfully processed: 1, Failed: 1"
+
+
+def test_lifecycle_state_only_advances_on_matching_events() -> None:
+    state = LifecycleState()
+    state.mark(EVENT_DOCUMENT_PARSED)
+    assert not state.web_loaded
+    assert state.document_parsed
+    assert not state.dispatch_acknowledged
+
+
 def test_dispatch_failure_blocks_stream_monitor(tmp_path: Path) -> None:
     prompt_file = tmp_path / "prompt.md"
     prompt_file.write_text("prompt")
     orch = _make_orchestrator()
+
+    def navigate(_page: object, emitter: object) -> None:
+        emitter.emit(orchestrator_module.EVENT_WEB_LOADED, {"url": "test"})
+
+    orch._browser.navigate_to_chat.side_effect = navigate
     orch._uploader.upload_attachment.return_value = False
     orch._sender.click_send.side_effect = RuntimeError("dispatch failed")
 

--- a/tests/test_core_pipeline_routing_gates.py
+++ b/tests/test_core_pipeline_routing_gates.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.core.src import agent_core_orchestrator as orchestrator_module
+from modules.core.src.agent_core_orchestrator import CoreOrchestrator
+from modules.core.src.utility_core_file_mover import move_file
+from modules.shared.src.taxonomy_config_vo import AppConfig
+from modules.shared.src.taxonomy_core_entity import CircuitBreaker, RateLimiter
+
+
+def _make_orchestrator() -> CoreOrchestrator:
+    return CoreOrchestrator(
+        browser=MagicMock(),
+        injector=MagicMock(),
+        sender=MagicMock(),
+        streamer=MagicMock(),
+        uploader=MagicMock(),
+        saver=MagicMock(),
+        audit=MagicMock(),
+        observability=MagicMock(get_logger=MagicMock(return_value=MagicMock())),
+        workspace=MagicMock(),
+        circuit_breaker=CircuitBreaker(),
+        rate_limiter=RateLimiter(),
+    )
+
+
+def _config(tmp_path: Path, *, mode: str = "batch", input_path: Path | None = None) -> AppConfig:
+    return AppConfig(
+        mode=mode,
+        input_path=input_path or tmp_path / "input",
+        output_path=tmp_path / "output",
+        done_path=tmp_path / "done",
+        failed_path=tmp_path / "failed",
+        proc_path=tmp_path / "processing",
+        session_path=tmp_path / "session",
+        log_path=tmp_path / "log",
+        timeout=321,
+        request_timeout=17,
+        poll_interval=0.75,
+        streaming_timeout=23,
+        rate_limit_per_minute=7,
+        circuit_breaker_threshold=2,
+        circuit_breaker_window=11,
+        retry_failed=False,
+    )
+
+
+def test_move_file_same_device_uses_replace_and_removes_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "source.md"
+    destination = tmp_path / "nested" / "destination.md"
+    source.write_text("payload")
+    calls: list[tuple[Path, Path]] = []
+    real_replace = os.replace
+
+    def recording_replace(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+        calls.append((Path(src), Path(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", recording_replace)
+    move_file(source, destination)
+
+    assert not source.exists()
+    assert destination.read_text() == "payload"
+    assert calls == [(source, destination)]
+
+
+def test_move_file_cross_device_copies_flushes_replaces_then_unlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.md"
+    destination = tmp_path / "nested" / "destination.md"
+    source.write_text("payload")
+    real_replace = os.replace
+    calls = 0
+
+    def simulate_cross_device(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(errno.EXDEV, "cross-device link")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", simulate_cross_device)
+    move_file(source, destination)
+
+    assert calls == 2
+    assert not source.exists()
+    assert destination.read_text() == "payload"
+    assert not list(destination.parent.glob(".*.tmp"))
+
+
+def test_single_public_api_moves_source_and_does_not_report_success_after_quarantine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "role-demo" / "todo" / "task.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("prompt")
+    cfg = _config(tmp_path, mode="single", input_path=source)
+    orch = _make_orchestrator()
+    orch._browser.browser_session.return_value.__enter__.return_value.pages = [MagicMock()]
+    orch._send_file = MagicMock(side_effect=RuntimeError("network down"))
+    monkeypatch.setattr(orchestrator_module, "build_app_config", lambda **_kwargs: cfg)
+
+    result = orch.process_single_file(source, cfg.output_path, headless=True)
+
+    failed = cfg.failed_path / "role-demo" / "task.md"
+    assert result.startswith("ERROR [PROCESSING_FAILED]")
+    assert not source.exists()
+    assert failed.exists()
+    assert not list(cfg.proc_path.rglob("task.md"))
+
+
+def test_batch_counts_quarantine_as_failed_and_continues(tmp_path: Path) -> None:
+    input_root = tmp_path / "input"
+    for name in ("failed-first.md", "successful-second.md"):
+        path = input_root / "role-demo" / "todo" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(name)
+    cfg = _config(tmp_path, mode="batch", input_path=input_root)
+    orch = _make_orchestrator()
+    orch._browser.browser_session.return_value.__enter__.return_value.pages = [MagicMock()]
+
+    def send_file(proc_file: Path, *_args: object, **_kwargs: object) -> str:
+        if proc_file.name.startswith("failed"):
+            raise RuntimeError("item failed")
+        return "response"
+
+    orch._send_file = MagicMock(side_effect=send_file)
+    result = orch.process_mode(cfg)
+
+    assert result == "Batch processing complete. Successfully processed: 1, Failed: 1"
+    assert (cfg.failed_path / "role-demo" / "failed-first.md").exists()
+    assert (cfg.done_path / "role-demo" / "successful-second.md").exists()
+    assert not list(input_root.rglob("*.md"))
+
+
+def test_process_mode_passes_complete_config_and_runtime_limits() -> None:
+    orch = _make_orchestrator()
+    cfg = _config(Path("/tmp"), mode="batch")
+    dispatch = MagicMock(return_value="dispatched")
+    orch._process_batch_with_config = dispatch
+
+    assert orch.process_mode(cfg) == "dispatched"
+    dispatch.assert_called_once_with(cfg)
+
+    orch._apply_runtime_config(cfg)
+    assert orch._cb._threshold == cfg.circuit_breaker_threshold
+    assert orch._cb._window_sec == cfg.circuit_breaker_window
+    assert orch._rl._max_per_minute == cfg.rate_limit_per_minute
+
+
+def test_lifecycle_flags_are_event_backed_and_passed_to_capabilities(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+    page = MagicMock()
+    orch._uploader.upload_attachment.return_value = False
+    orch._streamer.wait_for_response.return_value = "answer"
+
+    assert orch.send_file(page, prompt_file, timeout_sec=5) == "answer"
+    assert orch._uploader.upload_attachment.call_args.kwargs["web_loaded"] is True
+    assert orch._sender.click_send.call_args.kwargs["document_parsed"] is True
+    assert orch._streamer.wait_for_response.call_args.kwargs["dispatch_acknowledged"] is True
+    assert orch._streamer.wait_for_response.call_args.kwargs["polling_interval_sec"] == 1.0
+
+
+def test_navigation_failure_blocks_upload_and_send(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+    orch._browser.navigate_to_chat.side_effect = RuntimeError("navigation failed")
+
+    with pytest.raises(RuntimeError, match="navigation failed"):
+        orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
+
+    orch._uploader.upload_attachment.assert_not_called()
+    orch._sender.click_send.assert_not_called()
+    orch._streamer.wait_for_response.assert_not_called()
+
+
+def test_dispatch_failure_blocks_stream_monitor(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("prompt")
+    orch = _make_orchestrator()
+    orch._uploader.upload_attachment.return_value = False
+    orch._sender.click_send.side_effect = RuntimeError("dispatch failed")
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
+
+    orch._streamer.wait_for_response.assert_not_called()

--- a/tests/test_pipeline_fixtures.py
+++ b/tests/test_pipeline_fixtures.py
@@ -82,7 +82,7 @@ def test_resolve_role_paths_strips_done_and_failed(cfg: AppConfig) -> None:
     assert out_p == cfg.output_path / "task_001.md"
     assert done_p == cfg.input_path / "role-architect" / "done" / "task_001.md"
     assert fail_p == cfg.input_path / "role-architect" / "failed" / "task_001.md"
-    assert proc_p == cfg.proc_path / "role-architect" / "task_001.md"
+    assert proc_p == cfg.proc_path / "task_001.md"
 
 
 def test_resolve_role_paths_single_mode_no_duplicate(tmp_path: Path) -> None:

--- a/tests/test_qwen_client_extended.py
+++ b/tests/test_qwen_client_extended.py
@@ -8,8 +8,30 @@ import pytest
 from playwright.sync_api import Error
 
 from modules.core.src.capabilities_prompt_injector import PromptInjector
-from modules.shared.src import QwenCliError
+from modules.shared.src import (
+    EVENT_DISPATCH_ACKNOWLEDGED,
+    EVENT_DOCUMENT_PARSED,
+    EVENT_WEB_LOADED,
+    QwenCliError,
+)
 from tests.helpers import make_test_orchestrator
+
+
+def _configure_lifecycle_mocks(orch) -> None:
+    def navigate(_page, emitter):
+        emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
+
+    def upload(_page, _filepath, emitter=None, **_kwargs):
+        assert emitter is not None
+        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": "test"})
+        return True
+
+    def send(_page, emitter, **_kwargs):
+        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"file": "test"})
+
+    orch._browser.navigate_to_chat.side_effect = navigate
+    orch._uploader.upload_attachment.side_effect = upload
+    orch._sender.click_send.side_effect = send
 
 
 class TestSendFile:
@@ -21,6 +43,7 @@ class TestSendFile:
 
     def test_send_file_timeout_error(self, tmp_path):
         orch = make_test_orchestrator()
+        _configure_lifecycle_mocks(orch)
         page = MagicMock()
         orch._sender.count_messages.return_value = 0
         orch._uploader.upload_attachment.return_value = True
@@ -34,6 +57,7 @@ class TestSendFile:
 
     def test_send_file_delegates_to_capabilities(self, tmp_path):
         orch = make_test_orchestrator()
+        _configure_lifecycle_mocks(orch)
         page = MagicMock()
         orch._sender.count_messages.return_value = 2
         orch._uploader.upload_attachment.return_value = True

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -26,7 +26,7 @@ def test_click_send_primary_selector_success():
     _sender().click_send(mock_page, mock_emitter)
 
     mock_locator.first.click.assert_called_once()
-    mock_emitter.emit.assert_called_once()
+    assert mock_emitter.emit.call_count == 2
 
 
 def test_click_send_enter_fallback():
@@ -44,7 +44,7 @@ def test_click_send_enter_fallback():
 
     _sender().click_send(mock_page, mock_emitter)
     mock_page.keyboard.press.assert_called_once_with("Enter")
-    mock_emitter.emit.assert_called_once()
+    assert mock_emitter.emit.call_count == 2
 
 
 def test_click_send_all_failed():

--- a/tests/test_sender_extended.py
+++ b/tests/test_sender_extended.py
@@ -38,7 +38,7 @@ class TestClickSendExtended:
 
         _sender().click_send(page, emitter)
         page.keyboard.press.assert_called_once_with("Enter")
-        emitter.emit.assert_called_once()
+        assert emitter.emit.call_count == 2
 
     def test_selector_exception_continues(self):
         page = MagicMock()
@@ -58,7 +58,7 @@ class TestClickSendExtended:
 
         page.locator.side_effect = locator_factory
         _sender().click_send(page, emitter)
-        emitter.emit.assert_called_once()
+        assert emitter.emit.call_count == 2
 
 
 class TestCountMessagesExtended:

--- a/tests/test_types_extended.py
+++ b/tests/test_types_extended.py
@@ -117,10 +117,11 @@ class TestCircuitBreakerExtended:
 
     def test_is_tripped_reopens_after_window_expires(self):
         cb = CircuitBreaker(threshold=1, window_sec=1)
-        cb.record_failure()
-        assert cb.is_tripped is True
-        cb._failures[0] = time.time() - 2
-        assert cb.is_tripped is False
+        with patch("modules.shared.src.taxonomy_core_entity.time.time", return_value=100.0):
+            cb.record_failure()
+            assert cb.is_tripped is True
+        with patch("modules.shared.src.taxonomy_core_entity.time.time", return_value=102.0):
+            assert cb.is_tripped is False
 
     def test_success_resets_after_partial_failures(self):
         cb = CircuitBreaker(threshold=3, window_sec=30)

--- a/tests/test_types_extended.py
+++ b/tests/test_types_extended.py
@@ -103,26 +103,6 @@ class TestCircuitBreakerExtended:
         assert len(cb._failures) == 2
         assert cb.is_tripped is False  # threshold=3, only 2 in window
 
-    def test_configure_recomputes_trip_state(self):
-        cb = CircuitBreaker(threshold=2, window_sec=30)
-        cb.record_failure()
-        cb.record_failure()
-        assert cb.is_tripped is True
-
-        cb.configure(threshold=3, window_sec=30)
-        assert cb.is_tripped is False
-
-        cb.configure(threshold=1, window_sec=30)
-        assert cb.is_tripped is True
-
-    def test_is_tripped_reopens_after_window_expires(self):
-        cb = CircuitBreaker(threshold=1, window_sec=1)
-        with patch("modules.shared.src.taxonomy_core_entity.time.time", return_value=100.0):
-            cb.record_failure()
-            assert cb.is_tripped is True
-        with patch("modules.shared.src.taxonomy_core_entity.time.time", return_value=102.0):
-            assert cb.is_tripped is False
-
     def test_success_resets_after_partial_failures(self):
         cb = CircuitBreaker(threshold=3, window_sec=30)
         cb.record_failure()

--- a/tests/test_types_extended.py
+++ b/tests/test_types_extended.py
@@ -103,6 +103,25 @@ class TestCircuitBreakerExtended:
         assert len(cb._failures) == 2
         assert cb.is_tripped is False  # threshold=3, only 2 in window
 
+    def test_configure_recomputes_trip_state(self):
+        cb = CircuitBreaker(threshold=2, window_sec=30)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_tripped is True
+
+        cb.configure(threshold=3, window_sec=30)
+        assert cb.is_tripped is False
+
+        cb.configure(threshold=1, window_sec=30)
+        assert cb.is_tripped is True
+
+    def test_is_tripped_reopens_after_window_expires(self):
+        cb = CircuitBreaker(threshold=1, window_sec=1)
+        cb.record_failure()
+        assert cb.is_tripped is True
+        cb._failures[0] = time.time() - 2
+        assert cb.is_tripped is False
+
     def test_success_resets_after_partial_failures(self):
         cb = CircuitBreaker(threshold=3, window_sec=30)
         cb.record_failure()


### PR DESCRIPTION
## Summary

Fixes #67, #86, #87, #89, and #95 in one core-pipeline PR.

## Changes

- Replaced queue `shutil.move` behavior with same-device `os.replace` and cross-device copy/fsync/replace/unlink fallback.
- Unified single-file acquisition with `.processing` routing and preserved role-relative paths.
- Added explicit per-file `SUCCESS`/`FAILED` outcomes so quarantine failures cannot become false successes.
- Preserved complete `AppConfig` through mode dispatch, including paths, timeouts, retry mode, rate limits, and circuit-breaker settings.
- Enforced event-backed `EVENT_WEB_LOADED`, `EVENT_DOCUMENT_PARSED`, and `EVENT_DISPATCH_ACKNOWLEDGED` gates.
- Added regression coverage for atomic movement, public single/batch outcomes, configuration propagation, and gate failures.

## Verification

- `pytest -q` — passed
- `ruff format --check modules/ tests/` — passed
- `ruff check modules/ tests/` — passed
- `mypy modules/` — passed

Scope is limited to core pipeline implementation and regression tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces deterministic queue routing, atomic moves, and event‑gated send lifecycle across single, batch, and watcher. Old: single-file bypassed the queue and quarantine failures could look successful. New: all modes acquire via `.processing`, return explicit SUCCESS/FAILED outcomes, apply runtime limits, and enforce WEB_LOADED → DOCUMENT_PARSED → DISPATCH_ACKNOWLEDGED before upload/send/stream; streaming now uses min(request timeout, `streaming_timeout`) and `poll_interval`.

- Orchestrator: single/batch/watcher iterate the queue; per-file `ProcessingOutcome` drives accurate processed/failed counts; watcher reports totals; `process_mode` dispatches the supplied `AppConfig` and applies circuit-breaker and rate-limit settings.
- Send lifecycle: `LifecycleState` gates block upload/send/stream until events fire; `click_send` emits `EVENT_DISPATCH_ACKNOWLEDGED`; streaming passes `poll_interval` and the bounded timeout.
- File routing: `move_file` performs same-device `os.replace` and cross-device copy+fsync+replace+unlink; `move_to_processing` uses the same atomic path.
- Paths: resolution respects configured roots, avoids duplicate role segments, and uses role-aware `.processing` when applicable.
- Config/entities: `build_app_config` defaults `input_path` to `DEFAULT_TODO` and preserves runtime fields (timeouts, poll interval, streaming timeout, rate limits, circuit breaker, retry mode); `CircuitBreaker.configure` and `RateLimiter.configure` preserve history, and the breaker refreshes trip state when read.

**Migration**
- If you relied on `build_app_config` defaulting `input_path` to `DEFAULT_SESSION`, pass `input_path` explicitly or move inputs under `DEFAULT_TODO`.

<sup>Written for commit f6c249288732e5e3332d8abcc96f016f55c94cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

