### PR TITLE
fix: emit document parsed before prompt injected

### DIFF
--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -483,11 +483,14 @@ class CoreOrchestrator(ICoreAggregate):
                 "EVENT_FILE_UPLOADED was not emitted"
             )
 
-        self._injector.inject_text(page, PromptText(prompt))
-        emitter.emit(EVENT_PROMPT_INJECTED, {"file": str(filepath), "char_count": len(prompt)})
         emitter.emit(EVENT_DOCUMENT_PARSED, {"file": str(filepath), "file_size_bytes": filepath.stat().st_size})
         if not state.document_parsed:
-            raise RuntimeError("Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete")
+            raise RuntimeError(
+                "Cannot inject prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete"
+            )
+
+        self._injector.inject_text(page, PromptText(prompt))
+        emitter.emit(EVENT_PROMPT_INJECTED, {"file": str(filepath), "char_count": len(prompt)})
 
         self._sender.click_send(page, emitter, document_parsed=HeadlessFlag(state.document_parsed))
         if not state.dispatch_acknowledged:

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -432,6 +432,7 @@ class CoreOrchestrator(ICoreAggregate):
         custom_prompt_path: Path | None = None,
         rel_path: Path | None = None,
         cfg: AppConfig | None = None,
+        emitter: LifecycleEmitter | None = None,
     ) -> str:
         """Send a prompt file while enforcing event-backed lifecycle gates."""
         active_cfg = cfg or build_app_config(
@@ -443,7 +444,7 @@ class CoreOrchestrator(ICoreAggregate):
         logger = self._observability.get_logger()
         state = LifecycleState()
         gate = LifecycleGate(logger)
-        emitter = LifecycleEmitter(logger, gate=gate)
+        emitter = emitter or LifecycleEmitter(logger, gate=gate)
         for lifecycle_event in PIPELINE_EVENT_SEQUENCE:
 
             def mark_lifecycle_event(
@@ -508,7 +509,6 @@ class CoreOrchestrator(ICoreAggregate):
 
         if response and len(response.strip()) > 0:
             logger.info("Received response (%d chars)", len(response))
-            emitter.emit(EVENT_OUTPUT_COPIED, {"file": str(filepath), "char_count": len(response.strip())})
             return response.strip()
         raise ResponseDetectionTimeoutError(
             f"Response detection timeout after {stream_timeout_sec}s: no response detected"
@@ -549,6 +549,7 @@ class CoreOrchestrator(ICoreAggregate):
         custom_prompt_path: Path | None,
         rel_path: Path | None,
         cfg: AppConfig | None = None,
+        emitter: LifecycleEmitter | None = None,
     ) -> str:
         """Send a prompt file and return the AI response text."""
         active_cfg = cfg or build_app_config(
@@ -560,7 +561,9 @@ class CoreOrchestrator(ICoreAggregate):
 
         with self._browser.browser_session(active_cfg) as bctx:
             page = bctx.pages[0] if bctx.pages else bctx.new_page()
-            return self.send_file(page, filepath, timeout_sec, custom_prompt_path, rel_path, active_cfg)
+            return self.send_file(
+                page, filepath, timeout_sec, custom_prompt_path, rel_path, active_cfg, emitter=emitter
+            )
 
     def _emitter(self) -> LifecycleEmitter:
         return LifecycleEmitter(self._observability.get_logger())
@@ -612,7 +615,10 @@ class CoreOrchestrator(ICoreAggregate):
         role_prompt = load_role_prompt(proc_file, cfg.prompt_file, rel_path)
         full_prompt = f"{role_prompt}\n\n{prompt}" if role_prompt else prompt
 
-        text = self._send_file(proc_file, cfg.request_timeout, cfg.prompt_file, rel_path, cfg)
+        emitter = LifecycleEmitter(
+            self._observability.get_logger(), gate=LifecycleGate(self._observability.get_logger())
+        )
+        text = self._send_file(proc_file, cfg.request_timeout, cfg.prompt_file, rel_path, cfg, emitter=emitter)
         dur = time.time() - t0
 
         text = strip_input_from_output(text, full_prompt)
@@ -621,6 +627,14 @@ class CoreOrchestrator(ICoreAggregate):
         self._saver.write_output(
             out_path, ResponseText(text), ctx, FilePath(str(rel_path)), dur, len(prompt), OutputChars(len(text))
         )
+        if not out_path.is_file() or out_path.stat().st_size <= 0:
+            raise OSError(f"Output artifact was not written successfully: {out_path}")
+        if QwenEventType.GENERATION_FINISHED in emitter.completed:
+            emitter.emit(EVENT_OUTPUT_COPIED, {"file": str(out_path), "char_count": len(text)})
+        else:
+            self._observability.get_logger().warning(
+                "Output saved without lifecycle emission: EVENT_GENERATION_FINISHED was not accepted"
+            )
         self._audit.log(
             "SUCCESS", ctx, FilePath(str(rel_path)), FilePath(str(out_path)), dur, len(prompt), OutputChars(len(text))
         )

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -151,8 +151,11 @@ class FileUploader(IUploadProtocol):
         if direct_input is not None:
             log.debug("Setting file through direct Qwen file input selector")
             direct_input.set_input_files(str(filepath))
-            self._wait_for_attachment_card(page)
-            return True
+            try:
+                self._wait_for_attachment_card(page, filepath)
+                return True
+            except (TimeoutError, Error):
+                log.debug("Direct file input did not render an attachment card; trying chooser fallback")
 
         log.debug("Opening mode-select dropdown using primary/fallback selectors")
         dropdown_element = first_visible_locator(page, self.dropdown_selectors, timeout_ms=1000)
@@ -177,7 +180,7 @@ class FileUploader(IUploadProtocol):
         log.debug("Setting file on file chooser: %s", filepath.name)
         fc.value.set_files(str(filepath))
 
-        self._wait_for_attachment_card(page)
+        self._wait_for_attachment_card(page, filepath)
         return True
 
     def _find_file_input(self, page: Page) -> Any | None:
@@ -191,13 +194,29 @@ class FileUploader(IUploadProtocol):
                 continue
         return None
 
-    def _wait_for_attachment_card(self, page: Page) -> None:
-        """Wait for a positive attachment indicator after setting a file."""
-        log.debug("Waiting for file card attachment indicator to render and complete parsing")
-        card_selector_str = ", ".join(self.card_selectors)
-        page.locator(card_selector_str).first.wait_for(state="visible", timeout=self.card_render_timeout_ms)
+    def _wait_for_attachment_card(self, page: Page, filepath: Path) -> None:
+        """Wait for the uploaded filename to appear in Qwen's live attachment DOM."""
+        log.debug("Waiting for Qwen attachment filename node: %s", filepath.name)
+        filename_stem = filepath.stem
+        filename_selectors = (
+            ".fileitem-file-name-text",
+            ".fileitem-file-name",
+            "[class*='fileitem-file-name-text']",
+            "[class*='fileitem-file-name']",
+        )
+        for selector in filename_selectors:
+            matching = page.locator(selector).filter(has_text=filename_stem).last
+            try:
+                matching.wait_for(state="visible", timeout=self.card_render_timeout_ms)
+                break
+            except (TimeoutError, Error):
+                continue
+        else:
+            card_selector_str = ", ".join(self.card_selectors)
+            page.locator(card_selector_str).last.wait_for(state="visible", timeout=self.card_render_timeout_ms)
+
         with contextlib.suppress(Exception):
-            page.locator("[class*='loading'], [class*='parsing'], [class*='spin'], .ant-spin").first.wait_for(
+            page.locator("[class*='loading'], [class*='parsing'], [class*='spin'], .ant-spin").last.wait_for(
                 state="hidden", timeout=5000
             )
         time.sleep(2.0)

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -5,7 +5,6 @@ Implements IUploadProtocol.
 
 from __future__ import annotations
 
-import contextlib
 import time
 from pathlib import Path
 from typing import Any
@@ -207,14 +206,35 @@ class FileUploader(IUploadProtocol):
         while time.monotonic() < deadline:
             matches = self._attachment_match_count(page, filepath)
             if matches > baseline_matches or (baseline_matches == 0 and matches > 0):
-                with contextlib.suppress(Exception):
-                    page.locator("[class*='loading'], [class*='parsing'], [class*='spin'], .ant-spin").last.wait_for(
-                        state="hidden", timeout=5000
-                    )
-                time.sleep(2.0)
+                self._wait_for_parse_ready(page, filepath)
                 return
             page.wait_for_timeout(100)
         raise TimeoutError(f"Exact uploaded filename was not rendered in Qwen attachment DOM: {filepath.name}")
+
+    def _wait_for_parse_ready(self, page: Page, filepath: Path) -> None:
+        """Wait for Qwen's attachment-specific parse-ready icon before continuing."""
+        deadline = time.monotonic() + (self.card_render_timeout_ms / 1000)
+        while time.monotonic() < deadline:
+            card = page.locator(".fileitem-btn").filter(has_text=filepath.stem).last
+            try:
+                if card.count() == 0:
+                    page.wait_for_timeout(100)
+                    continue
+                pending = any(
+                    card.locator(selector).count() > 0 and card.locator(selector).last.is_visible()
+                    for selector in self.config.parse_pending_selectors
+                )
+                ready = any(
+                    card.locator(selector).count() > 0 and card.locator(selector).last.is_visible()
+                    for selector in self.config.parse_ready_selectors
+                )
+                if ready and not pending:
+                    log.debug("Qwen document parsing is ready for %s", filepath.name)
+                    return
+            except (TimeoutError, Error):
+                pass
+            page.wait_for_timeout(100)
+        raise TimeoutError(f"Qwen document parsing did not reach ready state: {filepath.name}")
 
     def _attachment_match_count(self, page: Page, filepath: Path) -> int:
         """Count exact filename matches, preferring full filename nodes over stem-only nodes."""

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -148,15 +148,21 @@ class FileUploader(IUploadProtocol):
     def _try_upload_attempt(self, page: Page, filepath: Path) -> bool:
         """Execute a single attempt to attach a file via the Qwen Web UI."""
         direct_input = self._find_file_input(page)
+        baseline_matches = self._attachment_match_count(page, filepath)
         if direct_input is not None:
-            log.debug("Setting file through direct Qwen file input selector")
-            direct_input.set_input_files(str(filepath))
             try:
-                self._wait_for_attachment_card(page, filepath)
+                log.debug("Setting file through direct Qwen file input selector")
+                direct_input.set_input_files(str(filepath))
+                self._wait_for_attachment_card(page, filepath, baseline_matches)
                 return True
             except (TimeoutError, Error):
-                log.debug("Direct file input did not render an attachment card; trying chooser fallback")
+                if self._attachment_match_count(page, filepath) > baseline_matches:
+                    log.debug("Direct upload rendered the exact attachment after timeout; skipping chooser fallback")
+                    return True
+                log.debug("Direct file input did not render an exact attachment; trying chooser fallback")
 
+        if self._attachment_match_count(page, filepath) > baseline_matches:
+            return True
         log.debug("Opening mode-select dropdown using primary/fallback selectors")
         dropdown_element = first_visible_locator(page, self.dropdown_selectors, timeout_ms=1000)
 
@@ -180,7 +186,7 @@ class FileUploader(IUploadProtocol):
         log.debug("Setting file on file chooser: %s", filepath.name)
         fc.value.set_files(str(filepath))
 
-        self._wait_for_attachment_card(page, filepath)
+        self._wait_for_attachment_card(page, filepath, baseline_matches)
         return True
 
     def _find_file_input(self, page: Page) -> Any | None:
@@ -194,32 +200,45 @@ class FileUploader(IUploadProtocol):
                 continue
         return None
 
-    def _wait_for_attachment_card(self, page: Page, filepath: Path) -> None:
-        """Wait for the uploaded filename to appear in Qwen's live attachment DOM."""
-        log.debug("Waiting for Qwen attachment filename node: %s", filepath.name)
-        filename_stem = filepath.stem
-        filename_selectors = (
-            ".fileitem-file-name-text",
-            ".fileitem-file-name",
-            "[class*='fileitem-file-name-text']",
-            "[class*='fileitem-file-name']",
-        )
-        for selector in filename_selectors:
-            matching = page.locator(selector).filter(has_text=filename_stem).last
+    def _wait_for_attachment_card(self, page: Page, filepath: Path, baseline_matches: int = 0) -> None:
+        """Wait for a newly rendered exact filename node in Qwen's live attachment DOM."""
+        log.debug("Waiting for exact Qwen attachment filename node: %s", filepath.name)
+        deadline = time.monotonic() + (self.card_render_timeout_ms / 1000)
+        while time.monotonic() < deadline:
+            matches = self._attachment_match_count(page, filepath)
+            if matches > baseline_matches or (baseline_matches == 0 and matches > 0):
+                with contextlib.suppress(Exception):
+                    page.locator("[class*='loading'], [class*='parsing'], [class*='spin'], .ant-spin").last.wait_for(
+                        state="hidden", timeout=5000
+                    )
+                time.sleep(2.0)
+                return
+            page.wait_for_timeout(100)
+        raise TimeoutError(f"Exact uploaded filename was not rendered in Qwen attachment DOM: {filepath.name}")
+
+    def _attachment_match_count(self, page: Page, filepath: Path) -> int:
+        """Count exact filename matches, preferring full filename nodes over stem-only nodes."""
+        normalized_name = " ".join(filepath.name.split()).casefold()
+        normalized_stem = " ".join(filepath.stem.split()).casefold()
+        for selector, expected in (
+            (".fileitem-file-name", normalized_name),
+            ("[class*='fileitem-file-name']", normalized_name),
+            (".fileitem-file-name-text", normalized_stem),
+            ("[class*='fileitem-file-name-text']", normalized_stem),
+        ):
             try:
-                matching.wait_for(state="visible", timeout=self.card_render_timeout_ms)
-                break
+                locator = page.locator(selector)
+                visible_texts = []
+                for index in range(locator.count()):
+                    item = locator.nth(index)
+                    if item.is_visible():
+                        visible_texts.append(item.inner_text())
             except (TimeoutError, Error):
                 continue
-        else:
-            card_selector_str = ", ".join(self.card_selectors)
-            page.locator(card_selector_str).last.wait_for(state="visible", timeout=self.card_render_timeout_ms)
-
-        with contextlib.suppress(Exception):
-            page.locator("[class*='loading'], [class*='parsing'], [class*='spin'], .ant-spin").last.wait_for(
-                state="hidden", timeout=5000
-            )
-        time.sleep(2.0)
+            matches = sum(" ".join(text.split()).casefold() == expected for text in visible_texts)
+            if matches:
+                return matches
+        return 0
 
     # ─── Block 3: Dunder Methods, Factories & Helpers ─────
 

--- a/modules/core/src/capabilities_stream_monitor.py
+++ b/modules/core/src/capabilities_stream_monitor.py
@@ -71,11 +71,15 @@ class StreamMonitor(IStreamProtocol):
             return False
 
     def is_thinking_active(self, page: Page) -> bool:
-        """Check if thinking indicator is active."""
+        """Check whether Qwen's live thinking/status indicator is visible."""
         try:
-            typing_selector = ".thinking:not([style*='display: none']), [class*='thinking']"
-            return is_selector_visible(page, typing_selector)
-        except Error:
+            thinking_selector = (
+                "[class*='qwen-chat-thinking-status-card']:not([class*='completed']), "
+                "[class*='thinking']:not([class*='completed']), "
+                "[class*='typing'], [class*='streaming']"
+            )
+            return is_selector_visible(page, thinking_selector)
+        except Exception:
             return False
 
     def wait_for_response(
@@ -101,9 +105,6 @@ class StreamMonitor(IStreamProtocol):
         has_streaming = False
 
         log.info("Waiting for AI response (timeout: %ds)", timeout_sec)
-        emitter.emit(EVENT_THINKING_STARTED)
-        has_thinking = True
-
         baseline_text: str | None = _dom_latest(page)
 
         start = time.time()
@@ -113,9 +114,15 @@ class StreamMonitor(IStreamProtocol):
         while time.time() - start < timeout_sec:
             try:
                 count = count_messages(page)
-                if count >= msg_count_before:
+                if not has_thinking and self.is_thinking_active(page):
+                    emitter.emit(EVENT_THINKING_STARTED, {"source": "qwen-thinking-dom"})
+                    has_thinking = True
+                if count > msg_count_before:
                     text = _dom_latest(page)
                     if text is not None and should_treat_as_new_response(text, baseline_text, int(active_min_len)):
+                        if not has_thinking:
+                            emitter.emit(EVENT_THINKING_STARTED, {"source": "response-start-fallback"})
+                            has_thinking = True
                         if text == last_text:
                             stable_count += 1
                             is_complete = self.is_generation_complete(page)

--- a/modules/shared/src/taxonomy_config_vo.py
+++ b/modules/shared/src/taxonomy_config_vo.py
@@ -68,6 +68,8 @@ class UploadConfig:
             "[class*='file-card']",
             "[class*='file-item']",
             "[class*='fileitem']",
+            "[class*='fileitem-file-name']",
+            "[class*='file-content-info']",
         )
     )
 

--- a/modules/shared/src/taxonomy_config_vo.py
+++ b/modules/shared/src/taxonomy_config_vo.py
@@ -60,6 +60,23 @@ class UploadConfig:
         )
     )
 
+    parse_ready_selectors: Sequence[str] = field(
+        default_factory=lambda: (
+            ".fileitem-icon:not([class*='loading']):not([class*='spin'])",
+            "[class*='fileitem-icon']:not([class*='loading']):not([class*='spin'])",
+        )
+    )
+
+    parse_pending_selectors: Sequence[str] = field(
+        default_factory=lambda: (
+            ".fileitem-loading-icon",
+            "[class*='loading']",
+            "[class*='parsing']",
+            "[class*='spin']",
+            ".ant-spin",
+        )
+    )
+
     card_selectors: Sequence[str] = field(
         default_factory=lambda: (
             ".file-card-list",

--- a/modules/shared/src/taxonomy_core_entity.py
+++ b/modules/shared/src/taxonomy_core_entity.py
@@ -245,6 +245,11 @@ class LifecycleEmitter:
         self._logger = logger or logging.getLogger("lifecycle")
         self._gate = gate
 
+    @property
+    def completed(self) -> tuple[QwenEventType, ...]:
+        """Return accepted events from the attached lifecycle gate."""
+        return self._gate.completed if self._gate is not None else ()
+
     def on(self, event_name: QwenEventType | str, callback: LifecycleCallback) -> None:
         """Register a callback for a named lifecycle event."""
         key = str(event_name)

--- a/modules/shared/src/taxonomy_core_event.py
+++ b/modules/shared/src/taxonomy_core_event.py
@@ -68,8 +68,8 @@ EVENT_OUTPUT_COPIED = QwenEventType.OUTPUT_COPIED
 PIPELINE_EVENT_SEQUENCE: tuple[QwenEventType, ...] = (
     QwenEventType.WEB_LOADED,
     QwenEventType.FILE_UPLOADED,
-    QwenEventType.PROMPT_INJECTED,
     QwenEventType.DOCUMENT_PARSED,
+    QwenEventType.PROMPT_INJECTED,
     QwenEventType.SEND_CLICKED,
     QwenEventType.DISPATCH_ACKNOWLEDGED,
     QwenEventType.THINKING_STARTED,

--- a/tests/fixtures/qwen_fixture.html
+++ b/tests/fixtures/qwen_fixture.html
@@ -61,7 +61,7 @@
     <input id="filesUpload" type="file" />
 
     <div class="message-input-column-file" id="attachmentCard">
-      <div class="fileitem-btn"><span id="attName">doc.md</span></div>
+      <div class="fileitem-btn"><span id="attName" class="fileitem-file-name-text">doc.md</span></div>
       <div class="fileitem-file-size" id="attSize">0 B</div>
       <div class="fileitem-file-size" id="attStatus">Parsing...</div>
     </div>

--- a/tests/fixtures/qwen_fixture.html
+++ b/tests/fixtures/qwen_fixture.html
@@ -61,7 +61,7 @@
     <input id="filesUpload" type="file" />
 
     <div class="message-input-column-file" id="attachmentCard">
-      <div class="fileitem-btn"><span id="attName" class="fileitem-file-name-text">doc.md</span></div>
+      <div class="fileitem-btn"><span id="attIcon" class="fileitem-icon"></span><span id="attName" class="fileitem-file-name-text">doc.md</span></div>
       <div class="fileitem-file-size" id="attSize">0 B</div>
       <div class="fileitem-file-size" id="attStatus">Parsing...</div>
     </div>
@@ -96,6 +96,7 @@
   const modeSelect = $("modeSelect");
   const modeDropdown = $("modeDropdown");
   const attStatus = $("attStatus");
+  const attIcon = $("attIcon");
 
   function syncSendEnabled() {
     const hasText = chatInput.value.trim().length > 0;
@@ -126,10 +127,15 @@
     $("attName").textContent = file.name;
     $("attSize").textContent = file.size + " B";
     attStatus.textContent = "Parsing...";
+    attIcon.className = "fileitem-loading-icon";
     attachmentCard.classList.add("visible");
     syncSendEnabled();
     // simulate Qwen finishing parse after a short delay
-    setTimeout(() => { attStatus.textContent = "Ready"; syncSendEnabled(); }, 600);
+    setTimeout(() => {
+      attStatus.textContent = "Ready";
+      attIcon.className = "fileitem-icon";
+      syncSendEnabled();
+    }, 600);
   });
 
   // Send button -> emulate dispatch + assistant reply

--- a/tests/test_core_pipeline_routing_gates.py
+++ b/tests/test_core_pipeline_routing_gates.py
@@ -29,13 +29,20 @@ from modules.shared.src.taxonomy_core_vo import (
 
 
 def _make_orchestrator() -> CoreOrchestrator:
+    saver = MagicMock()
+
+    def write_output(path: Path, content: object, *_args: object, **_kwargs: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(content), encoding="utf-8")
+
+    saver.write_output.side_effect = write_output
     return CoreOrchestrator(
         browser=MagicMock(),
         injector=MagicMock(),
         sender=MagicMock(),
         streamer=MagicMock(),
         uploader=MagicMock(),
-        saver=MagicMock(),
+        saver=saver,
         audit=MagicMock(),
         observability=MagicMock(get_logger=MagicMock(return_value=MagicMock())),
         workspace=MagicMock(),

--- a/tests/test_file_uploader.py
+++ b/tests/test_file_uploader.py
@@ -98,7 +98,7 @@ class TestUploadAttachment:
         with patch.object(FileUploader, "_wait_for_attachment_card"):
             result = FileUploader().upload_attachment(page, f)
         assert result is True
-        page.locator.assert_called_once_with("#filesUpload")
+        assert page.locator.call_args_list[0].args == ("#filesUpload",)
         direct_input.set_input_files.assert_called_once_with(str(f))
 
     def test_emitter_called_on_success(self, tmp_path):

--- a/tests/test_pipeline_fixtures.py
+++ b/tests/test_pipeline_fixtures.py
@@ -288,6 +288,12 @@ def test_file_moves_to_done_on_success(tmp_path: Path, mocker: Any) -> None:
     proc_file.write_text("Test prompt content")
 
     mock_saver = mocker.MagicMock()
+
+    def write_output(path: Path, *_args: object, **_kwargs: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("Response text", encoding="utf-8")
+
+    mock_saver.write_output.side_effect = write_output
     mock_audit = mocker.MagicMock()
     orchestrator = _make_orchestrator(mocker, audit=mock_audit)
     orchestrator._saver = mock_saver

--- a/tests/test_taxonomy_core_event_refactor.py
+++ b/tests/test_taxonomy_core_event_refactor.py
@@ -37,8 +37,8 @@ def test_pipeline_event_sequence_is_canonical_and_ordered() -> None:
     assert PIPELINE_EVENT_SEQUENCE == (
         QwenEventType.WEB_LOADED,
         QwenEventType.FILE_UPLOADED,
-        QwenEventType.PROMPT_INJECTED,
         QwenEventType.DOCUMENT_PARSED,
+        QwenEventType.PROMPT_INJECTED,
         QwenEventType.SEND_CLICKED,
         QwenEventType.DISPATCH_ACKNOWLEDGED,
         QwenEventType.THINKING_STARTED,
@@ -47,8 +47,8 @@ def test_pipeline_event_sequence_is_canonical_and_ordered() -> None:
         QwenEventType.OUTPUT_COPIED,
     )
     assert EVENT_ORDER[QwenEventType.WEB_LOADED] < EVENT_ORDER[QwenEventType.FILE_UPLOADED]
-    assert EVENT_ORDER[QwenEventType.FILE_UPLOADED] < EVENT_ORDER[QwenEventType.PROMPT_INJECTED]
-    assert EVENT_ORDER[QwenEventType.PROMPT_INJECTED] < EVENT_ORDER[QwenEventType.DOCUMENT_PARSED]
+    assert EVENT_ORDER[QwenEventType.FILE_UPLOADED] < EVENT_ORDER[QwenEventType.DOCUMENT_PARSED]
+    assert EVENT_ORDER[QwenEventType.DOCUMENT_PARSED] < EVENT_ORDER[QwenEventType.PROMPT_INJECTED]
     assert EVENT_ORDER[QwenEventType.DOCUMENT_PARSED] < EVENT_ORDER[QwenEventType.SEND_CLICKED]
     assert EVENT_ORDER[QwenEventType.SEND_CLICKED] < EVENT_ORDER[QwenEventType.DISPATCH_ACKNOWLEDGED]
     assert EVENT_ORDER[QwenEventType.DISPATCH_ACKNOWLEDGED] < EVENT_ORDER[QwenEventType.THINKING_STARTED]
@@ -93,10 +93,14 @@ def test_entity_remains_for_stateful_runtime_behavior() -> None:
 def test_lifecycle_gate_rejects_skipped_predecessors_and_records_reason() -> None:
     gate = LifecycleGate()
     gate.validate(QwenEventType.WEB_LOADED)
-    with pytest.raises(RuntimeError, match="EVENT_FILE_UPLOADED"):
+    with pytest.raises(RuntimeError, match="EVENT_DOCUMENT_PARSED"):
         gate.validate(QwenEventType.PROMPT_INJECTED)
     assert gate.rejections[0]["event"] == "EVENT_PROMPT_INJECTED"
-    assert "EVENT_FILE_UPLOADED" in gate.rejections[0]["reason"]
+    assert "EVENT_DOCUMENT_PARSED" in gate.rejections[0]["reason"]
+
+    gate.validate(QwenEventType.FILE_UPLOADED)
+    with pytest.raises(RuntimeError, match="EVENT_DOCUMENT_PARSED"):
+        gate.validate(QwenEventType.PROMPT_INJECTED)
 
 
 def test_error_taxonomy_has_new_source_and_legacy_facade() -> None:


### PR DESCRIPTION
Correct the lifecycle order to WEB_LOADED -> FILE_UPLOADED -> DOCUMENT_PARSED -> PROMPT_INJECTED -> SEND_CLICKED. Add regression coverage for the canonical sequence and predecessor gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `DOCUMENT_PARSED` before injecting prompts and enforce predecessor gates. The uploader now waits for Qwen’s parse‑ready state and a visible, exact attachment filename; it prefers the direct input and falls back to the chooser only when no exact match renders. `THINKING_STARTED` fires only when Qwen shows a thinking indicator or when a response starts, and `OUTPUT_COPIED` only after `GENERATION_FINISHED` and a saved, non-empty artifact.

- **Migration**
  - Update analytics/alerts expecting `PROMPT_INJECTED` before `DOCUMENT_PARSED` or matching the old “Cannot send prompt…” text; the new error is “Cannot inject prompt…”.
  - Expect later/fewer `THINKING_STARTED` and `OUTPUT_COPIED` events; listen to `GENERATION_FINISHED` or use saved artifacts if you need earlier signals.

<sup>Written for commit 4534c1eb7a5aaaf4b936ae68d6f5f9ac033d5a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

