### PR TITLE
fix: reject Qwen page shell as assistant output

### DIFF
--- a/modules/shared/src/taxonomy_core_constant.py
+++ b/modules/shared/src/taxonomy_core_constant.py
@@ -143,42 +143,13 @@ JS_GET_RESPONSE_TEXT: str = """
 () => {
     var responseNodes = document.querySelectorAll(
         '.response-message-content, .qwen-markdown-text, ' +
-        '.chat-response-message .qwen-markdown, .qwen-chat-message-assistant .qwen-markdown'
+        '.chat-response-message .qwen-markdown'
     );
     for (var ri = responseNodes.length - 1; ri >= 0; ri--) {
         var responseNode = responseNodes[ri];
         if (responseNode.closest('.qwen-chat-message-user')) continue;
         var responseText = (responseNode.innerText || '').trim();
         if (responseText.length > 0) return responseText;
-    }
-    var SKIP_CLASSES = [
-        'model-selector', 'fileitem', 'placeholder', 'message-input',
-        'header', 'footer', 'feedback', 'downLoad', 'sidebar',
-        'mode-select', 'send-button', 'toolbar', 'nav', 'spinner',
-        'thinking', 'attachment', 'file-card', 'file-content',
-        'chat-footer', 'chat-prompt-recommend'
-    ];
-    function isInChrome(el) {
-        var p = el;
-        while (p) {
-            var cls = p.className;
-            if (cls && typeof cls === 'string') {
-                for (var i = 0; i < SKIP_CLASSES.length; i++) {
-                    if (cls.indexOf(SKIP_CLASSES[i]) >= 0) return true;
-                }
-            }
-            if (p.tagName === 'HEADER' || p.tagName === 'FOOTER' ||
-                p.tagName === 'NAV' || p.tagName === 'ASIDE') return true;
-            p = p.parentElement;
-        }
-        return false;
-    }
-    var assistantNodes = document.querySelectorAll(
-        '.qwen-chat-message-assistant, .chat-message-assistant, [data-role="assistant"]'
-    );
-    for (var ai = assistantNodes.length - 1; ai >= 0; ai--) {
-        var assistantText = (assistantNodes[ai].innerText || '').trim();
-        if (assistantText.length > 0 && !isInChrome(assistantNodes[ai])) return assistantText;
     }
     return null;
 }

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -18,6 +18,7 @@ from modules.shared.src import (
     LifecycleEmitter,
     OutputValidationError,
 )
+from modules.shared.src.taxonomy_core_constant import JS_GET_RESPONSE_TEXT
 
 # ─── validate_response_content ──────────────────────────────────────────────
 
@@ -267,6 +268,14 @@ class TestWaitForResponseEdgeCases:
                 stability_checks=2,
             )
             assert result == stable_text
+
+
+class TestResponseExtractionContract:
+    def test_js_extraction_excludes_page_shell_fallback(self):
+        assert ".response-message-content" in JS_GET_RESPONSE_TEXT
+        assert ".qwen-markdown-text" in JS_GET_RESPONSE_TEXT
+        assert "document.querySelectorAll('div, p, pre, section, article, main')" not in JS_GET_RESPONSE_TEXT
+        assert "qwen-chat-message-assistant" not in JS_GET_RESPONSE_TEXT
 
 
 class TestPreSendBaseline:


### PR DESCRIPTION
## Summary

Prevents the single-file CLI from writing Qwen navigation, sidebar, upload status, or page-shell text as assistant output.

## Root cause

The previous generic assistant-container fallback could match a shell-level container and return UI text such as `New Chat`, `Qwen3.8-Max`, and `Parsing...` as the response.

## Changes

- Keep only exact response-content extraction targets: `.response-message-content` and `.qwen-markdown-text`.
- Remove broad page-shell and assistant-container fallback paths.
- Return no response when an exact assistant response node is unavailable, allowing the existing timeout/quarantine gate to prevent a false output artifact.
- Add regression assertions that the extraction JavaScript contains the exact response selectors and no page-shell fallback.

## Validation

- Focused pytest: 63 passed.
- mypy: passed, 57 source files.
- Ruff: passed.
- lint-arwaky v3.6.1: passed, 0 violations.
- Diagnostic authenticated DOM probe confirmed that an idle Qwen session has no response node; the previously captured Qwen HTML evidence confirms the exact response nodes used by this patch.

Closes #118


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects Qwen page-shell UI as assistant output to prevent false responses. Previously, a broad assistant-container fallback could emit UI strings (e.g., “New Chat”, “Qwen3.8-Max”, “Parsing…”). Now the extractor only reads exact response nodes and returns no text when none exist, letting the existing timeout/quarantine handle no-output cases.

- Restricts DOM queries to: .response-message-content, .qwen-markdown-text, and .chat-response-message .qwen-markdown.
- Removes assistant-container/page-shell fallbacks and chrome-skipping logic to avoid shell/UI capture.
- Adds a regression test asserting only the exact selectors are present and no page-shell or qwen-chat-message-assistant fallback remains.

<sup>Written for commit c8f774f1e3066893f9f2a3c05c86efdf39817739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

