### PR TITLE
chore(ci): add .coderabbit.yaml to filter binary media assets from AI review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit AI Code Reviewer Configuration
+version: "2"
+language: "en-US"
+reviews:
+  profile: "chill"
+path_filters:
+  - "!docs/**"
+  - "!*.gif"
+  - "!*.webp"
+  - "!*.png"
+  - "!*.jpg"
+  - "!*.mp4"
+  - "!*.webm"


### PR DESCRIPTION
Filters out binary media assets and docs folder from CodeRabbit AI code reviews to prevent internal errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project review configuration with English-language settings and a relaxed review profile.
  * Excluded documentation and common media files from automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.coderabbit.yaml` to configure CodeRabbit code reviews and exclude docs and binary media assets, reducing review errors and noise. Previously reviews ran on all files; now reviews skip `docs/**` and common media types.

- Sets `version: "2"`, `language: "en-US"`, and `reviews.profile: "chill"`.
- Adds `path_filters` for `docs/**`, `*.gif`, `*.webp`, `*.png`, `*.jpg`, `*.mp4`, `*.webm`.
- CI-only change with no runtime or build impact.

<sup>Written for commit 923a8d2e9ae14225a15476aada262d4e1b0a7442. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

