### PR TITLE
ci: harden automated release state handling

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           # --auto holds the PR until the branch-protection/required checks
           # pass, then merges with squash. Idempotent across re-runs.
-          gh pr merge "$PR_NUMBER" --auto --squash \
+          gh pr merge "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto --squash \
             --subject "$PR_TITLE" || \
             echo "Auto-merge not available yet (e.g. checks still pending) — a later event will retry."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -91,6 +91,23 @@ jobs:
           else
             RANGE="${LAST_TAG}..HEAD"
           fi
+
+          CURRENT=$(grep -m1 -oP '^version\s*=\s*"\K[^"]+' pyproject.toml || true)
+          if [ -z "$CURRENT" ]; then
+            echo "Cannot determine package version from pyproject.toml."
+            exit 1
+          fi
+          if [ -n "$LAST_TAG" ]; then
+            IFS='.' read -r CUR_MAJ CUR_MIN CUR_PAT <<< "$CURRENT"
+            IFS='.' read -r TAG_MAJ TAG_MIN TAG_PAT <<< "${LAST_TAG#v}"
+            if [ "${CUR_MAJ:-0}" -gt "${TAG_MAJ:-0}" ] || \
+               { [ "${CUR_MAJ:-0}" -eq "${TAG_MAJ:-0}" ] && [ "${CUR_MIN:-0}" -gt "${TAG_MIN:-0}" ]; } || \
+               { [ "${CUR_MAJ:-0}" -eq "${TAG_MAJ:-0}" ] && [ "${CUR_MIN:-0}" -eq "${TAG_MIN:-0}" ] && [ "${CUR_PAT:-0}" -gt "${TAG_PAT:-0}" ]; }; then
+              echo "Package version ${CURRENT} is ahead of latest tag ${LAST_TAG}."
+              echo "Recover the unpublished version or create its tag before opening another release PR."
+              exit 1
+            fi
+          fi
           echo "range=${RANGE}" >> "$GITHUB_OUTPUT"
           echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
 
@@ -158,6 +175,8 @@ jobs:
           entry = f"## [{version}] - {date}\n\n{body}\n\n"
           with open("CHANGELOG.md") as f:
               content = f.read()
+          if re.search(rf"^## \[{re.escape(version)}\](?:\s|$)", content, flags=re.M):
+              raise SystemExit(f"Release heading already exists: {version}")
           # Keep a Changelog layout: header block first, then releases
           # newest-first — insert before the first existing release heading.
           m = re.search(r"^## \[", content, flags=re.M)
@@ -177,7 +196,7 @@ jobs:
           # Skip only when an open release PR for this version already exists
           # (prevents duplicate release PRs after a merge). The branch itself
           # may exist from a previous attempt and is overwritten below.
-          if gh pr list --head "$BRANCH" --state open --json number \
+          if gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number \
             --jq 'length' 2>/dev/null | grep -q '[1-9]'; then
             echo "Release PR for ${VERSION} already open — skipping."
             exit 0
@@ -203,7 +222,7 @@ jobs:
           See the v${VERSION} entry in [CHANGELOG.md](CHANGELOG.md).
           BODY
           )
-          gh pr create --base main --head "$BRANCH" \
+          gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" \
             --title "chore(release): v${VERSION}" \
             --body "$PR_BODY"
 
@@ -211,7 +230,7 @@ jobs:
           # (GitHub anti-recursion guard), so dispatch CI on the release branch
           # explicitly — the checks attach to the same head SHA and gate the
           # PR — then arm auto-merge so the PR lands once checks pass.
-          gh workflow run ci.yml --ref "$BRANCH"
-          gh pr merge --auto --squash \
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$BRANCH"
+          gh pr merge --repo "$GITHUB_REPOSITORY" --auto --squash \
             --subject "chore(release): v${VERSION}" "$BRANCH" || \
             echo "Auto-merge not available yet (e.g. checks still pending) — the auto-merge workflow re-arms on later PR events."

--- a/.github/workflows/tag-release-prs.yml
+++ b/.github/workflows/tag-release-prs.yml
@@ -78,7 +78,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          sleep 2
           gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "v${RELEASE_VERSION}" \
+            -f "tag=v${RELEASE_VERSION}"
             --repo "$GITHUB_REPOSITORY" \
             --ref "v${RELEASE_VERSION}" \
             -f "tag=v${RELEASE_VERSION}"

--- a/.github/workflows/tag-release-prs.yml
+++ b/.github/workflows/tag-release-prs.yml
@@ -24,7 +24,7 @@ jobs:
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release/v') &&
       startsWith(github.event.pull_request.title, 'chore(release):')
     steps:
@@ -54,7 +54,12 @@ jobs:
           fi
           TAG="v${VERSION}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists."
+            EXISTING_SHA=$(git rev-list -n 1 "$TAG")
+            if [ "$EXISTING_SHA" != "$MERGE_SHA" ]; then
+              echo "Tag ${TAG} already points to ${EXISTING_SHA}, not ${MERGE_SHA}."
+              exit 1
+            fi
+            echo "Tag ${TAG} already exists at the expected merge commit."
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -73,4 +78,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          gh workflow run release.yml --ref "v${RELEASE_VERSION}" -f "tag=v${RELEASE_VERSION}"
+          gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "v${RELEASE_VERSION}" \
+            -f "tag=v${RELEASE_VERSION}"


### PR DESCRIPTION
## Ringkasan

PR ini memperbaiki bug automated release yang menyebabkan PR seperti #117 membuat versi dan changelog duplikat.

## Perubahan

- Auto-release berhenti secara eksplisit jika versi pada `pyproject.toml` lebih maju daripada tag Git terakhir, sehingga state release yang belum ditag tidak menghasilkan release PR duplikat.
- Generator changelog menolak heading versi yang sudah ada.
- Auto-merge, auto-release, dan tag workflow menggunakan repository eksplisit pada perintah `gh`.
- Tag workflow memvalidasi source repository dan tidak lagi bergantung pada login author literal `github-actions[bot]`.
- Tag yang sudah ada harus menunjuk merge SHA yang sama; tag yang menunjuk commit lain dianggap konflik.
- Dispatch release workflow menyertakan repository dan input tag yang tepat.

## Validasi lokal

- YAML workflow validation: passed.
- `git diff --check`: passed.
- Tidak mengubah file source aplikasi.
- PR #123 ke `develop` hanya mengubah source/test, sehingga tidak ada konflik file workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate release PRs, tags, and changelog entries by hardening automated release state checks and scoping all `gh` invocations to the current repository. Previously, ahead-of-tag versions and ambiguous `gh` commands could create duplicate artifacts; now workflows halt early, validate state, and dispatch with explicit repo context.

- Auto-release stops if `pyproject.toml` version exceeds the latest tag and asks maintainers to tag or recover the unpublished version first.
- Changelog generator rejects an existing version heading.
- All `gh` commands use `--repo "$GITHUB_REPOSITORY"` in auto-merge, auto-release, and workflow dispatch; the tag workflow dispatches `release.yml` with explicit repo and adds a short delay to avoid post-tag race conditions.
- Tagging workflow validates the source repository instead of relying on `github-actions[bot]`.
- Existing tag must point to the expected merge SHA; mismatches fail fast; matching tags are idempotent.

**Operational notes**
- No application/source changes.
- If auto-release exits due to an ahead version, create the missing tag or revert the version before retrying.

<sup>Written for commit 151415c1bed2fa0f09fd4e324133b442cc72d7ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

