### PR TITLE
fix: enforce strict CLI event pipeline gates

### DIFF
--- a/.agents/skills/cleanup-consolidate-python/SKILL.md
+++ b/.agents/skills/cleanup-consolidate-python/SKILL.md
@@ -128,17 +128,21 @@ If yes → **Consolidate into single module**
 def process(self) -> None:
     pass
 
+
 def get_value(self) -> str:
     return ""
+
 
 def get_items(self) -> list:
     return []
 
+
 def get_mapping(self) -> dict:
     return {}
 
-def compute(self) -> None:
-    ...
+
+def compute(self) -> None: ...
+
 
 def transform(self, data):
     raise NotImplementedError  # with no subclass implementing it
@@ -157,13 +161,16 @@ def transform(self, data):
 def get_name(self) -> str:
     return self.name
 
+
 # ❌ Simple comparison — trivially inlineable
 def is_active(self) -> bool:
     return self.status == "active"
 
+
 # ❌ Single-field delegation — no logic added
 def get_id(self) -> int:
     return self._inner.id
+
 
 # ❌ Trivial passthrough
 def save(self, data):
@@ -185,6 +192,8 @@ Same logic in multiple modules — keep in the module that **owns the domain log
 # ❌ In utils/helpers.py AND services/processor.py:
 def clamp(value: float, min_val: float, max_val: float) -> float:
     return max(min_val, min(value, max_val))
+
+
 # KEEP in utils/helpers.py (owns utility logic). Remove from services/.
 ```
 
@@ -229,7 +238,7 @@ If **any** check fails → **KEEP** and add comment: `# REVIEW: candidate for re
 ```python
 # ❌ Assigned but never read
 result = compute_something()  # result never used after this line
-_ = some_function()           # intentional discard — KEEP this pattern
+_ = some_function()  # intentional discard — KEEP this pattern
 
 # ❌ Loop variable never used
 for item in items:  # item never referenced in loop body
@@ -608,9 +617,9 @@ validators_url.py
 ### Detection Patterns: Split Functionality (Merge)
 
 ```python
-services/user_creator.py
-services/user_updater.py
-services/user_deleter.py
+services / user_creator.py
+services / user_updater.py
+services / user_deleter.py
 # All handle user CRUD → merge into services/user_service.py
 ```
 

--- a/MIGRATION_PYTHON.md
+++ b/MIGRATION_PYTHON.md
@@ -200,6 +200,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class UserId:
     """User identifier value object."""
+
     value: str
 
     def __post_init__(self) -> None:
@@ -210,6 +211,7 @@ class UserId:
 @dataclass(frozen=True)
 class Email:
     """Email value object."""
+
     value: str
 
     def __post_init__(self) -> None:
@@ -285,16 +287,13 @@ class IUserRepositoryProtocol(ABC):
     """
 
     @abstractmethod
-    def find_by_id(self, user_id: UserId) -> Optional[User]:
-        ...
+    def find_by_id(self, user_id: UserId) -> Optional[User]: ...
 
     @abstractmethod
-    def find_by_email(self, email: Email) -> Optional[User]:
-        ...
+    def find_by_email(self, email: Email) -> Optional[User]: ...
 
     @abstractmethod
-    def save(self, user: User) -> None:
-        ...
+    def save(self, user: User) -> None: ...
 ```
 
 ```python
@@ -313,12 +312,10 @@ class IUserAggregate(ABC):
     """
 
     @abstractmethod
-    def get_user(self, user_id: UserId) -> UserResponse:
-        ...
+    def get_user(self, user_id: UserId) -> UserResponse: ...
 
     @abstractmethod
-    def register_user(self, command: "RegisterCommand") -> UserResponse:
-        ...
+    def register_user(self, command: "RegisterCommand") -> UserResponse: ...
 ```
 
 ### Rules Enforced
@@ -369,6 +366,7 @@ def normalize_email(email: Email) -> Email:
 def generate_user_id() -> str:
     """Generate a UUID-based user identifier."""
     import uuid
+
     return str(uuid.uuid4())
 ```
 
@@ -428,7 +426,9 @@ class UserRepository(IUserRepositoryProtocol):
     def save(self, user: User) -> None:
         self._db.execute(
             "INSERT INTO users (id, email, name) VALUES (%s, %s, %s)",
-            user.id.value, user.email.value, user.name.value,
+            user.id.value,
+            user.email.value,
+            user.name.value,
         )
 ```
 

--- a/modules/cli/src/surface_cli_run_command.py
+++ b/modules/cli/src/surface_cli_run_command.py
@@ -5,9 +5,22 @@ Smart surface: maps parsed args to a config VO, delegates to the core aggregate.
 
 from __future__ import annotations
 
+import re
+
 from modules.shared.src.contract_core_aggregate import ICoreAggregate
 from modules.shared.src.taxonomy_config_vo import AppConfig
 from modules.shared.src.utility_core_response import error_response, safe_handle, success_response
+
+
+def _processing_failure_message(result: object) -> str | None:
+    """Return a failure reason when a normal core response reports failed work."""
+    message = str(result)
+    if message.startswith("ERROR ["):
+        return message
+    match = re.search(r"\bFailed:\s*(\d+)\b", message, flags=re.IGNORECASE)
+    if match and int(match.group(1)) > 0:
+        return message
+    return None
 
 
 @safe_handle
@@ -20,4 +33,7 @@ def handle(args: object, core: ICoreAggregate) -> dict[str, object]:
         )
 
     result = core.process_mode(cfg)
+    failure = _processing_failure_message(result)
+    if failure is not None:
+        return error_response(RuntimeError(failure), "processing_failed", "cli-422")
     return success_response(result)

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -453,7 +453,7 @@ class CoreOrchestrator(ICoreAggregate):
 
         self._injector.inject_text(page, PromptText(prompt))
         emitter.emit(EVENT_PROMPT_INJECTED, {"file": str(filepath), "char_count": len(prompt)})
-        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt)})
+        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "file_size_bytes": filepath.stat().st_size})
         if not state.document_parsed:
             raise RuntimeError("Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete")
 

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -41,17 +41,25 @@ from modules.shared.src.taxonomy_core_constant import (
     DEFAULT_OUTPUT,
     DEFAULT_TODO,
 )
-from modules.shared.src.taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, LifecycleState, RateLimiter
+from modules.shared.src.taxonomy_core_entity import (
+    CircuitBreaker,
+    LifecycleEmitter,
+    LifecycleGate,
+    LifecycleState,
+    RateLimiter,
+)
 from modules.shared.src.taxonomy_core_error import (
     AuthRequiredError,
     CircuitBreakerOpenError,
     QwenCliError,
+    ResponseDetectionTimeoutError,
+    UploadFailureError,
 )
 from modules.shared.src.taxonomy_core_event import (
-    EVENT_DISPATCH_ACKNOWLEDGED,
     EVENT_DOCUMENT_PARSED,
     EVENT_OUTPUT_COPIED,
-    EVENT_WEB_LOADED,
+    EVENT_PROMPT_INJECTED,
+    PIPELINE_EVENT_SEQUENCE,
 )
 from modules.shared.src.taxonomy_core_vo import (
     FailureThreshold,
@@ -398,11 +406,12 @@ class CoreOrchestrator(ICoreAggregate):
             output_path=DEFAULT_OUTPUT,
             headless=True,
         )
