### PR TITLE
fix: stabilize single-file response monitoring and uploads

### DIFF
--- a/modules/cli/src/surface_cli_login_command.py
+++ b/modules/cli/src/surface_cli_login_command.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-from collections.abc import Callable
-
 from modules.shared.src.contract_core_aggregate import ICoreAggregate
 from modules.shared.src.taxonomy_config_vo import AppConfig
-from modules.shared.src.utility_core_response import error_response, safe_handle, success_response
+from modules.shared.src.utility_core_response import safe_handle, success_response
 
 
 @safe_handle

--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -640,10 +640,20 @@ class CoreOrchestrator(ICoreAggregate):
         self._saver.write_output(
             out_path, ResponseText(text), ctx, FilePath(str(rel_path)), dur, len(prompt), OutputChars(len(text))
         )
-        if not out_path.is_file() or out_path.stat().st_size <= 0:
-            raise OSError(f"Output artifact was not written successfully: {out_path}")
+        try:
+            output_size = out_path.stat().st_size
+            if not out_path.is_file() or output_size <= 0:
+                raise OSError(f"Output artifact was not written successfully: {out_path}")
+            with out_path.open("rb") as output_file:
+                if not output_file.read(1):
+                    raise OSError(f"Output artifact is not readable or empty: {out_path}")
+        except OSError as exc:
+            raise OSError(f"Output artifact verification failed: {out_path}") from exc
         if QwenEventType.GENERATION_FINISHED in emitter.completed:
-            emitter.emit(EVENT_OUTPUT_COPIED, {"file": str(out_path), "char_count": len(text)})
+            emitter.emit(
+                EVENT_OUTPUT_COPIED,
+                {"file": str(out_path), "char_count": len(text), "file_size_bytes": output_size},
+            )
         else:
             self._observability.get_logger().warning(
                 "Output saved without lifecycle emission: EVENT_GENERATION_FINISHED was not accepted"

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -235,11 +235,8 @@ class FileUploader(IUploadProtocol):
             ("", normalized_name),
         ):
             try:
-                if selector:
-                    locator = page.locator(selector)
-                else:
-                    # Broadest fallback: find any visible text node containing the filename
-                    locator = page.locator("body")
+                # Broadest fallback: find any visible text node containing the filename
+                locator = page.locator(selector) if selector else page.locator("body")
                 visible_texts = []
                 for index in range(locator.count()):
                     item = locator.nth(index)

--- a/modules/root_mcp_main_entry.py
+++ b/modules/root_mcp_main_entry.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import sys
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any
+from typing import Any, cast
 
 from mcp.server import InitializationOptions, Server
 from mcp.server.stdio import stdio_server
