### PR TITLE
fix(core): complete capabilities and aggregate test coverage

### DIFF
--- a/modules/core/FRD.md
+++ b/modules/core/FRD.md
@@ -224,7 +224,9 @@ Lifecycle gates the agent must honor:
   - Must refuse send when `document_parsed` is false (attachment still
     parsing).
   - Click uses multi-selector send helpers (`button[aria-label*='Send']`,
-    submit, class/id fallbacks) with Enter-key fallback.
+    submit, class/id fallbacks) with an optional Enter-key fallback.
+  - An explicit per-call `SenderConfig` overrides the instance default; Enter is
+    attempted only when `try_enter_key_fallback` is true.
   - `count_messages` is the pre-send baseline for FR-006.
   - `latest_message_text` returns the longest non-chrome text block.
 - **Edge Cases**: send button disabled while file is parsing; selector drift;
@@ -236,7 +238,10 @@ Lifecycle gates the agent must honor:
   - [ ] Click is blocked when `document_parsed` is false.
   - [ ] Successful click emits `EVENT_SEND_CLICKED`.
   - [ ] `count_messages` matches assistant/turn nodes on the fixture.
-  - [ ] Enter fallback is attempted when the send button is not clickable.
+  - [ ] Enter fallback is attempted when the send button is not clickable and
+    enabled by configuration.
+  - [ ] Disabled fallback never presses Enter and failed dispatch raises
+    `SendDispatchError` without emitting `EVENT_SEND_CLICKED`.
 - **Tests**: `tests/test_sender.py`, `tests/test_sender_extended.py`,
   `tests/test_qwen_client_behavior.py`.
 
@@ -329,7 +334,11 @@ Lifecycle gates the agent must honor:
     `QUARANTINED`, …).
   - `log` writes the file-level result. On error it also appends
     `errors.log` and `errors.jsonl`.
-  - `get_audit_log(limit)` returns the last N non-empty JSONL lines.
+  - `get_audit_log(limit)` returns the last N non-empty JSONL lines by reading
+    backward in bounded blocks; memory use is proportional to the block size
+    and requested result count, not the complete history.
+  - Blank, malformed, or truncated tail lines are skipped; a non-positive
+    limit returns an empty JSON array.
   - Missing audit file returns a clear "does not exist yet" message, not an
     exception.
   - Workspace init is **not** owned here; optional `IWorkspaceProtocol` is
@@ -341,10 +350,12 @@ Lifecycle gates the agent must honor:
 - **Acceptance Criteria**:
   - [ ] Success `log` produces one JSON object with duration and char counts.
   - [ ] Failed `log` writes audit + `errors.log` + `errors.jsonl`.
-  - [ ] `get_audit_log(2)` returns at most two records.
+  - [ ] `get_audit_log(2)` returns at most two records without a full-file read.
+  - [ ] Empty, malformed, truncated-tail, and non-positive-limit cases are covered.
   - [ ] Missing file returns the explicit empty-state message.
-- **Tests**: `tests/test_pipeline_core.py`, `tests/test_pipeline_extended.py`,
-  MCP `qwen_get_audit_log` tests in `tests/test_mcp_server.py`.
+- **Tests**: `tests/test_audit_repository.py`, `tests/test_pipeline_core.py`,
+  `tests/test_pipeline_extended.py`, and MCP `qwen_get_audit_log` tests in
+  `tests/test_mcp_server.py`.
 
 ### FR-009: Observability Setup
 
@@ -353,7 +364,9 @@ Lifecycle gates the agent must honor:
 - **Description**: Bootstrap the telemetry stack (Sentry → OpenTelemetry →
   structlog) and process-wide exception hooks. In-memory metrics
   (`MetricsCounter`) and `status.json` (`StatusFileWriter`) are helper types
-  in this file — not standalone capabilities.
+  in this file — not standalone capabilities. The legacy `IMetricsProtocol`
+  and `IStatusProtocol` contracts remain helper-level compatibility contracts
+  owned by FR-009; they do not represent additional FRs or capabilities.
 - **Input**: log `Path`; env `SENTRY_DSN`, `OTEL_EXPORTER_OTLP_ENDPOINT`,
   `OTEL_SERVICE_NAME`, `ENVIRONMENT`.
 - **Output**: configured loggers (`stderr` + `app.jsonl`), optional OTLP
