### PR TITLE
fix: stabilize Qwen parse gate and browser session

### DIFF
--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -253,9 +253,6 @@ class BrowserAdapter(IBrowserProtocol):
             "user_data_dir": str(cfg.session_path),
             "headless": cfg.headless,
             "permissions": ["clipboard-read", "clipboard-write"],
-            "user_agent": (
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-            ),
             "args": chrome_args,
             "viewport": {"width": 1280, "height": 800},
         }
@@ -275,6 +272,29 @@ class BrowserAdapter(IBrowserProtocol):
                         "**/*.{png,jpg,jpeg,gif,webp,mp4,mp3,woff,woff2,ttf,otf}",
                         lambda r: r.abort(),
                     )
+
+                def attach_page_diagnostics(page: Page) -> None:
+                    def on_request_failed(request: Any) -> None:
+                        log.warning("browser_request_failed", url=request.url, error=request.failure)
+
+                    def on_console(message: Any) -> None:
+                        if message.type in {"error", "warning"}:
+                            log.warning("browser_console_message", type=message.type, text=message.text)
+
+                    def on_response(response: Any) -> None:
+                        url = response.url.lower()
+                        if response.status >= 400 and any(
+                            token in url for token in ("chat", "completion", "generate", "conversation", "api")
+                        ):
+                            log.warning("browser_http_error", status=response.status, url=response.url)
+
+                    page.on("requestfailed", on_request_failed)
+                    page.on("console", on_console)
+                    page.on("response", on_response)
+
+                for existing_page in ctx.pages:
+                    attach_page_diagnostics(existing_page)
+                ctx.on("page", attach_page_diagnostics)
                 try:
                     yield ctx
                 finally:

--- a/modules/core/src/capabilities_file_uploader.py
+++ b/modules/core/src/capabilities_file_uploader.py
@@ -203,18 +203,22 @@ class FileUploader(IUploadProtocol):
         raise TimeoutError(f"Exact uploaded filename was not rendered in Qwen attachment DOM: {filepath.name}")
 
     def _wait_for_parse_ready(self, page: Page, filepath: Path) -> None:
-        """Wait for Qwen's document parsing to complete by checking text state."""
+        """Wait until Qwen's matching attachment card exposes a ready state."""
         deadline = time.monotonic() + (self.card_render_timeout_ms / 1000)
         while time.monotonic() < deadline:
-            card = page.locator(".fileitem-btn").filter(has_text=filepath.stem).last
+            card_selector = ", ".join(self.config.card_selectors)
+            card = page.locator(card_selector).filter(has_text=filepath.stem).last
             try:
                 if card.count() == 0:
                     page.wait_for_timeout(100)
                     continue
-                # Check for parsing text (e.g., "Parsing...", size + "Parsing...")
                 card_text = card.inner_text().casefold()
-                has_parsing = "parsing" in card_text
-                if not has_parsing:
+                pending_visible = any(
+                    card.locator(selector).count() > 0 and card.locator(selector).first.is_visible(timeout=100)
+                    for selector in self.config.parse_pending_selectors
+                )
+
+                if not pending_visible and "parsing" not in card_text:
                     log.debug("Qwen document parsing is ready for %s", filepath.name)
                     return
             except (TimeoutError, Error):


### PR DESCRIPTION
## Summary

Stabilizes real Qwen single-file processing after repeated live runs exposed two additional issues.

## Changes

- Use the complete Qwen attachment card selector set when waiting for parse completion instead of assuming `.fileitem-btn` contains the filename and status.
- Keep `EVENT_DOCUMENT_PARSED` gated on the matching card having no pending/loading/parsing state.
- Remove the hardcoded Chrome 131 user-agent so the persistent session uses the actual Chromium runtime user-agent.
- Add browser telemetry for failed requests, console errors, and relevant HTTP responses.

## Evidence

The previous live run failed because the parse gate could not find a ready state on the actual Qwen attachment card. After the card selector fix, the real CLI reached `EVENT_FILE_UPLOADED`, `EVENT_DOCUMENT_PARSED`, `EVENT_PROMPT_INJECTED`, `EVENT_SEND_CLICKED`, `EVENT_DISPATCH_ACKNOWLEDGED`, and `EVENT_THINKING_STARTED`.

The remaining live run did not produce an assistant response. Before the user-agent change, Qwen emitted a WebSocket 403 for `/api/v1/notifications/ws`; with the user-agent override removed, that 403 was no longer present in telemetry, although the model still did not render a response in that particular run.

## Validation

- Focused regression tests passed.
- Ruff passed.
- mypy passed — 57 source files.
- lint-arwaky v3.6.1 passed — 0 violations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Qwen attachment parse gating and the Playwright browser session for real runs. Previously we inferred readiness from `.fileitem-btn` text and could emit parsed while the card was pending; now we match the full attachment selector set, gate on no pending indicators, drop the fixed Chrome 131 user agent, and add browser telemetry for faster failure diagnosis.

**Review notes**
- Parse gate: use `config.card_selectors` for the attachment card and `config.parse_pending_selectors` to detect pending; only emit EVENT_DOCUMENT_PARSED when no pending state and no "parsing" text are present.
- Browser session: remove the hardcoded user agent so the persistent profile sends the runtime UA; this eliminated a observed 403 on `/api/v1/notifications/ws`.
- Diagnostics: attach listeners to all existing and new pages to log request failures, console errors/warnings, and 4xx/5xx responses on chat/completion-like endpoints.

<sup>Written for commit 880a27abfe5d110872a45b680bd4c94177e015ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

