### PR TITLE
fix: preserve pre-send baseline for response detection

### DIFF
--- a/modules/core/src/agent_core_orchestrator.py
+++ b/modules/core/src/agent_core_orchestrator.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from playwright.sync_api import Page
 
 from modules.core.src.utility_core_config_factory import build_app_config
+from modules.core.src.utility_core_dom_query import latest_message_text
 from modules.core.src.utility_core_error_mapping import to_error_response
 from modules.core.src.utility_core_file_mover import move_file, move_to_processing
 from modules.core.src.utility_core_io_writer import ensure_dir
@@ -503,6 +504,10 @@ class CoreOrchestrator(ICoreAggregate):
                 "Cannot inject prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete"
             )
 
+        try:
+            baseline_response = latest_message_text(page)
+        except Exception:
+            baseline_response = None
         self._injector.inject_text(page, PromptText(prompt))
         emitter.emit(EVENT_PROMPT_INJECTED, {"file": str(filepath), "char_count": len(prompt)})
 
@@ -518,6 +523,7 @@ class CoreOrchestrator(ICoreAggregate):
             emitter,
             polling_interval_sec=PollIntervalSec(active_cfg.poll_interval),
             dispatch_acknowledged=HeadlessFlag(state.dispatch_acknowledged),
+            baseline_text=baseline_response,
         )
 
         if response and len(response.strip()) > 0:

--- a/modules/core/src/capabilities_stream_monitor.py
+++ b/modules/core/src/capabilities_stream_monitor.py
@@ -92,10 +92,12 @@ class StreamMonitor(IStreamProtocol):
         stability_checks: int = 4,
         min_text_length: int = 1,
         dispatch_acknowledged: bool = True,
+        baseline_text: ResponseText | None = None,
     ) -> ResponseText | None:
         """Wait for new assistant message with stability check and output validation."""
         if not dispatch_acknowledged:
             raise RuntimeError("Cannot wait for response: prompt dispatch (EVENT_DISPATCH_ACKNOWLEDGED) is incomplete")
+        _ = msg_count_before
 
         active_poll = PollIntervalSec(polling_interval_sec)
         active_checks = StabilityChecks(stability_checks)
@@ -105,7 +107,7 @@ class StreamMonitor(IStreamProtocol):
         has_streaming = False
 
         log.info("Waiting for AI response (timeout: %ds)", timeout_sec)
-        baseline_text: str | None = _dom_latest(page)
+        previous_text: str | None = str(baseline_text) if baseline_text is not None else _dom_latest(page)
 
         start = time.time()
         last_text: str | None = None
@@ -113,35 +115,32 @@ class StreamMonitor(IStreamProtocol):
 
         while time.time() - start < timeout_sec:
             try:
-                count = count_messages(page)
+                count_messages(page)
                 if not has_thinking and self.is_thinking_active(page):
                     emitter.emit(EVENT_THINKING_STARTED, {"source": "qwen-thinking-dom"})
                     has_thinking = True
-                if count > msg_count_before:
-                    text = _dom_latest(page)
-                    if text is not None and should_treat_as_new_response(text, baseline_text, int(active_min_len)):
-                        if not has_thinking:
-                            emitter.emit(EVENT_THINKING_STARTED, {"source": "response-start-fallback"})
-                            has_thinking = True
-                        if text == last_text:
-                            stable_count += 1
-                            is_complete = self.is_generation_complete(page)
-                            if is_stability_satisfied(
-                                stable_count, int(active_checks), has_thinking, has_streaming, is_complete
-                            ):
-                                log.info(
-                                    "Response stabilized after %d checks (is_complete=%s)", stable_count, is_complete
-                                )
-                                validate_response_content(text)
-                                emitter.emit(EVENT_GENERATION_FINISHED, {"text_length": len(text)})
-                                return ResponseText(text)
-                        else:
-                            if has_thinking:
-                                if not has_streaming:
-                                    has_streaming = True
-                                    emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": len(text)})
-                                stable_count = 0
-                                last_text = text
+                text = _dom_latest(page)
+                if text is not None and should_treat_as_new_response(text, previous_text, int(active_min_len)):
+                    if not has_thinking:
+                        emitter.emit(EVENT_THINKING_STARTED, {"source": "response-start-fallback"})
+                        has_thinking = True
+                    if text == last_text:
+                        stable_count += 1
+                        is_complete = self.is_generation_complete(page)
+                        if is_stability_satisfied(
+                            stable_count, int(active_checks), has_thinking, has_streaming, is_complete
+                        ):
+                            log.info("Response stabilized after %d checks (is_complete=%s)", stable_count, is_complete)
+                            validate_response_content(text)
+                            emitter.emit(EVENT_GENERATION_FINISHED, {"text_length": len(text)})
+                            return ResponseText(text)
+                    else:
+                        if has_thinking:
+                            if not has_streaming:
+                                has_streaming = True
+                                emitter.emit(EVENT_STREAMING_GENERATION, {"text_length": len(text)})
+                            stable_count = 0
+                            last_text = text
                 time.sleep(active_poll)
             except TimeoutError as e:
                 raise NetworkTimeoutError(f"Browser network timeout during streaming poll: {e}") from e