@@ -411,7 +424,12 @@ Lifecycle gates the agent must honor:
   - [ ] `release_lock` allows a subsequent acquire.
   - [ ] `sd_notify_ready` is a no-op without `NOTIFY_SOCKET`.
   - [ ] MCP container can be built with `use_linux_guard=False`.
-- **Tests**: `tests/test_linux.py`.
+  - [ ] The CLI root acquires the lock, emits `READY=1`, dispatches, emits
+    `STOPPING=1`, and releases the lock on both success and exception.
+- **Production caller**: `modules/root_cli_main_entry.py` owns the CLI lifecycle;
+  `modules/root_mcp_main_entry.py` explicitly constructs a lock-free container.
+- **Tests**: `tests/test_linux.py` covers the capability; `tests/test_cli_linux_guard.py`
+  covers the production CLI and MCP boundaries.
 
 ## Capability Inventory (exactly 10)
 
@@ -452,12 +470,12 @@ API. It sequences FR-001…FR-010; it does not implement their business rules.
 | FR-002 | `IUploadProtocol` | `capabilities_file_uploader.py` | `test_file_uploader.py` |
 | FR-003 | `ISaverProtocol` | `capabilities_output_saver.py` | `test_saver*.py` |
 | FR-004 | `IInjectionProtocol` | `capabilities_prompt_injector.py` | `test_prompt_injector*.py` |
-| FR-005 | `ISendProtocol` | `capabilities_send_dispatcher.py` | `test_sender*.py` |
+| FR-005 | `ISendProtocol` | `capabilities_send_dispatcher.py` | `test_sender*.py` (unit; includes enabled/disabled fallback) |
 | FR-006 | `IStreamProtocol` | `capabilities_stream_monitor.py` | `test_streamer*.py` |
 | FR-007 | `IWorkspaceProtocol` | `capabilities_workspace_provisioner.py` | `test_init_cmd.py` |
-| FR-008 | `IAuditProtocol` | `capabilities_audit_repository.py` | `test_pipeline_*.py` |
+| FR-008 | `IAuditProtocol` | `capabilities_audit_repository.py` | `test_audit_repository.py`, `test_pipeline_*.py` |
 | FR-009 | `IObservabilityProtocol` | `capabilities_observability_setup.py` | `test_observability*.py` |
-| FR-010 | `ILinuxProtocol` | `capabilities_linux_guard.py` | `test_linux.py` |
+| FR-010 | `ILinuxProtocol` | `capabilities_linux_guard.py` | `test_linux.py` (unit), `test_cli_linux_guard.py` (production path) |
 
 End-to-end locks: `tests/test_qwen_client_behavior.py`, `tests/test_e2e_pipeline.py` (manual/`e2e` mark).
 