-        emitter = self._emitter()
+        logger = self._observability.get_logger()
         state = LifecycleState()
-        emitter.on(EVENT_WEB_LOADED, lambda _event: state.mark(EVENT_WEB_LOADED))
-        emitter.on(EVENT_DOCUMENT_PARSED, lambda _event: state.mark(EVENT_DOCUMENT_PARSED))
-        emitter.on(EVENT_DISPATCH_ACKNOWLEDGED, lambda _event: state.mark(EVENT_DISPATCH_ACKNOWLEDGED))
+        gate = LifecycleGate(logger)
+        emitter = LifecycleEmitter(logger, gate=gate)
+        for lifecycle_event in PIPELINE_EVENT_SEQUENCE:
+            emitter.on(lifecycle_event, lambda _event, name=lifecycle_event: state.mark(name))
         try:
             prompt = filepath.read_text(encoding="utf-8").strip()
         except OSError as e:
@@ -424,15 +433,21 @@ class CoreOrchestrator(ICoreAggregate):
         attached = self._uploader.upload_attachment(
             page, filepath, emitter=emitter, web_loaded=HeadlessFlag(state.web_loaded)
         )
-        if not attached:
-            self._observability.get_logger().warning(
-                "File upload failed, proceeding with text-only prompt: %s", filepath.name
+        if not attached or not state.file_uploaded:
+            upload_error = getattr(self._uploader, "last_error", None)
+            detail = f": {upload_error}" if upload_error else ""
+            logger.error("File upload could not be positively verified: %s%s", filepath.name, detail)
+            raise UploadFailureError(
+                f"Attachment upload failed or was not verified for {filepath.name}{detail}; "
+                "EVENT_FILE_UPLOADED was not emitted"
             )
-            emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt), "fallback": True})
+
+        self._injector.inject_text(page, PromptText(prompt))
+        emitter.emit(EVENT_PROMPT_INJECTED, {"file": str(filepath), "char_count": len(prompt)})
+        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": len(prompt)})
         if not state.document_parsed:
             raise RuntimeError("Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete")
 
-        self._injector.inject_text(page, PromptText(prompt))
         self._sender.click_send(page, emitter, document_parsed=HeadlessFlag(state.document_parsed))
         if not state.dispatch_acknowledged:
             raise RuntimeError("Cannot wait for response: prompt dispatch (EVENT_DISPATCH_ACKNOWLEDGED) is incomplete")
@@ -448,10 +463,12 @@ class CoreOrchestrator(ICoreAggregate):
         )
 
         if response and len(response.strip()) > 0:
-            self._observability.get_logger().info("Received response (%d chars)", len(response))
+            logger.info("Received response (%d chars)", len(response))
             emitter.emit(EVENT_OUTPUT_COPIED, {"file": str(filepath), "char_count": len(response.strip())})
             return response.strip()