--- a/modules/core/src/utility_core_dom_query.py
+++ b/modules/core/src/utility_core_dom_query.py
@@ -13,6 +13,7 @@ from modules.shared.src.taxonomy_core_constant import (
     COMBINED_MESSAGE_SELECTOR,
     JS_COUNT_TURNS,
     JS_GET_RESPONSE_TEXT,
+    RESPONSE_CONTENT_SELECTOR,
 )
 from modules.shared.src.taxonomy_core_vo import MessageCount, ResponseText
 
@@ -62,7 +63,7 @@ def latest_message_text(page: Page) -> ResponseText | None:
     except Error:
         pass
     try:
-        locator = page.locator(COMBINED_MESSAGE_SELECTOR)
+        locator = page.locator(RESPONSE_CONTENT_SELECTOR)
         if locator.count() > 0:
             text = locator.last.text_content()
             if text is not None:

--- a/modules/shared/src/contract_core_protocol.py
+++ b/modules/shared/src/contract_core_protocol.py
@@ -101,6 +101,7 @@ class IStreamProtocol(ABC):
         stability_checks: StabilityChecks = StabilityChecks(4),
         min_text_length: MinTextLength = MinTextLength(1),
         dispatch_acknowledged: HeadlessFlag = HeadlessFlag(True),
+        baseline_text: ResponseText | None = None,
     ) -> ResponseText | None:
         """Wait for a stable assistant response; return its text."""
 

--- a/modules/shared/src/taxonomy_core_constant.py
+++ b/modules/shared/src/taxonomy_core_constant.py
@@ -127,6 +127,7 @@ MESSAGE_SELECTORS: tuple[str, ...] = (
 )
 
 COMBINED_MESSAGE_SELECTOR: str = ", ".join(MESSAGE_SELECTORS)
+RESPONSE_CONTENT_SELECTOR: str = ".response-message-content, .qwen-markdown-text"
 
 STOP_BUTTON_SELECTORS: str = (
     "button[aria-label*='Stop' i], button:has-text('Stop'), [class*='stop-btn'], [class*='icon-stop']"
@@ -141,28 +142,14 @@ TYPING_INDICATOR_SELECTORS: str = (
 JS_GET_RESPONSE_TEXT: str = """
 () => {
     var responseNodes = document.querySelectorAll(
-        '.chat-response-message .response-message-content .qwen-markdown-text,' +
-        '.chat-response-message .response-message-content .qwen-markdown,' +
-        '.chat-response-message .response-message-content,' +
-        '.chat-response-message .qwen-markdown-text'
+        '.response-message-content, .qwen-markdown-text, ' +
+        '.chat-response-message .qwen-markdown, .qwen-chat-message-assistant .qwen-markdown'
     );
     for (var ri = responseNodes.length - 1; ri >= 0; ri--) {
         var responseNode = responseNodes[ri];
         if (responseNode.closest('.qwen-chat-message-user')) continue;
         var responseText = (responseNode.innerText || '').trim();
         if (responseText.length > 0) return responseText;
-    }
-    var containers = ['#chatLog', '[class*="chat-log"]', '[class*="virtual-list"]',
-                      '[class*="message-list"]', '[class*="conversation-body"]',
-                      '[class*="dialog-content"]', '.chat-messages-container',
-                      '.chat-response-message', '.qwen-chat-message-assistant'];
-    for (var ci = 0; ci < containers.length; ci++) {
-        var container = document.querySelector(containers[ci]);
-        if (container && container.children.length > 0) {
-            var lastChild = container.children[container.children.length - 1];
-            var txt = (lastChild.innerText || '').trim();
-            if (txt.length > 20) return txt;
-        }
     }
     var SKIP_CLASSES = [
         'model-selector', 'fileitem', 'placeholder', 'message-input',
@@ -186,17 +173,14 @@ JS_GET_RESPONSE_TEXT: str = """
         }
         return false;
     }