@@ -486,7 +504,11 @@ End-to-end locks: `tests/test_qwen_client_behavior.py`, `tests/test_e2e_pipeline
 - [ ] FR-007: second `init` is idempotent.
 - [ ] FR-008: failed file produces `FAILED` audit + quarantine path (agent).
 - [ ] FR-009: process starts with empty `SENTRY_DSN` and no OTLP endpoint.
-- [ ] FR-010: two CLI processes cannot hold the same lock.
+- [ ] FR-010: two CLI processes cannot hold the same lock; the production root
+      lifecycle test verifies notification ordering and cleanup.
+- [ ] Aggregate boundary: failed batch items report `Failed: 1`, failed single
+      files return an error envelope, nested role routing is preserved, and a
+      supplied `AppConfig` reaches the browser session unchanged.
 
 ## Assumptions & Constraints
 

--- a/modules/core/src/capabilities_audit_repository.py
+++ b/modules/core/src/capabilities_audit_repository.py
@@ -103,14 +103,15 @@ class AuditRepository(IAuditProtocol):
             self._workspace.init_workspace(FilePath(str(target_dir)))
 
     def get_audit_log(self, limit: int = 20) -> ResponseText:
-        """Fetch recent entries from the JSONL audit trail log."""
+        """Fetch recent entries without loading the complete JSONL file."""
         audit_file = self._audit
         if not audit_file.exists():
             return ResponseText("Audit log file does not exist yet.")
+        if limit <= 0:
+            return ResponseText("[]")
 
-        lines = audit_file.read_text(encoding="utf-8").strip().splitlines()
-        recent = lines[-limit:]
-        records: list[Any] = [json.loads(line) for line in recent if line.strip()]
+        records = _read_recent_jsonl_records(audit_file, limit)
+        records.reverse()
         return ResponseText(json.dumps(records, indent=2))
 
     # Block 3: Dunder Methods, Factories & Helpers
@@ -118,3 +119,51 @@ class AuditRepository(IAuditProtocol):
     def __repr__(self) -> str:
         """Return string representation of AuditRepository."""
         return f"AuditRepository(log_dir={self._audit.parent!r})"
+
+
+_AUDIT_READ_BLOCK_SIZE = 64 * 1024
+
+
+def _read_recent_jsonl_records(audit_file: Path, limit: int) -> list[Any]:
+    """Read at most ``limit`` valid JSONL records from the end of a file.
+
+    Reading backwards in fixed-size blocks keeps memory bounded by the block
+    size plus the requested result count. Blank, malformed, and undecodable
+    lines are ignored so a partially written final record cannot hide older
+    valid audit entries.
+    """
+    records: list[Any] = []
+    pending = b""
+    with audit_file.open("rb") as stream:
+        position = stream.seek(0, 2)
+        while position > 0 and len(records) < limit:
+            block_size = min(_AUDIT_READ_BLOCK_SIZE, position)
+            position -= block_size
+            stream.seek(position)
+            pending = stream.read(block_size) + pending
+            lines = pending.split(b"\n")
+            pending = lines[0]
+            for raw_line in reversed(lines[1:]):
+                record = _decode_jsonl_record(raw_line)
+                if record is not None:
+                    records.append(record)
+                    if len(records) >= limit:
+                        break
+
+        if pending and len(records) < limit:
+            record = _decode_jsonl_record(pending)
+            if record is not None:
+                records.append(record)
+
+    return records
+
+
+def _decode_jsonl_record(raw_line: bytes) -> Any | None:
+    """Decode one JSONL line, returning ``None`` for blank or partial data."""
+    try:
+        line = raw_line.strip().decode("utf-8")
+        if not line:
+            return None
+        return json.loads(line)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -54,7 +54,12 @@ class SendDispatcher(ISendProtocol):
                 "Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete"
             )
 
-        _dom_click_send(page)
+        effective_config = _config or SenderConfig(
+            click_timeout_ms=int(self.click_timeout_ms),
+            try_enter_key_fallback=bool(self.try_enter_key_fallback),
+        )
+        if not _dom_click_send(page, _config=effective_config):
+            raise SendDispatchError("Unable to dispatch prompt: send button and Enter fallback both failed")
         details: dict[str, object] = {"selector": "SendDispatcher"}
         emitter.emit(EVENT_SEND_CLICKED, details)
         emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, details)

--- a/modules/core/src/utility_core_dom_helper.py
+++ b/modules/core/src/utility_core_dom_helper.py
@@ -196,7 +196,8 @@ def click_send(
     effective_timeout = timeout_ms if timeout_ms is not None else 3000
     effective_fallback = try_enter_fallback if try_enter_fallback is not None else True
     if _config is not None:
-        effective_timeout = _config.click_timeout_ms
+        if timeout_ms is None:
+            effective_timeout = _config.click_timeout_ms
         if try_enter_fallback is None:
             effective_fallback = _config.try_enter_key_fallback
 

--- a/modules/core/src/utility_core_dom_helper.py
+++ b/modules/core/src/utility_core_dom_helper.py
@@ -7,11 +7,11 @@ visibility checks, click helpers, locator selection, and selector-fallback itera
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from contextlib import suppress
 from typing import Any, TypeVar
 
 from playwright.sync_api import Error, Locator, Page
 
+from modules.shared.src.taxonomy_config_vo import SenderConfig
 from modules.shared.src.taxonomy_core_constant import SEND_SELECTORS
 
 T = TypeVar("T")
@@ -180,21 +180,36 @@ def any_visible_locator(
     return False
 
 
-def click_send(page: Page, _config: object = None) -> None:
-    """Click send button via selector fallback, Enter key as last resort.
+def click_send(
+    page: Page,
+    _config: SenderConfig | None = None,
+    *,
+    try_enter_fallback: bool | None = None,
+    timeout_ms: int | None = None,
+) -> bool:
+    """Click the send button and optionally use Enter as a last resort.
 
-    Parameters
-    ----------
-    page : Page
-        Active Playwright page.
-    config : optional
-        Unused — kept for API compatibility.
-
+    When a :class:`SenderConfig` is provided, it is the single source of truth
+    for the selector timeout and fallback policy. The explicit keyword options
+    are retained for callers that need to use this stateless helper directly.
     """
-    clicked = click_first_visible_enabled(page, SEND_SELECTORS, timeout_ms=3000)
-    if not clicked:
-        with suppress(Exception):
-            page.keyboard.press("Enter")
+    effective_timeout = timeout_ms if timeout_ms is not None else 3000
+    effective_fallback = try_enter_fallback if try_enter_fallback is not None else True
+    if _config is not None:
+        effective_timeout = _config.click_timeout_ms
+        if try_enter_fallback is None:
+            effective_fallback = _config.try_enter_key_fallback
+
+    clicked = click_first_visible_enabled(page, SEND_SELECTORS, timeout_ms=effective_timeout)
+    if clicked:
+        return True
+    if not effective_fallback:
+        return False
+    try:
+        page.keyboard.press("Enter")
+    except Exception:
+        return False
+    return True
 
 
 def is_any_visible(page: Page, selector: str) -> bool:

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -153,15 +153,18 @@ def _run_cli_lifecycle(dispatch: Callable[[SharedContainer], int]) -> int:
 
 
 def _dispatch(
-    container: SharedContainer, raw_argv: list[str], args: argparse.Namespace | None, cfg: AppConfig | None
+    container: SharedContainer,
+    raw_argv: list[str],
+    args: argparse.Namespace | None,
+    cfg: AppConfig | None,
 ) -> int:
-    """Dispatch one already-parsed CLI invocation."""
+    """Dispatch one already-parsed CLI invocation inside the Linux lifecycle."""
     # Explicit precedence: login wins over init, including --login --init.
     if args is not None and bool(getattr(args, "login", False)):
         if cfg is None:
             print(f"{_ERROR_PREFIX} Missing login configuration.", file=sys.stderr)
             return 1
-        return _run_manual_login(cfg)
+        return _run_manual_login(cfg, container)
 
     # Init is an action rather than an AppConfig mode. It wins over watcher
     # and path inference when login is absent.
@@ -220,9 +223,10 @@ def _interactive_prompt(core: Any | None = None) -> AppConfig | None:
     return surface_cli_interactive_controller.InteractiveController(core).interactive_prompt()
 
 
-def _run_manual_login(cfg: AppConfig) -> int:
+def _run_manual_login(cfg: AppConfig, container: SharedContainer | None = None) -> int:
     """Launch visible browser for interactive login."""
-    container = _default_container()
+    if container is None:
+        container = _default_container()
     result = surface_cli_login_command.handle(None, container.core, cfg)
     return _result_exit_code(result)
 

--- a/tests/test_aggregate_boundaries.py
+++ b/tests/test_aggregate_boundaries.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.core.src.agent_core_orchestrator import CoreOrchestrator
+from modules.shared.src import AppConfig
+
+
+def _orchestrator(mocker) -> CoreOrchestrator:
+    return CoreOrchestrator(
+        browser=mocker.MagicMock(),
+        injector=mocker.MagicMock(),
+        sender=mocker.MagicMock(),
+        streamer=mocker.MagicMock(),
+        uploader=mocker.MagicMock(),
+        saver=mocker.MagicMock(),
+        audit=mocker.MagicMock(),
+        observability=mocker.MagicMock(),
+        workspace=mocker.MagicMock(),
+    )
+
+
+def _config(tmp_path: Path, mode: str, input_path: Path, output_path: Path) -> AppConfig:
+    return AppConfig(
+        mode=mode,
+        input_path=input_path,
+        output_path=output_path,
+        done_path=tmp_path / "done",
+        failed_path=tmp_path / "failed",
+        proc_path=tmp_path / "processing",
+        session_path=tmp_path / "session",
+        log_path=tmp_path / "log",
+        timeout=37,
+        request_timeout=23,
+        streaming_timeout=29,
+        poll_interval=0.75,
+        headless=True,
+    )
+
+
+def test_public_batch_reports_failed_item_as_failed(mocker, tmp_path: Path) -> None:
+    cfg = _config(tmp_path, "batch", tmp_path / "input", tmp_path / "output")
+    orchestrator = _orchestrator(mocker)
+    queued = (tmp_path / "processing" / "role-a" / "task.md", Path("role-a/task.md"))
+    orchestrator._iter_todo = mocker.MagicMock(return_value=[queued])
+    orchestrator._process_file = mocker.MagicMock(side_effect=RuntimeError("browser failed"))
+
+    result = orchestrator.process_mode(cfg)
+
+    assert "Successfully processed: 0" in result
+    assert "Failed: 1" in result
+
+
+def test_public_single_failure_is_not_success(mocker, tmp_path: Path) -> None:
+    source = tmp_path / "input" / "role-a" / "todo" / "task.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("prompt", encoding="utf-8")
+    cfg = _config(tmp_path, "single", source, tmp_path / "output" / "result.md")
+    orchestrator = _orchestrator(mocker)
+    proc_file = tmp_path / "processing" / "role-a" / "task.md"
+    orchestrator._iter_todo = mocker.MagicMock(return_value=[(proc_file, Path("role-a/todo/task.md"))])
+    orchestrator._process_file = mocker.MagicMock(side_effect=RuntimeError("browser failed"))
+
+    result = orchestrator.process_mode(cfg)
+
+    assert str(result).startswith("ERROR [RuntimeError]: browser failed")
+    assert "Successfully processed" not in result
+
+
+def test_public_batch_preserves_nested_role_routing(mocker, tmp_path: Path) -> None:
+    source = tmp_path / "input" / "role-architect" / "nested" / "deep" / "task.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("prompt", encoding="utf-8")
+    cfg = _config(tmp_path, "batch", tmp_path / "input", tmp_path / "output")
+    orchestrator = _orchestrator(mocker)
+    orchestrator._process_file = mocker.MagicMock()
+
+    result = orchestrator.process_mode(cfg)
+
+    assert "Successfully processed: 1" in result
+    proc_file, rel_path = orchestrator._process_file.call_args.args[:2]
+    assert rel_path == Path("role-architect/nested/deep/task.md")
+    assert proc_file == cfg.proc_path / "role-architect" / "nested" / "deep" / "task.md"
+    assert not source.exists()
+
+
+def test_public_mode_preserves_custom_paths_and_runtime_controls(mocker, tmp_path: Path) -> None:
+    cfg = _config(tmp_path, "batch", tmp_path / "custom-input", tmp_path / "custom-output")
+    orchestrator = _orchestrator(mocker)
+    orchestrator._iter_todo = mocker.MagicMock(return_value=[])
+
+    result = orchestrator.process_mode(cfg)
+
+    assert "Successfully processed: 0" in result
+    orchestrator._browser.browser_session.assert_called_once_with(cfg)

--- a/tests/test_aggregate_boundaries.py
+++ b/tests/test_aggregate_boundaries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from modules.core.src.agent_core_orchestrator import CoreOrchestrator
-from modules.shared.src import AppConfig
+from modules.shared.src import AppConfig, ProcessingOutcome, ProcessingStatus
 
 
 def _orchestrator(mocker) -> CoreOrchestrator:
@@ -73,7 +73,7 @@ def test_public_batch_preserves_nested_role_routing(mocker, tmp_path: Path) -> N
     source.write_text("prompt", encoding="utf-8")
     cfg = _config(tmp_path, "batch", tmp_path / "input", tmp_path / "output")
     orchestrator = _orchestrator(mocker)
-    orchestrator._process_file = mocker.MagicMock()
+    orchestrator._process_file = mocker.MagicMock(return_value=ProcessingOutcome(ProcessingStatus.SUCCESS))
 
     result = orchestrator.process_mode(cfg)
 

--- a/tests/test_audit_repository.py
+++ b/tests/test_audit_repository.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.core.src import capabilities_audit_repository as audit_module
+from modules.core.src.capabilities_audit_repository import AuditRepository
+
+
+def _records(response: str) -> list[dict[str, int]]:
+    return json.loads(response)
+
+
+def test_get_audit_log_missing_file_returns_contract_message(tmp_path: Path) -> None:
+    result = AuditRepository(tmp_path).get_audit_log()
+
+    assert result == "Audit log file does not exist yet."
+
+
+def test_get_audit_log_empty_file_returns_empty_json_array(tmp_path: Path) -> None:
+    (tmp_path / "audit_history.jsonl").write_text("", encoding="utf-8")
+
+    assert AuditRepository(tmp_path).get_audit_log() == "[]"
+
+
+def test_get_audit_log_reads_last_non_empty_valid_records(tmp_path: Path) -> None:
+    audit_file = tmp_path / "audit_history.jsonl"
+    audit_file.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": 1}),
+                "",
+                "not-json",
+                json.dumps({"id": 2}),
+                json.dumps({"id": 3}),
+                '{"id": 4',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert _records(AuditRepository(tmp_path).get_audit_log(limit=2)) == [{"id": 2}, {"id": 3}]
+
+
+def test_get_audit_log_zero_or_negative_limit_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "audit_history.jsonl").write_text(json.dumps({"id": 1}) + "\n", encoding="utf-8")
+
+    assert AuditRepository(tmp_path).get_audit_log(limit=0) == "[]"
+    assert AuditRepository(tmp_path).get_audit_log(limit=-1) == "[]"
+
+
+def test_get_audit_log_does_not_use_full_file_read_and_handles_large_tail(tmp_path: Path) -> None:
+    audit_file = tmp_path / "audit_history.jsonl"
+    audit_file.write_text(
+        "".join(json.dumps({"id": index}) + "\n" for index in range(2000)),
+        encoding="utf-8",
+    )
+    monkey_patch = patch.object(Path, "read_text", side_effect=AssertionError("full-file read is forbidden"))
+    monkey_patch.start()
+    try:
+        audit_module._AUDIT_READ_BLOCK_SIZE = 64
+        result = _records(AuditRepository(tmp_path).get_audit_log(limit=3))
+    finally:
+        monkey_patch.stop()
+        audit_module._AUDIT_READ_BLOCK_SIZE = 64 * 1024
+
+    assert result == [{"id": 1997}, {"id": 1998}, {"id": 1999}]

--- a/tests/test_dom_helper.py
+++ b/tests/test_dom_helper.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from modules.core.src.utility_core_dom_helper import click_send
+from modules.shared.src.taxonomy_config_vo import SenderConfig
+
+
+def test_click_send_explicit_timeout_overrides_config() -> None:
+    page = MagicMock()
+    locator = page.locator.return_value.first
+    locator.is_visible.return_value = True
+    config = SenderConfig(click_timeout_ms=5000, try_enter_key_fallback=False)
+
+    assert click_send(page, config, timeout_ms=7000) is True
+    locator.is_visible.assert_called_once_with(timeout=7000)
+    locator.click.assert_called_once_with()
+
+
+def test_click_send_uses_config_timeout_when_not_explicit() -> None:
+    page = MagicMock()
+    locator = page.locator.return_value.first
+    locator.is_visible.return_value = True
+    config = SenderConfig(click_timeout_ms=5000, try_enter_key_fallback=False)
+
+    assert click_send(page, config) is True
+    locator.is_visible.assert_called_once_with(timeout=5000)

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from modules.core.src.capabilities_send_dispatcher import SendDispatcher
 from modules.core.src.utility_core_dom_query import count_messages, latest_message_text
-from modules.shared.src import LifecycleEmitter
+from modules.shared.src import LifecycleEmitter, SendDispatchError
 
 
 def _sender() -> SendDispatcher:
@@ -56,9 +58,10 @@ def test_click_send_all_failed():
     mock_locator.first.is_visible.return_value = False
     mock_page.locator.return_value = mock_locator
 
-    # No visible selector and Enter fails — click_send must not raise
+    # No visible selector and Enter fails — the public contract reports dispatch failure.
     mock_page.keyboard.press.side_effect = Exception("no textarea")
-    _sender().click_send(mock_page, mock_emitter)
+    with pytest.raises(SendDispatchError, match="send button and Enter fallback"):
+        _sender().click_send(mock_page, mock_emitter)
     mock_page.keyboard.press.assert_called_once()
 
 

--- a/tests/test_sender_extended.py
+++ b/tests/test_sender_extended.py
@@ -10,6 +10,7 @@ from playwright.sync_api import Error
 from modules.core.src.capabilities_send_dispatcher import SendDispatcher
 from modules.core.src.utility_core_dom_query import count_messages, latest_message_text
 from modules.shared.src import LifecycleEmitter, SendDispatchError
+from modules.shared.src.taxonomy_config_vo import SenderConfig
 
 
 def _sender() -> SendDispatcher:
@@ -114,3 +115,39 @@ class TestLatestMessageTextExtended:
         page.locator.side_effect = Error("crashed")
         result = latest_message_text(page)
         assert result is None
+
+
+def _page_with_no_send_selector() -> MagicMock:
+    page = MagicMock()
+
+    def locator_factory(_selector):
+        loc = MagicMock()
+        loc.count.return_value = 0
+        loc.first.is_visible.return_value = False
+        return loc
+
+    page.locator.side_effect = locator_factory
+    return page
+
+
+def test_no_visible_selector_does_not_press_enter_when_instance_fallback_disabled():
+    page = _page_with_no_send_selector()
+    emitter = MagicMock(spec=LifecycleEmitter)
+
+    with pytest.raises(SendDispatchError, match="send button and Enter fallback"):
+        SendDispatcher(try_enter_key_fallback=False).click_send(page, emitter)
+
+    page.keyboard.press.assert_not_called()
+    emitter.emit.assert_not_called()
+
+
+def test_per_call_sender_config_overrides_instance_fallback():
+    page = _page_with_no_send_selector()
+    emitter = MagicMock(spec=LifecycleEmitter)
+    config = SenderConfig(try_enter_key_fallback=False)
+
+    with pytest.raises(SendDispatchError, match="send button and Enter fallback"):
+        SendDispatcher(try_enter_key_fallback=True).click_send(page, emitter, _config=config)
+
+    page.keyboard.press.assert_not_called()
+    emitter.emit.assert_not_called()


### PR DESCRIPTION
## Summary

This PR completes the remaining core capability and aggregate-boundary work for issues #68, #90, #96, and #97.

## Changes

- Clarifies FR-009 ownership for metrics and status helpers without introducing new capabilities or FRs.
- Implements bounded reverse-block reads for audit JSONL tails, including empty, blank, malformed, truncated, and non-positive-limit cases.
- Propagates `SenderConfig` explicitly through `SendDispatcher` and the DOM helper; disabled Enter fallback never presses Enter, and all-strategies failure raises `SendDispatchError`.
- Preserves full `AppConfig` propagation at the aggregate boundary and fixes false-success reporting for failed batch and single-file processing.
- Adds deterministic aggregate, audit, sender, CLI Linux lifecycle, and MCP lock-free integration coverage.
- Updates FRD traceability with production callers and unit-versus-production-path test mapping.

## Validation

- `pytest -q`
- `ruff format --check modules/ tests/`
- `ruff check modules/ tests/`
- `mypy modules/`
- `git diff --check`

All checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes core capability work and aggregate-boundary fixes for Linear #68, #90, #96, and #97. Audit tails are memory-bounded, send dispatch is deterministic with per-call overrides, the orchestrator honors the `ProcessingOutcome` contract, and the CLI enforces a single-instance lifecycle.

- Audit logs: old behavior read the whole JSONL; new behavior reads bounded blocks backward, skips blank/malformed/truncated tail lines, and returns "[]" for non‑positive limits. Side effect: memory use scales with block size and requested count, not history size.
- Send dispatch: old behavior always attempted Enter and did not fail hard; new behavior honors per‑call `SenderConfig`, an explicit `timeout_ms` to `utility_core_dom_helper.click_send` overrides config, disabled fallback never presses Enter, failures raise `SendDispatchError`, and `EVENT_SEND_CLICKED` only emits on success.
- Orchestrator: preserves the supplied `AppConfig`, honors the `ProcessingOutcome` contract (batch counts failures correctly; single‑file failures surface an error envelope), and preserves nested role routing.
- CLI Linux lifecycle: acquires a lock, emits `READY=1` and `STOPPING=1`, then releases the lock; MCP stays lock‑free. Side effect: a second instance exits with code 1 and an error message.
- Tests/Docs: adds targeted tests for audit tails, DOM helper timeout override, sender fallback/error reporting, aggregate boundaries (`ProcessingOutcome`), and CLI lifecycle; clarifies FR‑009 ownership and capability boundaries in `FRD.md`.

**Migration**
- Callers of `SendDispatcher.click_send` must handle `SendDispatchError`.
- If calling `utility_core_dom_helper.click_send` directly, use the boolean return and optionally pass `SenderConfig` or `timeout_ms`; Enter is not attempted when disabled.

<sup>Written for commit 8afea5f1153248da070902ef033bd1f511ca7b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