-        raise TimeoutError(f"Timeout after {stream_timeout_sec}s: no response detected")
+        raise ResponseDetectionTimeoutError(
+            f"Response detection timeout after {stream_timeout_sec}s: no response detected"
+        )
 
     # ─── Private orchestration helpers (Block 3) ─────────────────
     def _execute(self, fn: Callable[[], ResponseText]) -> ResponseText:

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -60,6 +60,8 @@ from modules.shared.src.taxonomy_core_event import (
     EVENT_OUTPUT_COPIED,
     EVENT_PROMPT_INJECTED,
     PIPELINE_EVENT_SEQUENCE,
+    LifecycleEvent,
+    QwenEventType,
 )
 from modules.shared.src.taxonomy_core_vo import (
     FailureThreshold,
@@ -411,7 +413,14 @@ class CoreOrchestrator(ICoreAggregate):
         gate = LifecycleGate(logger)
         emitter = LifecycleEmitter(logger, gate=gate)
         for lifecycle_event in PIPELINE_EVENT_SEQUENCE:
-            emitter.on(lifecycle_event, lambda _event, name=lifecycle_event: state.mark(name))
+
+            def mark_lifecycle_event(
+                _event: LifecycleEvent,
+                name: QwenEventType = lifecycle_event,
+            ) -> None:
+                state.mark(name)
+
+            emitter.on(lifecycle_event, mark_lifecycle_event)
         try:
             prompt = filepath.read_text(encoding="utf-8").strip()
         except OSError as e:

--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -265,9 +265,11 @@ class BrowserAdapter(IBrowserProtocol):
 
         isolate_thread_event_loop()
 
+        context_started = False
         try:
             with sync_playwright() as p:
                 ctx = self._launch_context(p, kwargs)
+                context_started = True
                 if cfg.mode != "login":
                     ctx.route(
                         "**/*.{png,jpg,jpeg,gif,webp,mp4,mp3,woff,woff2,ttf,otf}",
@@ -278,11 +280,16 @@ class BrowserAdapter(IBrowserProtocol):
                 finally:
                     try:
                         ctx.close()
-                    except Error as e:
-                        log.warning("Error closing browser context: %s", e)
+                    except Exception as e:
+                        # Teardown is best-effort and must never mask the domain failure.
+                        log.warning("browser_context_cleanup_failed", error=str(e))
         except AuthRequiredError:
             raise
+        except BrowserLaunchError:
+            raise
         except Exception as e:
+            if context_started:
+                raise
             log.critical("browser_launch_failed", error=str(e))
             raise BrowserLaunchError(f"Failed to launch browser: {e}") from e
 

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -147,6 +147,13 @@ class FileUploader(IUploadProtocol):
 
     def _try_upload_attempt(self, page: Page, filepath: Path) -> bool:
         """Execute a single attempt to attach a file via the Qwen Web UI."""
+        direct_input = self._find_file_input(page)
+        if direct_input is not None:
+            log.debug("Setting file through direct Qwen file input selector")
+            direct_input.set_input_files(str(filepath))
+            self._wait_for_attachment_card(page)
+            return True
+
         log.debug("Opening mode-select dropdown using primary/fallback selectors")
         dropdown_element = first_visible_locator(page, self.dropdown_selectors, timeout_ms=1000)
 
@@ -156,9 +163,7 @@ class FileUploader(IUploadProtocol):
         dropdown_element.click(timeout=self.dropdown_timeout_ms)
 
         log.debug("Locating upload option using resilient selector fallbacks")
-        option_element = first_visible_locator(
-            page, self.upload_option_selectors, timeout_ms=self.option_timeout_ms
-        )
+        option_element = first_visible_locator(page, self.upload_option_selectors, timeout_ms=self.option_timeout_ms)
 
         if not option_element:
             raise TimeoutError(
@@ -172,6 +177,22 @@ class FileUploader(IUploadProtocol):
         log.debug("Setting file on file chooser: %s", filepath.name)
         fc.value.set_files(str(filepath))
 
+        self._wait_for_attachment_card(page)
+        return True
+
+    def _find_file_input(self, page: Page) -> Any | None:
+        """Find the stable hidden Qwen file input without requiring visibility."""
+        for selector in self.config.file_input_selectors:
+            locator = page.locator(selector).first
+            try:
+                if locator.count() > 0:
+                    return locator
+            except Exception:
+                continue
+        return None
+
+    def _wait_for_attachment_card(self, page: Page) -> None:
+        """Wait for a positive attachment indicator after setting a file."""
         log.debug("Waiting for file card attachment indicator to render and complete parsing")
         card_selector_str = ", ".join(self.card_selectors)
         page.locator(card_selector_str).first.wait_for(state="visible", timeout=self.card_render_timeout_ms)
@@ -180,8 +201,6 @@ class FileUploader(IUploadProtocol):
                 state="hidden", timeout=5000
             )
         time.sleep(2.0)
-
-        return True
 
     # ─── Block 3: Dunder Methods, Factories & Helpers ─────
 

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -18,7 +18,7 @@ from modules.shared.src.contract_core_protocol import IUploadProtocol
 from modules.shared.src.taxonomy_config_vo import DEFAULT_UPLOAD_CONFIG, UploadConfig
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter
 from modules.shared.src.taxonomy_core_error import FileValidationError
-from modules.shared.src.taxonomy_core_event import EVENT_DOCUMENT_PARSED
+from modules.shared.src.taxonomy_core_event import EVENT_FILE_UPLOADED
 from modules.shared.src.taxonomy_core_vo import (
     BackoffDelaySec,
     CardRenderTimeoutMs,
@@ -55,6 +55,7 @@ class FileUploader(IUploadProtocol):
         self.dropdown_selectors = self.config.dropdown_selectors
         self.upload_option_selectors = self.config.upload_option_selectors
         self.card_selectors = self.config.card_selectors
+        self.last_error: Exception | None = None
 
     # ─── Block 2: Public Contract (IUploadProtocol ONLY) ──
     def upload_attachment(
@@ -73,14 +74,17 @@ class FileUploader(IUploadProtocol):
             self.max_file_size_mb = MaxFileSizeMb(config.get("max_file_size_mb", float(self.max_file_size_mb)))
             self.max_retries = MaxRetries(config.get("max_retries", int(self.max_retries)))
 
+        self.last_error = None
         try:
             size_bytes = FileSizeBytes(_validate_file_util(filepath, float(self.max_file_size_mb)))
         except FileValidationError as e:
+            self.last_error = e
             log.error("Pre-flight validation failed: %s", e)
             return False
 
         attempt = 0
         max_attempts = max(1, self.max_retries + 1)
+        started_at = time.monotonic()
 
         while attempt < max_attempts:
             attempt += 1
@@ -95,7 +99,7 @@ class FileUploader(IUploadProtocol):
             try:
                 success = self._try_upload_attempt(page, filepath)
                 if success:
-                    elapsed = time.monotonic()
+                    elapsed = time.monotonic() - started_at
                     log.info(
                         "File attached successfully in %.2fs (attempt %d): %s",
                         elapsed,
@@ -103,12 +107,17 @@ class FileUploader(IUploadProtocol):
                         filepath.name,
                     )
                     if emitter:
-                        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "char_count": size_bytes})
+                        emitter.emit(
+                            EVENT_FILE_UPLOADED,
+                            {"file": str(filepath), "byte_count": int(size_bytes), "attempt": attempt},
+                        )
                     return True
             except TimeoutError as e:
+                self.last_error = e
                 log.warning("Timeout during upload attempt %d/%d: %s", attempt, max_attempts, e)
                 self._close_dropdown_if_open(page)
             except Error as e:
+                self.last_error = e
                 log.warning("Unexpected error during upload attempt %d/%d: %s", attempt, max_attempts, e)
                 self._close_dropdown_if_open(page)
 
@@ -119,7 +128,7 @@ class FileUploader(IUploadProtocol):
             "All %d upload attempts failed for %s after %.2fs",
             max_attempts,
             filepath.name,
-            time.monotonic() - size_bytes,
+            time.monotonic() - started_at,
         )
         return False
 
@@ -146,13 +155,15 @@ class FileUploader(IUploadProtocol):
 
         dropdown_element.click(timeout=self.dropdown_timeout_ms)
 
-        log.debug("Locating 'Upload attachment' option")
-        option_element = first_visible_locator(page, self.upload_option_selectors, timeout_ms=1000)
+        log.debug("Locating upload option using resilient selector fallbacks")
+        option_element = first_visible_locator(
+            page, self.upload_option_selectors, timeout_ms=self.option_timeout_ms
+        )
 
         if not option_element:
-            option_element = page.locator(self.upload_option_selectors[0], has_text="Upload attachment").first
-            if not option_element.is_visible(timeout=self.option_timeout_ms):
-                option_element = page.locator("text='Upload attachment'").first
+            raise TimeoutError(
+                "Unable to locate a visible upload action using configured label, aria-label, or data-testid selectors"
+            )
 
         log.debug("Triggering file chooser")
         with page.expect_file_chooser(timeout=self.file_chooser_timeout_ms) as fc:

--- a/modules/core/src/capabilities_stream_monitor.py
+++ b/modules/core/src/capabilities_stream_monitor.py
@@ -130,10 +130,11 @@ class StreamMonitor(IStreamProtocol):
                                 return ResponseText(text)
                         else:
                             if has_thinking:
-                                has_streaming = True
+                                if not has_streaming:
+                                    has_streaming = True
+                                    emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": len(text)})
                                 stable_count = 0
                                 last_text = text
-                                emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": len(text)})
                 time.sleep(active_poll)
             except TimeoutError as e:
                 raise NetworkTimeoutError(f"Browser network timeout during streaming poll: {e}") from e

--- a/modules/core/src/capabilities_stream_monitor.py
+++ b/modules/core/src/capabilities_stream_monitor.py
@@ -148,6 +148,7 @@ class StreamMonitor(IStreamProtocol):
 
         if last_text is not None:
             validate_response_content(last_text)
+            emitter.emit(EVENT_GENERATION_FINISHED, {"text_length": len(last_text), "fallback": True})
             return ResponseText(last_text)
 
         log.warning("Timeout after %ds — no response detected", timeout_sec)

--- a/modules/shared/src/__init__.py
+++ b/modules/shared/src/__init__.py
@@ -80,7 +80,7 @@ from .taxonomy_core_constant import (
 )
 
 # ─── Taxonomy: entities ───────────────────────────────────────
-from .taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, LifecycleState, RateLimiter
+from .taxonomy_core_entity import CircuitBreaker, LifecycleEmitter, LifecycleGate, LifecycleState, RateLimiter
 
 # ─── Taxonomy: domain errors ──────────────────────────────────
 from .taxonomy_core_error import (
@@ -99,9 +99,11 @@ from .taxonomy_core_error import (
     QuarantineError,
     QwenCliError,
     RateLimitError,
+    ResponseDetectionTimeoutError,
     SendDispatchError,
     SingleInstanceError,
     UIInteractionError,
+    UploadFailureError,
     UploadTimeoutError,
 )
 
@@ -298,8 +300,10 @@ __all__ = [
     "ElementNotFoundError",
     "NetworkTimeoutError",
     "OutputValidationError",
+    "ResponseDetectionTimeoutError",
     "FileUploadError",
     "FileValidationError",
+    "UploadFailureError",
     "UploadTimeoutError",
     "UIInteractionError",
     "PipelineError",
@@ -345,6 +349,7 @@ __all__ = [
     "CircuitBreaker",
     "RateLimiter",
     "LifecycleState",
+    "LifecycleGate",
     # Events
     "LifecycleEmitter",
     # Contracts

--- a/modules/shared/src/taxonomy_config_vo.py
+++ b/modules/shared/src/taxonomy_config_vo.py
@@ -35,12 +35,18 @@ class UploadConfig:
             ".mode-select-open",
             "[class*='mode-select']",
             "button:has-text('Upload')",
+            "button[aria-label*='attach' i]",
+            "[data-testid*='attach' i]",
         )
     )
 
     upload_option_selectors: Sequence[str] = field(
         default_factory=lambda: (
             ".mode-select-dropdown-item",
+            "[data-testid*='upload' i]",
+            "[aria-label*='upload' i]",
+            "button:has-text('Upload attachment')",
+            "button:has-text('Upload file')",
             "text='Upload attachment'",
             "text='Upload file'",
         )

--- a/modules/shared/src/taxonomy_config_vo.py
+++ b/modules/shared/src/taxonomy_config_vo.py
@@ -40,6 +40,14 @@ class UploadConfig:
         )
     )
 
+    file_input_selectors: Sequence[str] = field(
+        default_factory=lambda: (
+            "#filesUpload",
+            "input[type='file'][aria-label='Upload files']",
+            "input[type='file']",
+        )
+    )
+
     upload_option_selectors: Sequence[str] = field(
         default_factory=lambda: (
             ".mode-select-dropdown-item",

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -9,6 +9,7 @@ import logging
 import time
 from collections import deque
 from collections.abc import Callable
+from typing import Protocol
 
 from modules.shared.src.taxonomy_core_constant import MAX_ATTEMPTS
 from modules.shared.src.taxonomy_core_event import (
@@ -175,10 +176,17 @@ class LifecycleState:
             setattr(self, flags[key], True)
 
 
+class LifecycleLogger(Protocol):
+    """Logger protocol accepted by lifecycle entities."""
+
+    def info(self, message: EventMessage) -> object:
+        """Record an informational lifecycle message."""
+
+
 class LifecycleGate:
     """Strict predecessor gate for the ordered processing lifecycle."""
 
-    def __init__(self, logger: Callable[..., object] | None = None) -> None:
+    def __init__(self, logger: Callable[..., object] | LifecycleLogger | None = None) -> None:
         self._logger = logger
         self._completed: list[QwenEventType] = []
         self.rejections: list[dict[str, str]] = []
@@ -210,20 +218,18 @@ class LifecycleGate:
             self._completed.append(event)
             return
 
-        rejection = {"event": str(event), "reason": reason}
+        rejection = {"event": event.value, "reason": reason}
         self.rejections.append(rejection)
-        self._log(f"lifecycle_gate_rejected event={event} reason={reason}")
+        self._log(EventMessage(f"lifecycle_gate_rejected event={event} reason={reason}"))
         raise RuntimeError(f"Lifecycle gate rejected {event}: {reason}")
 
-    def _log(self, message: str) -> None:
+    def _log(self, message: EventMessage) -> None:
         if self._logger is None:
             return
         if callable(self._logger):
             self._logger(message)
         else:
-            info = getattr(self._logger, "info", None)
-            if callable(info):
-                info(message)
+            self._logger.info(message)
 
 
 class LifecycleEmitter:
@@ -231,7 +237,7 @@ class LifecycleEmitter:
 
     def __init__(
         self,
-        logger: Callable[..., object] | None = None,
+        logger: Callable[..., object] | LifecycleLogger | None = None,
         gate: LifecycleGate | None = None,
     ) -> None:
         """Initialize callbacks, an optional logger, and an optional strict gate."""

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from modules.shared.src.taxonomy_core_constant import MAX_ATTEMPTS
 from modules.shared.src.taxonomy_core_event import (
     EVENT_DESCRIPTIONS,
+    PIPELINE_EVENT_SEQUENCE,
     CallbackRegistry,
     EventDetails,
     EventMessage,
@@ -145,26 +146,98 @@ class LifecycleState:
 
     def __init__(self) -> None:
         self.web_loaded = False
+        self.file_uploaded = False
+        self.prompt_injected = False
         self.document_parsed = False
+        self.send_clicked = False
         self.dispatch_acknowledged = False
+        self.thinking_started = False
+        self.streaming_generation = False
+        self.generation_finished = False
+        self.output_copied = False
 
     def mark(self, event_name: QwenEventType | str) -> None:
         """Advance exactly the gate represented by an emitted event."""
-        if event_name == QwenEventType.WEB_LOADED:
-            self.web_loaded = True
-        elif event_name == QwenEventType.DOCUMENT_PARSED:
-            self.document_parsed = True
-        elif event_name == QwenEventType.DISPATCH_ACKNOWLEDGED:
-            self.dispatch_acknowledged = True
+        key = str(event_name)
+        flags = {
+            str(QwenEventType.WEB_LOADED): "web_loaded",
+            str(QwenEventType.FILE_UPLOADED): "file_uploaded",
+            str(QwenEventType.PROMPT_INJECTED): "prompt_injected",
+            str(QwenEventType.DOCUMENT_PARSED): "document_parsed",
+            str(QwenEventType.SEND_CLICKED): "send_clicked",
+            str(QwenEventType.DISPATCH_ACKNOWLEDGED): "dispatch_acknowledged",
+            str(QwenEventType.THINKING_STARTED): "thinking_started",
+            str(QwenEventType.STREAMING_GENERATION): "streaming_generation",
+            str(QwenEventType.GENERATION_FINISHED): "generation_finished",
+            str(QwenEventType.OUTPUT_COPIED): "output_copied",
+        }
+        if key in flags:
+            setattr(self, flags[key], True)
+
+
+class LifecycleGate:
+    """Strict predecessor gate for the ordered processing lifecycle."""
+
+    def __init__(self, logger: Callable[..., object] | None = None) -> None:
+        self._logger = logger
+        self._completed: list[QwenEventType] = []
+        self.rejections: list[dict[str, str]] = []
+        self._predecessor = {
+            event: PIPELINE_EVENT_SEQUENCE[index - 1]
+            for index, event in enumerate(PIPELINE_EVENT_SEQUENCE)
+            if index > 0
+        }
+
+    @property
+    def completed(self) -> tuple[QwenEventType, ...]:
+        """Return the accepted event sequence in emission order."""
+        return tuple(self._completed)
+
+    def validate(self, event_name: QwenEventType | str) -> None:
+        """Accept an event or raise with an auditable predecessor reason."""
+        try:
+            event = event_name if isinstance(event_name, QwenEventType) else QwenEventType(str(event_name))
+        except ValueError:
+            return
+
+        predecessor = self._predecessor.get(event)
+        if event in self._completed:
+            reason = f"{event} was already emitted"
+        elif predecessor is not None and (not self._completed or self._completed[-1] != predecessor):
+            last_event = self._completed[-1] if self._completed else "none"
+            reason = f"requires successful predecessor {predecessor}; last event was {last_event}"
+        else:
+            self._completed.append(event)
+            return
+
+        rejection = {"event": str(event), "reason": reason}
+        self.rejections.append(rejection)
+        self._log(f"lifecycle_gate_rejected event={event} reason={reason}")
+        raise RuntimeError(f"Lifecycle gate rejected {event}: {reason}")
+
+    def _log(self, message: str) -> None:
+        if self._logger is None:
+            return
+        if callable(self._logger):
+            self._logger(message)
+        else:
+            info = getattr(self._logger, "info", None)
+            if callable(info):
+                info(message)
 
 
 class LifecycleEmitter:
     """Event bus for pipeline lifecycle events with typed dispatcher capability."""
 
-    def __init__(self, logger: Callable[..., object] | None = None) -> None:
-        """Initialize with an empty callback registry and an optional logger."""
+    def __init__(
+        self,
+        logger: Callable[..., object] | None = None,
+        gate: LifecycleGate | None = None,
+    ) -> None:
+        """Initialize callbacks, an optional logger, and an optional strict gate."""
         self._callbacks: CallbackRegistry = {}
         self._logger = logger or logging.getLogger("lifecycle")
+        self._gate = gate
 
     def on(self, event_name: QwenEventType | str, callback: LifecycleCallback) -> None:
         """Register a callback for a named lifecycle event."""
@@ -174,6 +247,8 @@ class LifecycleEmitter:
     def emit(self, event_name: QwenEventType | str, details: EventDetails | None = None) -> LifecycleEvent:
         """Emit a lifecycle event to all registered callbacks."""
         key = str(event_name)
+        if self._gate is not None:
+            self._gate.validate(event_name)
         evt = LifecycleEvent(
             name=key,
             timestamp=time.time(),

--- a/modules/shared/src/taxonomy_core_error.py
+++ b/modules/shared/src/taxonomy_core_error.py
@@ -85,8 +85,8 @@ class OutputWriteError(QwenCliError):
 
 _ERROR_CATEGORY_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
     (("auth", "login", "captcha", "signin"), "auth"),
-    (('response detection', 'response timeout', 'stream timeout'), 'response_timeout'),
-    (('network', 'connection', 'timeout', 'dns', 'socket'), 'network'),
+    (("response detection", "response timeout", "stream timeout"), "response_timeout"),
+    (("network", "connection", "timeout", "dns", "socket"), "network"),
     (("rate", "limit", "throttl", "429"), "rate_limit"),
     (("browser", "launch", "dom", "playwright", "chromium"), "browser"),
     (("injection", "paste", "clipboard", "fill"), "injection"),

--- a/modules/shared/src/taxonomy_core_error.py
+++ b/modules/shared/src/taxonomy_core_error.py
@@ -39,6 +39,10 @@ class NetworkTimeoutError(QwenCliError):
     """Raised when network operation times out or drops."""
 
 
+class ResponseDetectionTimeoutError(QwenCliError):
+    """Raised when a valid dispatch produces no detectable assistant response."""
+
+
 class OutputValidationError(QwenCliError):
     """Raised when response content fails sanity check, such as a challenge page."""
 
@@ -49,6 +53,10 @@ class FileUploadError(QwenCliError):
 
 class FileValidationError(FileUploadError):
     """Raised when file pre-flight validation fails."""
+
+
+class UploadFailureError(FileUploadError):
+    """Raised when an attachment cannot be positively verified as uploaded."""
 
 
 class UploadTimeoutError(FileUploadError):
@@ -77,7 +85,8 @@ class OutputWriteError(QwenCliError):
 
 _ERROR_CATEGORY_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
     (("auth", "login", "captcha", "signin"), "auth"),
-    (("network", "connection", "timeout", "dns", "socket"), "network"),
+    (('response detection', 'response timeout', 'stream timeout'), 'response_timeout'),
+    (('network', 'connection', 'timeout', 'dns', 'socket'), 'network'),
     (("rate", "limit", "throttl", "429"), "rate_limit"),
     (("browser", "launch", "dom", "playwright", "chromium"), "browser"),
     (("injection", "paste", "clipboard", "fill"), "injection"),
@@ -112,9 +121,11 @@ __all__ = [
     "SingleInstanceError",
     "ElementNotFoundError",
     "NetworkTimeoutError",
+    "ResponseDetectionTimeoutError",
     "OutputValidationError",
     "FileUploadError",
     "FileValidationError",
+    "UploadFailureError",
     "UploadTimeoutError",
     "UIInteractionError",
     "PipelineError",

--- a/modules/shared/src/taxonomy_core_event.py
+++ b/modules/shared/src/taxonomy_core_event.py
@@ -71,6 +71,7 @@ PIPELINE_EVENT_SEQUENCE: tuple[QwenEventType, ...] = (
     QwenEventType.PROMPT_INJECTED,
     QwenEventType.DOCUMENT_PARSED,
     QwenEventType.SEND_CLICKED,
+    QwenEventType.DISPATCH_ACKNOWLEDGED,
     QwenEventType.THINKING_STARTED,
     QwenEventType.STREAMING_GENERATION,
     QwenEventType.GENERATION_FINISHED,

--- a/tests/test_cli_run_command.py
+++ b/tests/test_cli_run_command.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from modules.cli.src.surface_cli_run_command import handle
+
+
+def test_failed_batch_is_not_reported_as_success() -> None:
+    core = MagicMock()
+    core.process_mode.return_value = "Batch processing complete. Successfully processed: 1, Failed: 1"
+    args = SimpleNamespace(_cfg=object())
+
+    result = handle(args, core)
+
+    assert result["success"] is False
+    assert result["category"] == "processing_failed"
+    assert "Failed: 1" in str(result["error"])
+
+
+def test_error_processing_response_is_not_reported_as_success() -> None:
+    core = MagicMock()
+    core.process_mode.return_value = "ERROR [PROCESSING_FAILED]: upload failed"
+    args = SimpleNamespace(_cfg=object())
+
+    result = handle(args, core)
+
+    assert result["success"] is False
+    assert result["category"] == "processing_failed"
+
+
+def test_successful_batch_remains_success() -> None:
+    core = MagicMock()
+    core.process_mode.return_value = "Batch processing complete. Successfully processed: 2, Failed: 0"
+    args = SimpleNamespace(_cfg=object())
+
+    result = handle(args, core)
+
+    assert result == {"success": True, "message": core.process_mode.return_value}
+
+
+def test_missing_config_is_validation_error() -> None:
+    result = handle(SimpleNamespace(), MagicMock())
+
+    assert result["success"] is False
+    assert result["category"] == "validation_error"

--- a/tests/test_core_pipeline_routing_gates.py
+++ b/tests/test_core_pipeline_routing_gates.py
@@ -12,7 +12,16 @@ from modules.core.src.agent_core_orchestrator import CoreOrchestrator
 from modules.core.src.utility_core_file_mover import move_file
 from modules.shared.src.taxonomy_config_vo import AppConfig
 from modules.shared.src.taxonomy_core_entity import CircuitBreaker, LifecycleState, RateLimiter
-from modules.shared.src.taxonomy_core_event import EVENT_DOCUMENT_PARSED, EVENT_WEB_LOADED
+from modules.shared.src.taxonomy_core_event import (
+    EVENT_DISPATCH_ACKNOWLEDGED,
+    EVENT_DOCUMENT_PARSED,
+    EVENT_FILE_UPLOADED,
+    EVENT_GENERATION_FINISHED,
+    EVENT_SEND_CLICKED,
+    EVENT_STREAMING_GENERATION,
+    EVENT_THINKING_STARTED,
+    EVENT_WEB_LOADED,
+)
 from modules.shared.src.taxonomy_core_vo import (
     ProcessingOutcome,
     ProcessingStatus,
@@ -178,18 +187,28 @@ def test_lifecycle_flags_are_event_backed_and_passed_to_capabilities(tmp_path: P
     page = MagicMock()
 
     def navigate(_page: object, emitter: object) -> None:
-        emitter.emit(orchestrator_module.EVENT_WEB_LOADED, {"url": "test"})
+        emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
 
-    def upload(_page: object, _filepath: Path, **_kwargs: object) -> bool:
-        return False
+    def upload(_page: object, _filepath: Path, **kwargs: object) -> bool:
+        emitter = kwargs["emitter"]
+        emitter.emit(EVENT_FILE_UPLOADED, {"source": "test"})
+        return True
 
     def send(_page: object, emitter: object, **_kwargs: object) -> None:
-        emitter.emit(orchestrator_module.EVENT_DISPATCH_ACKNOWLEDGED, {"source": "test"})
+        emitter.emit(EVENT_SEND_CLICKED, {"source": "test"})
+        emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"source": "test"})
 
     orch._browser.navigate_to_chat.side_effect = navigate
     orch._uploader.upload_attachment.side_effect = upload
     orch._sender.click_send.side_effect = send
-    orch._streamer.wait_for_response.return_value = "answer"
+
+    def stream(_page: object, _timeout: int, _before: int, emitter: object, **_kwargs: object) -> str:
+        emitter.emit(EVENT_THINKING_STARTED)
+        emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": 6})
+        emitter.emit(EVENT_GENERATION_FINISHED, {"text_length": 6})
+        return "answer"
+
+    orch._streamer.wait_for_response.side_effect = stream
 
     assert orch.send_file(page, prompt_file, timeout_sec=5) == "answer"
     assert orch._uploader.upload_attachment.call_args.kwargs["web_loaded"] is True
@@ -210,7 +229,7 @@ def test_missing_web_loaded_event_blocks_upload(tmp_path: Path) -> None:
     orch._sender.click_send.assert_not_called()
 
 
-def test_missing_document_parsed_event_blocks_send(tmp_path: Path) -> None:
+def test_upload_success_without_verified_event_blocks_pipeline(tmp_path: Path) -> None:
     prompt_file = tmp_path / "prompt.md"
     prompt_file.write_text("prompt")
     orch = _make_orchestrator()
@@ -221,7 +240,7 @@ def test_missing_document_parsed_event_blocks_send(tmp_path: Path) -> None:
     orch._browser.navigate_to_chat.side_effect = navigate
     orch._uploader.upload_attachment.return_value = True
 
-    with pytest.raises(RuntimeError, match="EVENT_DOCUMENT_PARSED"):
+    with pytest.raises(RuntimeError, match="EVENT_FILE_UPLOADED"):
         orch.send_file(MagicMock(), prompt_file, timeout_sec=5)
 
     orch._sender.click_send.assert_not_called()
@@ -235,8 +254,9 @@ def test_missing_dispatch_acknowledgement_blocks_stream(tmp_path: Path) -> None:
     def navigate(_page: object, emitter: object) -> None:
         emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
 
-    def upload(_page: object, _filepath: Path, **_kwargs: object) -> bool:
-        return False
+    def upload(_page: object, _filepath: Path, **kwargs: object) -> bool:
+        kwargs["emitter"].emit(EVENT_FILE_UPLOADED, {"source": "test"})
+        return True
 
     orch._browser.navigate_to_chat.side_effect = navigate
     orch._uploader.upload_attachment.side_effect = upload
@@ -311,10 +331,15 @@ def test_dispatch_failure_blocks_stream_monitor(tmp_path: Path) -> None:
     orch = _make_orchestrator()
 
     def navigate(_page: object, emitter: object) -> None:
-        emitter.emit(orchestrator_module.EVENT_WEB_LOADED, {"url": "test"})
+        emitter.emit(EVENT_WEB_LOADED, {"url": "test"})
 
     orch._browser.navigate_to_chat.side_effect = navigate
-    orch._uploader.upload_attachment.return_value = False
+
+    def upload(_page: object, _filepath: Path, **kwargs: object) -> bool:
+        kwargs["emitter"].emit(EVENT_FILE_UPLOADED, {"source": "test"})
+        return True
+
+    orch._uploader.upload_attachment.side_effect = upload
     orch._sender.click_send.side_effect = RuntimeError("dispatch failed")
 
     with pytest.raises(RuntimeError, match="dispatch failed"):

--- a/tests/test_file_uploader.py
+++ b/tests/test_file_uploader.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from modules.core.src.capabilities_file_uploader import FileUploader
-from modules.shared.src import FileValidationError, LifecycleEmitter
+from modules.shared.src import EVENT_FILE_UPLOADED, FileValidationError, LifecycleEmitter
 
 
 class TestValidateFile:
@@ -96,7 +96,10 @@ class TestUploadAttachment:
 
         with patch.object(FileUploader, "_try_upload_attempt", return_value=True):
             FileUploader().upload_attachment(page, f, emitter=emitter)
-            emitter.emit.assert_called_once()
+            emitter.emit.assert_called_once_with(
+                EVENT_FILE_UPLOADED,
+                {"file": str(f), "byte_count": 5, "attempt": 1},
+            )
 
     def test_retry_on_failure(self, tmp_path):
         f = tmp_path / "test.md"

--- a/tests/test_file_uploader.py
+++ b/tests/test_file_uploader.py
@@ -88,6 +88,19 @@ class TestUploadAttachment:
             result = FileUploader().upload_attachment(page, f)
             assert result is True
 
+    def test_direct_qwen_file_input_is_preferred(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("hello")
+        page = MagicMock()
+        direct_input = MagicMock()
+        direct_input.count.return_value = 1
+        page.locator.return_value.first = direct_input
+        with patch.object(FileUploader, "_wait_for_attachment_card"):
+            result = FileUploader().upload_attachment(page, f)
+        assert result is True
+        page.locator.assert_called_once_with("#filesUpload")
+        direct_input.set_input_files.assert_called_once_with(str(f))
+
     def test_emitter_called_on_success(self, tmp_path):
         f = tmp_path / "test.md"
         f.write_text("hello")

--- a/tests/test_qwen_client_behavior.py
+++ b/tests/test_qwen_client_behavior.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from modules.core.src.agent_core_orchestrator import CoreOrchestrator
+from modules.shared.src import ResponseDetectionTimeoutError
 
 
 def _make_orchestrator() -> CoreOrchestrator:
@@ -164,5 +165,5 @@ class TestSendFilePipeline:
         monkeypatch.setattr(client._streamer, "wait_for_response", lambda *a, **k: None)
 
         probe = _probe_file(tmp_path)
-        with pytest.raises(TimeoutError, match="Timeout after"):
+        with pytest.raises(ResponseDetectionTimeoutError, match="Response detection timeout"):
             client.send_file(page, probe, timeout_sec=1)

--- a/tests/test_qwen_client_extended.py
+++ b/tests/test_qwen_client_extended.py
@@ -10,9 +10,14 @@ from playwright.sync_api import Error
 from modules.core.src.capabilities_prompt_injector import PromptInjector
 from modules.shared.src import (
     EVENT_DISPATCH_ACKNOWLEDGED,
-    EVENT_DOCUMENT_PARSED,
+    EVENT_FILE_UPLOADED,
+    EVENT_GENERATION_FINISHED,
+    EVENT_SEND_CLICKED,
+    EVENT_STREAMING_GENERATION,
+    EVENT_THINKING_STARTED,
     EVENT_WEB_LOADED,
     QwenCliError,
+    ResponseDetectionTimeoutError,
 )
 from tests.helpers import make_test_orchestrator
 
@@ -23,10 +28,11 @@ def _configure_lifecycle_mocks(orch) -> None:
 
     def upload(_page, _filepath, emitter=None, **_kwargs):
         assert emitter is not None
-        emitter.emit(EVENT_DOCUMENT_PARSED, {"file": "test"})
+        emitter.emit(EVENT_FILE_UPLOADED, {"file": "test"})
         return True
 
     def send(_page, emitter, **_kwargs):
+        emitter.emit(EVENT_SEND_CLICKED, {"file": "test"})
         emitter.emit(EVENT_DISPATCH_ACKNOWLEDGED, {"file": "test"})
 
     orch._browser.navigate_to_chat.side_effect = navigate
@@ -47,12 +53,16 @@ class TestSendFile:
         page = MagicMock()
         orch._sender.count_messages.return_value = 0
         orch._uploader.upload_attachment.return_value = True
-        orch._streamer.wait_for_response.return_value = None
+        def timeout_stream(_page, _timeout, _before, emitter, **_kwargs):
+            emitter.emit(EVENT_THINKING_STARTED)
+            return None
+
+        orch._streamer.wait_for_response.side_effect = timeout_stream
 
         f = tmp_path / "task.md"
         f.write_text("hello")
 
-        with pytest.raises(TimeoutError, match="Timeout"):
+        with pytest.raises(ResponseDetectionTimeoutError, match="Response detection timeout"):
             orch.send_file(page, f, timeout_sec=10)
 
     def test_send_file_delegates_to_capabilities(self, tmp_path):
@@ -61,7 +71,13 @@ class TestSendFile:
         page = MagicMock()
         orch._sender.count_messages.return_value = 2
         orch._uploader.upload_attachment.return_value = True
-        orch._streamer.wait_for_response.return_value = "the response"
+        def successful_stream(_page, _timeout, _before, emitter, **_kwargs):
+            emitter.emit(EVENT_THINKING_STARTED)
+            emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": 12})
+            emitter.emit(EVENT_GENERATION_FINISHED, {"text_length": 12})
+            return "the response"
+
+        orch._streamer.wait_for_response.side_effect = successful_stream
 
         f = tmp_path / "task.md"
         f.write_text("hello")

--- a/tests/test_qwen_client_extended.py
+++ b/tests/test_qwen_client_extended.py
@@ -53,6 +53,7 @@ class TestSendFile:
         page = MagicMock()
         orch._sender.count_messages.return_value = 0
         orch._uploader.upload_attachment.return_value = True
+
         def timeout_stream(_page, _timeout, _before, emitter, **_kwargs):
             emitter.emit(EVENT_THINKING_STARTED)
             return None
@@ -71,6 +72,7 @@ class TestSendFile:
         page = MagicMock()
         orch._sender.count_messages.return_value = 2
         orch._uploader.upload_attachment.return_value = True
+
         def successful_stream(_page, _timeout, _before, emitter, **_kwargs):
             emitter.emit(EVENT_THINKING_STARTED)
             emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": 12})

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -12,6 +12,7 @@ from modules.core.src.capabilities_stream_monitor import (
 )
 from modules.shared.src import (
     CHALLENGE_KEYWORDS,
+    EVENT_STREAMING_GENERATION,
     AuthRequiredError,
     LifecycleEmitter,
     OutputValidationError,
@@ -205,6 +206,37 @@ class TestWaitForResponseEdgeCases:
                 polling_interval_sec=0,
             )
             assert result is None
+
+    def test_emits_streaming_event_once_for_multiple_response_updates(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+        first_text = "The first streamed response chunk is long enough."
+        second_text = "The second streamed response chunk is also long enough."
+        msg_side_effect = [None, first_text, second_text, second_text, second_text]
+
+        with (
+            patch("modules.core.src.capabilities_stream_monitor.count_messages", return_value=2),
+            patch("modules.core.src.capabilities_stream_monitor._dom_latest", side_effect=msg_side_effect),
+            patch.object(StreamMonitor, "is_generation_complete", return_value=True),
+            patch("modules.core.src.capabilities_stream_monitor.time") as mock_time,
+        ):
+            mock_time.time.side_effect = [0] + [0.1] * 20
+            mock_time.sleep = MagicMock()
+
+            result = StreamMonitor().wait_for_response(
+                page,
+                timeout_sec=5,
+                msg_count_before=1,
+                emitter=emitter,
+                polling_interval_sec=0,
+                stability_checks=2,
+            )
+
+        assert result == second_text
+        streaming_events = [
+            call for call in emitter.emit.call_args_list if call.args and call.args[0] == EVENT_STREAMING_GENERATION
+        ]
+        assert len(streaming_events) == 1
 
     def test_returns_stable_text(self):
         page = MagicMock()

--- a/tests/test_taxonomy_core_event_refactor.py
+++ b/tests/test_taxonomy_core_event_refactor.py
@@ -102,4 +102,7 @@ def test_lifecycle_gate_rejects_skipped_predecessors_and_records_reason() -> Non
 def test_error_taxonomy_has_new_source_and_legacy_facade() -> None:
     assert LEGACY_QWEN_CLI_ERROR is QwenCliError
     assert ErrorCategory.categorize(RuntimeError("network timeout")) == "network"
-    assert ErrorCategory.categorize(ResponseDetectionTimeoutError("Response detection timeout after 10s")) == "response_timeout"
+    assert (
+        ErrorCategory.categorize(ResponseDetectionTimeoutError("Response detection timeout after 10s"))
+        == "response_timeout"
+    )

--- a/tests/test_taxonomy_core_event_refactor.py
+++ b/tests/test_taxonomy_core_event_refactor.py
@@ -11,8 +11,8 @@ from modules.shared.src import (
     EVENT_WEB_LOADED,
     PIPELINE_EVENT_SEQUENCE,
 )
-from modules.shared.src.taxonomy_core_entity import LifecycleEmitter, LifecycleState
-from modules.shared.src.taxonomy_core_error import ErrorCategory, QwenCliError
+from modules.shared.src.taxonomy_core_entity import LifecycleEmitter, LifecycleGate, LifecycleState
+from modules.shared.src.taxonomy_core_error import ErrorCategory, QwenCliError, ResponseDetectionTimeoutError
 from modules.shared.src.taxonomy_core_event import (
     EVENT_DOCUMENT_PARSED,
     EVENT_GENERATION_FINISHED,
@@ -40,6 +40,7 @@ def test_pipeline_event_sequence_is_canonical_and_ordered() -> None:
         QwenEventType.PROMPT_INJECTED,
         QwenEventType.DOCUMENT_PARSED,
         QwenEventType.SEND_CLICKED,
+        QwenEventType.DISPATCH_ACKNOWLEDGED,
         QwenEventType.THINKING_STARTED,
         QwenEventType.STREAMING_GENERATION,
         QwenEventType.GENERATION_FINISHED,
@@ -49,7 +50,8 @@ def test_pipeline_event_sequence_is_canonical_and_ordered() -> None:
     assert EVENT_ORDER[QwenEventType.FILE_UPLOADED] < EVENT_ORDER[QwenEventType.PROMPT_INJECTED]
     assert EVENT_ORDER[QwenEventType.PROMPT_INJECTED] < EVENT_ORDER[QwenEventType.DOCUMENT_PARSED]
     assert EVENT_ORDER[QwenEventType.DOCUMENT_PARSED] < EVENT_ORDER[QwenEventType.SEND_CLICKED]
-    assert EVENT_ORDER[QwenEventType.SEND_CLICKED] < EVENT_ORDER[QwenEventType.THINKING_STARTED]
+    assert EVENT_ORDER[QwenEventType.SEND_CLICKED] < EVENT_ORDER[QwenEventType.DISPATCH_ACKNOWLEDGED]
+    assert EVENT_ORDER[QwenEventType.DISPATCH_ACKNOWLEDGED] < EVENT_ORDER[QwenEventType.THINKING_STARTED]
     assert EVENT_ORDER[QwenEventType.THINKING_STARTED] < EVENT_ORDER[QwenEventType.STREAMING_GENERATION]
     assert EVENT_ORDER[QwenEventType.STREAMING_GENERATION] < EVENT_ORDER[QwenEventType.GENERATION_FINISHED]
     assert EVENT_ORDER[QwenEventType.GENERATION_FINISHED] < EVENT_ORDER[QwenEventType.OUTPUT_COPIED]
@@ -88,6 +90,16 @@ def test_entity_remains_for_stateful_runtime_behavior() -> None:
     assert isinstance(LifecycleEmitter(), LifecycleEmitter)
 
 
+def test_lifecycle_gate_rejects_skipped_predecessors_and_records_reason() -> None:
+    gate = LifecycleGate()
+    gate.validate(QwenEventType.WEB_LOADED)
+    with pytest.raises(RuntimeError, match="EVENT_FILE_UPLOADED"):
+        gate.validate(QwenEventType.PROMPT_INJECTED)
+    assert gate.rejections[0]["event"] == "EVENT_PROMPT_INJECTED"
+    assert "EVENT_FILE_UPLOADED" in gate.rejections[0]["reason"]
+
+
 def test_error_taxonomy_has_new_source_and_legacy_facade() -> None:
     assert LEGACY_QWEN_CLI_ERROR is QwenCliError
     assert ErrorCategory.categorize(RuntimeError("network timeout")) == "network"
+    assert ErrorCategory.categorize(ResponseDetectionTimeoutError("Response detection timeout after 10s")) == "response_timeout"


### PR DESCRIPTION
## Summary

Closes #109.

This change enforces the CLI event lifecycle as a strict predecessor-gated pipeline. Upload and prompt injection success are now positively verified before downstream events can be emitted, and failed uploads stop processing instead of falling back to a false-success text-only path.

## Changes

- Added a strict `LifecycleGate` with rejection diagnostics for skipped, duplicated, or out-of-order events.
- Added `EVENT_FILE_UPLOADED` and `EVENT_PROMPT_INJECTED` enforcement in the runtime pipeline.
- Added resilient upload selectors and preserved the original upload locator/timeout error.
- Classified response detection timeouts separately from browser launch failures.
- Made browser context cleanup idempotent and unable to mask the primary domain failure.
- Changed normal CLI processing responses with quarantined/failed files into `success=false` envelopes, producing a non-zero exit status.
- Ensured generation completion is emitted before output copy on the stream fallback path.
- Added and updated regression tests for event gates, upload handling, timeout classification, and CLI failure envelopes.

## Verification

- `ruff check modules tests`
- `pytest -q`

Both checks pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a strict, predecessor-gated CLI event pipeline and removes the text-only fallback on upload failures. Previously, uploads could fail silently and partial batches returned success; now verified `EVENT_FILE_UPLOADED` and `EVENT_PROMPT_INJECTED` are required, response timeouts raise `ResponseDetectionTimeoutError`, and partial/failed batches return `processing_failed` with a non-zero exit.

- Gates via `LifecycleGate` using the canonical sequence: `EVENT_FILE_UPLOADED` → `EVENT_PROMPT_INJECTED` → `EVENT_DOCUMENT_PARSED` → `EVENT_SEND_CLICKED` → `EVENT_DISPATCH_ACKNOWLEDGED` → …; out-of-order or skipped predecessors raise with reasons.
- Uploader verifies attachments and emits `EVENT_FILE_UPLOADED {byte_count, attempt}`; prefers a direct hidden file input, adds resilient selectors, and exposes `last_error`. Orchestrator raises `UploadFailureError` if the event is missing.
- Orchestrator emits `EVENT_PROMPT_INJECTED` on text injection and `EVENT_DOCUMENT_PARSED` on attachment parse; `ResponseDetectionTimeoutError` distinguishes a sent prompt with no detected reply.
- Stream monitor emits `EVENT_GENERATION_FINISHED` before output copy on the fallback path and prevents duplicate `EVENT_STREAMING_GENERATION` emissions.
- CLI treats outputs containing “ERROR […]” or “Failed: N>0” as failures and returns `category=processing_failed` with a non-zero exit.

**Migration notes**
- Emit lifecycle events in order; ensure `EVENT_FILE_UPLOADED` and `EVENT_PROMPT_INJECTED` precede downstream events or the gate will reject.
- Catch `ResponseDetectionTimeoutError` and `UploadFailureError`.
- Update CLI wrappers to expect non-zero exit and parse `processing_failed` envelopes on partial failures.
- If you override upload selectors, include `file_input_selectors`; treat `EVENT_FILE_UPLOADED` (not `EVENT_DOCUMENT_PARSED`) as the upload success signal.

<sup>Written for commit 08fa552e11f7e418bc5fdd6649df2f32bea52e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