-    var best = null;
-    var bestLen = 0;
-    var all = document.querySelectorAll('div, p, pre, section, article, main');
-    for (var i = 0; i < all.length; i++) {
-        var el = all[i];
-        if (['SCRIPT','STYLE','TEXTAREA','INPUT','BUTTON'].indexOf(el.tagName) >= 0) continue;
-        if (isInChrome(el)) continue;
-        var txt2 = (el.innerText || '').trim();
-        if (txt2.length > bestLen) { bestLen = txt2.length; best = txt2; }
+    var assistantNodes = document.querySelectorAll(
+        '.qwen-chat-message-assistant, .chat-message-assistant, [data-role="assistant"]'
+    );
+    for (var ai = assistantNodes.length - 1; ai >= 0; ai--) {
+        var assistantText = (assistantNodes[ai].innerText || '').trim();
+        if (assistantText.length > 0 && !isInChrome(assistantNodes[ai])) return assistantText;
     }
-    return best;
+    return null;
 }
 """
 

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -12,6 +12,7 @@ from modules.core.src.capabilities_stream_monitor import (
 )
 from modules.shared.src import (
     CHALLENGE_KEYWORDS,
+    EVENT_GENERATION_FINISHED,
     EVENT_STREAMING_GENERATION,
     AuthRequiredError,
     LifecycleEmitter,
@@ -266,3 +267,37 @@ class TestWaitForResponseEdgeCases:
                 stability_checks=2,
             )
             assert result == stable_text
+
+
+class TestPreSendBaseline:
+    def test_detects_response_when_first_poll_already_has_new_text(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+        baseline = "Previous assistant answer"
+        response = "A newly generated response that is already rendered before polling starts."
+
+        with (
+            patch("modules.core.src.capabilities_stream_monitor.count_messages", return_value=2),
+            patch(
+                "modules.core.src.capabilities_stream_monitor._dom_latest",
+                side_effect=[response, response, response],
+            ),
+            patch.object(StreamMonitor, "is_generation_complete", return_value=True),
+            patch("modules.core.src.capabilities_stream_monitor.time") as mock_time,
+        ):
+            mock_time.time.side_effect = [0, 0.1, 0.2, 0.3, 0.4]
+            mock_time.sleep = MagicMock()
+            result = StreamMonitor().wait_for_response(
+                page,
+                timeout_sec=5,
+                msg_count_before=1,
+                emitter=emitter,
+                polling_interval_sec=0,
+                stability_checks=2,
+                baseline_text=baseline,
+            )
+
+        assert result == response
+        event_names = [call.args[0] for call in emitter.emit.call_args_list]
+        assert EVENT_STREAMING_GENERATION in event_names
+        assert EVENT_GENERATION_FINISHED in event_names


### PR DESCRIPTION
## Summary

Fixes the response-detection blocker after `EVENT_THINKING_STARTED` in the single-file CLI pipeline.

## Root cause

The monitor captured its response baseline only after the send action. When Qwen rendered a response quickly, the first polling baseline was already the new response. In addition, extraction was gated by a message count that is unreliable with Qwen's virtualized DOM. The generic body fallback could also return the entire Qwen page shell as if it were an answer.

## Changes

- Capture the latest assistant response before prompt injection and pass it as the monitor baseline.
- Detect response text independently of message-count increments.
- Preserve the existing `msg_count_before` API for compatibility while removing it as a hard response gate.
- Restrict extraction to `.response-message-content` and `.qwen-markdown-text` plus assistant response containers.
- Remove page-body extraction fallback that could contaminate output with sidebar, upload, and navigation text.
- Add a regression test for a response already rendered before the first polling iteration.

## Validation

- Focused pytest: 62 passed.
- mypy: passed, 57 source files.
- Ruff: passed.
- lint-arwaky v3.6.1: passed, 0 violations.
- Real CLI with baseline patch: reached `EVENT_STREAMING_GENERATION`, `EVENT_GENERATION_FINISHED`, and `EVENT_OUTPUT_COPIED` and wrote a non-empty output artifact.
- A later strict-output run correctly refused to write an artifact when Qwen produced no response, instead quarantining the input after timeout.

Closes #118


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed response detection after `EVENT_THINKING_STARTED` by preserving a pre-send baseline and narrowing DOM extraction. Previously the monitor captured its baseline after dispatch and relied on message count, so a fast Qwen render looked like “no change” and the body fallback could treat the whole page shell as a reply.

- Capture the latest assistant message before prompt injection and pass it to `wait_for_response` as `baseline_text`.
- Detect new text regardless of message-count increments; keep `msg_count_before` for compatibility only.
- Restrict extraction to `.response-message-content` and `.qwen-markdown-text` plus assistant containers; remove page-body fallback to prevent sidebar/upload/nav contamination.
- Add a regression test for “response already rendered before first poll”; protocol now accepts optional `baseline_text`. No migration required for existing callers.

<sup>Written for commit 02caf9d0c1fbe24b09efe7db4c9ccf23ad9f487d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