@@ -26,6 +26,7 @@ from mcp.types import (
 from mcp_types._types import ServerCapabilities, ToolsCapability
 
 from modules.core.src.capabilities_observability_setup import ObservabilitySetup
+from modules.core.src.root_core_container import SharedContainer
 from modules.mcp.src.surface_mcp_tool_command import McpToolCommand
 from modules.shared.src.taxonomy_core_constant import DEFAULT_LOG
 
@@ -46,8 +47,6 @@ _container: McpToolCommand | None = None
 def _get_tools() -> McpToolCommand:
     """Return the MCP surface tool command, wiring the container once."""
     global _container
-    from modules.core.src.root_core_container import SharedContainer
-
     if _container is None:
         shared = SharedContainer(use_linux_guard=False)
         shared.wire()
@@ -90,7 +89,7 @@ TOOLS: list[Tool] = [
     Tool(
         name="qwen_send_prompt",
         description="Send a direct text prompt string to chat.qwen.ai and return AI answer.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "prompt": {"type": "string"},
@@ -103,7 +102,7 @@ TOOLS: list[Tool] = [
     Tool(
         name="qwen_process_single",
         description="Process a single Markdown prompt file (1:1 CLI Single File Mode).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "input_file": {"type": "string"},
@@ -116,7 +115,7 @@ TOOLS: list[Tool] = [
     Tool(
         name="qwen_process_batch",
         description="Process all prompt files inside an input directory (1:1 CLI Batch Mode).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "input_dir": {"type": "string", "default": None},
@@ -128,7 +127,7 @@ TOOLS: list[Tool] = [
     Tool(
         name="qwen_start_watcher",
         description="Run folder watcher loop to continuously monitor input/ for new files.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "interval_sec": {"type": "integer", "default": 3},
@@ -139,12 +138,12 @@ TOOLS: list[Tool] = [
     Tool(
         name="qwen_setup_session",
         description="Launch visible browser on chat.qwen.ai for manual login / session setup.",
-        inputSchema={"type": "object", "properties": {}},
+        input_schema={"type": "object", "properties": {}},
     ),
     Tool(
         name="qwen_get_audit_log",
         description="Fetch latest entries from the JSONL audit trail log.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"limit": {"type": "integer", "default": 20}},
         },
@@ -171,35 +170,75 @@ qwen_start_watcher = _async_tool("qwen_start_watcher")
 qwen_setup_session = _async_tool("qwen_setup_session")
 qwen_get_audit_log = _async_tool("qwen_get_audit_log")
 
+
 # Legacy _tools() factory for mock patching
-def _tools():
+def _tools() -> McpToolCommand:
     """Legacy compatibility: return the MCP tool command instance."""
     return _get_tools()
+
 
 GENERATED_TOOLS = TOOL_HANDLERS  # For backward-compat imports
 
 # ─── Legacy MCP_TOOL_SPECS for test compatibility ──────────────────────────
 MCP_TOOL_SPECS: list[dict[str, Any]] = [
-    {"name": "qwen_send_prompt", "method": "send_prompt", "doc": "Send a direct text prompt string to chat.qwen.ai and return AI answer.", "params": [("prompt", "str", True), ("timeout_sec", "int", False, 120), ("headless", "bool", False, True)]},
-    {"name": "qwen_process_single", "method": "process_single", "doc": "Process a single Markdown prompt file (1:1 CLI Single File Mode).", "params": [("input_file", "str", True), ("output_file", "Any", False, None), ("headless", "bool", False, True)]},
-    {"name": "qwen_process_batch", "method": "process_batch", "doc": "Process all prompt files inside an input directory (1:1 CLI Batch Mode).", "params": [("input_dir", "Any", False, None), ("output_dir", "Any", False, None), ("headless", "bool", False, True)]},
-    {"name": "qwen_start_watcher", "method": "start_watcher", "doc": "Run folder watcher loop to continuously monitor input/ for new files.", "params": [("interval_sec", "int", False, 3), ("headless", "bool", False, True)]},
-    {"name": "qwen_setup_session", "method": "setup_session", "doc": "Launch visible browser on chat.qwen.ai for manual login / session setup.", "params": []},
-    {"name": "qwen_get_audit_log", "method": "get_audit_log", "doc": "Fetch latest entries from the JSONL audit trail log.", "params": [("limit", "int", False, 20)]},
+    {
+        "name": "qwen_send_prompt",
+        "method": "send_prompt",
+        "doc": "Send a direct text prompt string to chat.qwen.ai and return AI answer.",
+        "params": [("prompt", "str", True), ("timeout_sec", "int", False, 120), ("headless", "bool", False, True)],
+    },
+    {
+        "name": "qwen_process_single",
+        "method": "process_single",
+        "doc": "Process a single Markdown prompt file (1:1 CLI Single File Mode).",
+        "params": [("input_file", "str", True), ("output_file", "Any", False, None), ("headless", "bool", False, True)],
+    },
+    {
+        "name": "qwen_process_batch",
+        "method": "process_batch",
+        "doc": "Process all prompt files inside an input directory (1:1 CLI Batch Mode).",
+        "params": [
+            ("input_dir", "Any", False, None),
+            ("output_dir", "Any", False, None),
+            ("headless", "bool", False, True),
+        ],
+    },
+    {
+        "name": "qwen_start_watcher",
+        "method": "start_watcher",
+        "doc": "Run folder watcher loop to continuously monitor input/ for new files.",
+        "params": [("interval_sec", "int", False, 3), ("headless", "bool", False, True)],
+    },
+    {
+        "name": "qwen_setup_session",
+        "method": "setup_session",
+        "doc": "Launch visible browser on chat.qwen.ai for manual login / session setup.",
+        "params": [],
+    },
+    {
+        "name": "qwen_get_audit_log",
+        "method": "get_audit_log",
+        "doc": "Fetch latest entries from the JSONL audit trail log.",
+        "params": [("limit", "int", False, 20)],
+    },
 ]
 
+
 # ─── Legacy helpers for test compatibility ──────────────────────────────────
-def _get_mcp_app():
+def _get_mcp_app() -> Any:
     """Legacy: raise ImportError since MCP 2.0.0 uses Server."""
     raise ImportError("The 'mcp' Python package is required to run the MCP server. Install it via 'pip install mcp'.")
 
-def _register_tool(fn):
+
+def _register_tool(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Legacy: no-op for MCP 2.0.0 (tools are registered via Server callbacks)."""
     return fn
 
-def _register_tools():
+
+def _register_tools() -> None:
     """Legacy: no-op for MCP 2.0.0."""
     pass
+
 
 async def _handle_list_tools() -> ListToolsResult:
     return ListToolsResult(tools=TOOLS)
@@ -220,23 +259,24 @@ async def _handle_call_tool(name: str, arguments: dict[str, Any] | None) -> Call
         return CallToolResult(content=[], is_error=True)
 
 
-async def _handle_list_resources():
+async def _handle_list_resources() -> ListResourcesResult:
     """Return empty resource list."""
     return ListResourcesResult(resources=[])
 
 
-async def _handle_read_resource(uri: str):
+async def _handle_read_resource(_uri: str) -> ReadResourceResult:
     """Return empty resource content."""
     return ReadResourceResult(contents=[])
 
 
 # ─── Server runner ──────────────────────────────────────────────────────────
 
+
 def run_mcp_server() -> None:
     """Run the MCP server over stdio."""
     ObservabilitySetup(DEFAULT_LOG).setup_observability()
 
-    async def serve():
+    async def serve() -> None:
         async with stdio_server() as (read_stream, write_stream):
             capabilities = ServerCapabilities(tools=ToolsCapability())
             init_opts = InitializationOptions(
@@ -247,10 +287,10 @@ def run_mcp_server() -> None:
             server = Server(
                 name="Qwen-Web",
                 version="4.1.0",
-                on_list_tools=_handle_list_tools,
-                on_call_tool=_handle_call_tool,
-                on_list_resources=_handle_list_resources,
-                on_read_resource=_handle_read_resource,
+                on_list_tools=cast(Any, _handle_list_tools),
+                on_call_tool=cast(Any, _handle_call_tool),
+                on_list_resources=cast(Any, _handle_list_resources),
+                on_read_resource=cast(Any, _handle_read_resource),
             )
             await server.run(read_stream, write_stream, initialization_options=init_opts)
 

--- a/modules/shared/src/taxonomy_config_vo.py
+++ b/modules/shared/src/taxonomy_config_vo.py
@@ -47,6 +47,7 @@ class UploadConfig:
 
     upload_option_selectors: Sequence[str] = field(
         default_factory=lambda: (
+            "[role='menuitem']:has-text('Upload attachment')",
             "text='Upload attachment'",
             "text='Upload file'",
             ".mode-select-dropdown-item[data-action='upload']",

--- a/modules/shared/src/taxonomy_core_constant.py
+++ b/modules/shared/src/taxonomy_core_constant.py
@@ -110,6 +110,9 @@ SEND_SELECTORS: tuple[str, ...] = (
 )
 
 MESSAGE_SELECTORS: tuple[str, ...] = (
+    ".chat-response-message .response-message-content",
+    ".chat-response-message .qwen-markdown-text",
+    ".chat-response-message .qwen-markdown",
     ".chat-message-assistant .markdown-body",
     "[class*='assistant'] .markdown-body",
     "[class*='assistant'] [class*='markdown']",
@@ -129,10 +132,26 @@ STOP_BUTTON_SELECTORS: str = (
     "button[aria-label*='Stop' i], button:has-text('Stop'), [class*='stop-btn'], [class*='icon-stop']"
 )
 SEND_DISABLED_SELECTORS: str = "button[aria-label*='Send' i][disabled], button[class*='send' i][disabled]"
-TYPING_INDICATOR_SELECTORS: str = ".thinking:not([style*='display: none']), [class*='typing'], [class*='streaming']"
+TYPING_INDICATOR_SELECTORS: str = (
+    ".thinking:not([style*='display: none']):not([class*='completed']), "
+    "[class*='qwen-chat-thinking-status-card']:not([class*='completed']), "
+    "[class*='typing'], [class*='streaming']"
+)
 
 JS_GET_RESPONSE_TEXT: str = """
 () => {
+    var responseNodes = document.querySelectorAll(
+        '.chat-response-message .response-message-content .qwen-markdown-text,' +
+        '.chat-response-message .response-message-content .qwen-markdown,' +
+        '.chat-response-message .response-message-content,' +
+        '.chat-response-message .qwen-markdown-text'
+    );
+    for (var ri = responseNodes.length - 1; ri >= 0; ri--) {
+        var responseNode = responseNodes[ri];
+        if (responseNode.closest('.qwen-chat-message-user')) continue;
+        var responseText = (responseNode.innerText || '').trim();
+        if (responseText.length > 0) return responseText;
+    }
     var containers = ['#chatLog', '[class*="chat-log"]', '[class*="virtual-list"]',
                       '[class*="message-list"]', '[class*="conversation-body"]',
                       '[class*="dialog-content"]', '.chat-messages-container',
@@ -184,7 +203,8 @@ JS_GET_RESPONSE_TEXT: str = """
 JS_COUNT_TURNS: str = """
 () => {
     var turns = document.querySelectorAll(
-        '[class*="chat-message"], [class*="message-item"], [class*="virtual-list-item"], [class*="turn"]'
+        '.chat-response-message, [class*="chat-message"], [class*="message-item"], '
+        + '[class*="virtual-list-item"], [class*="turn"]'
     );
     return turns.length;
 }

--- a/tests/test_login_session.py
+++ b/tests/test_login_session.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-import threading
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from modules.cli.src.surface_cli_login_command import handle
 from modules.core.src.agent_core_orchestrator import CoreOrchestrator
 from modules.core.src.capabilities_browser_adapter import BrowserAdapter
-from modules.shared.src import AppConfig, AuthRequiredError
+from modules.shared.src import AppConfig
 
 
 class _BrowserHarness:
@@ -193,12 +190,9 @@ def test_manual_login_delays_check_session_after_confirmation(tmp_path: Path) ->
     This prevents the browser from being checked while the page is still
     stabilizing after a manual login — which previously caused a hang.
     """
-    import time
-
     session_path = tmp_path / "session"
     browser = _BrowserHarness([True])
     confirmation = MagicMock()
-    start = time.monotonic()
 
     result = _orchestrator(browser).setup_session(
         wait_for_confirmation=confirmation,

--- a/tests/test_taxonomy_core_event_refactor.py
+++ b/tests/test_taxonomy_core_event_refactor.py
@@ -13,6 +13,7 @@ from modules.shared.src import (
 )
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter, LifecycleGate, LifecycleState
 from modules.shared.src.taxonomy_core_error import ErrorCategory, QwenCliError, ResponseDetectionTimeoutError
+from modules.shared.src.taxonomy_core_error import QwenCliError as CANONICAL_QWEN_CLI_ERROR
 from modules.shared.src.taxonomy_core_event import (
     EVENT_DOCUMENT_PARSED,
     EVENT_GENERATION_FINISHED,
@@ -30,7 +31,6 @@ from modules.shared.src.taxonomy_core_vo import (
     EventDetails,
     EventOrderMap,
 )
-from modules.shared.src.taxonomy_core_error import QwenCliError as CANONICAL_QWEN_CLI_ERROR
 
 
 def test_pipeline_event_sequence_is_canonical_and_ordered() -> None:


### PR DESCRIPTION
## Summary

This PR stabilizes the event-driven single-file CLI pipeline against the current Qwen Web DOM.

## Changes

- Extract assistant responses from the observed `.chat-response-message`, `.response-message-content`, and `.qwen-markdown-text` nodes.
- Count `.chat-response-message` nodes as new turns so response polling can progress after `EVENT_THINKING_STARTED`.
- Treat `.qwen-chat-thinking-status-card-completed` as completed rather than an active typing indicator.
- Prefer the exact `[role='menuitem']:has-text('Upload attachment')` upload action for chooser fallback.
- Verify output artifacts exist, are non-empty, and are readable before emitting `EVENT_OUTPUT_COPIED`.
- Restore MCP `SharedContainer` patchability and MCP 2.0.0 typing compatibility.
- Clean repository Ruff/lint violations introduced by the MCP upgrade.

## Validation

- Focused pytest: passed (`66 passed` in the selected suite).
- mypy modules: passed (`57 source files`).
- Ruff: passed.
- lint-arwaky v3.6.1: passed (`0 violations`).
- Real CLI: upload succeeded and lifecycle progressed through `EVENT_THINKING_STARTED`; two later attempts were blocked by Qwen page navigation/response environment timeouts, so end-to-end generation completion remains dependent on the live Qwen session/network.

Closes #118


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes single-file CLI response monitoring and file uploads against the current Qwen Web DOM. Prevents stalls after thinking starts, removes false typing signals, and verifies outputs are written and readable before emitting lifecycle events.

- Response handling: adds DOM selectors for assistant text, counts `.chat-response-message` as turns so polling progresses post-`EVENT_THINKING_STARTED`, and stops treating completed thinking cards as “typing.”
- Uploads: prefers `[role='menuitem']:has-text('Upload attachment')` in `UploadConfig`; simplifies locator fallback in the uploader.
- Output verification: after saving, checks file exists, has size > 0, and is readable; emits `EVENT_OUTPUT_COPIED` with `file_size_bytes` in addition to `char_count`.
- MCP server: updates to `mcp` 2.0 style (`input_schema`, typed callbacks with `cast`), restores `SharedContainer` import/patchability; preserves legacy helper stubs and `MCP_TOOL_SPECS` for tests.
- Cleanup: removes unused imports and fixes lint/tests.

**Rollout**
- No config changes required.
- If you parse `EVENT_OUTPUT_COPIED`, accept the new `file_size_bytes` field; existing fields are unchanged.

<sup>Written for commit 76d5752d7388e3579342aff1e2c3369e9fc5c479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

