### PR TITLE
feat(cli): hide debug event logs by default and add -v/--verbose flag

### DIFF
--- a/modules/core/src/capabilities_observability_setup.py
+++ b/modules/core/src/capabilities_observability_setup.py
@@ -137,7 +137,7 @@ class ObservabilitySetup(IObservabilityProtocol):
 
     # ─── Block 2: Public Contract (IObservabilityProtocol ONLY) ──
 
-    def setup_observability(self, log_path: Path | None = None) -> None:
+    def setup_observability(self, log_path: Path | None = None, verbose: bool = False) -> None:
         """Bootstrap observability stack in 4 sequential steps:
 
         Step 1: Ensure log target directory exists
@@ -154,7 +154,7 @@ class ObservabilitySetup(IObservabilityProtocol):
         self._configure_tracing()
 
         # Step 3: Configure structlog/stdlib logging
-        self._configure_logging(target_path)
+        self._configure_logging(target_path, verbose=verbose)
 
         # Step 4: Install global process excepthooks
         install_excepthooks()
@@ -192,10 +192,11 @@ class ObservabilitySetup(IObservabilityProtocol):
         except (ImportError, RuntimeError):
             pass
 
-    def _configure_logging(self, log_path: Path) -> None:
+    def _configure_logging(self, log_path: Path, verbose: bool = False) -> None:
         """Configure structlog/stdlib logging (private helper)."""
+        log_level = logging.DEBUG if verbose else logging.WARNING
         if structlog is None:
-            logging.basicConfig(level=logging.INFO)
+            logging.basicConfig(level=log_level)
             return
 
         shared_processors: list[Any] = [
@@ -230,17 +231,19 @@ class ObservabilitySetup(IObservabilityProtocol):
         )
 
         root = logging.getLogger()
-        root.setLevel(logging.INFO)
+        root.setLevel(logging.DEBUG if verbose else logging.INFO)
         for handler in list(root.handlers):
             if handler.__class__.__name__.endswith("LogHandler"):
                 continue
             root.removeHandler(handler)
         stderr_handler = logging.StreamHandler(sys.stderr)
         stderr_handler.setFormatter(formatter)
+        stderr_handler.setLevel(log_level)
         root.addHandler(stderr_handler)
         try:
             file_handler = logging.FileHandler(log_path / "app.jsonl", encoding="utf-8")
             file_handler.setFormatter(formatter)
+            file_handler.setLevel(logging.DEBUG)
             root.addHandler(file_handler)
         except OSError:
             pass

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -38,40 +38,44 @@ _ERROR_PREFIX = "[ERROR]"
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments using subcommand-based interface."""
+    parent = argparse.ArgumentParser(add_help=False)
+    parent.add_argument("-v", "--verbose", action="store_true", default=argparse.SUPPRESS, help="Enable verbose debug event logging")
+
     p = argparse.ArgumentParser(
         prog="qwen-web-arwaky",
         description="Automate chat.qwen.ai without an API key.",
+        parents=[parent],
     )
     sub = p.add_subparsers(dest="action", metavar="ACTION")
 
     # ── doctor ────────────────────────────────────────────────────────────────
-    p_doctor = sub.add_parser("doctor", help="Run system environment and health diagnostics")
+    p_doctor = sub.add_parser("doctor", help="Run system environment and health diagnostics", parents=[parent])
     p_doctor.add_argument("--json", action="store_true", help="Format diagnostic output as JSON")
 
     # ── init ──────────────────────────────────────────────────────────────────
-    p_init = sub.add_parser("init", help="Initialize workspace (.agents/skills + .qwen-web symlinks)")
+    p_init = sub.add_parser("init", help="Initialize workspace (.agents/skills + .qwen-web symlinks)", parents=[parent])
     p_init.add_argument("--dir", dest="target_dir", default=None, help="Target directory (default: cwd)")
 
     # ── login ─────────────────────────────────────────────────────────────────
-    p_login = sub.add_parser("login", help="Open browser for manual login and save session")
+    p_login = sub.add_parser("login", help="Open browser for manual login and save session", parents=[parent])
     p_login.add_argument("--headless", action="store_true", help="Run browser headlessly")
 
     # ── prompt-direct ─────────────────────────────────────────────────────────
-    p_direct = sub.add_parser("prompt-direct", help="Send an inline text prompt to Qwen")
+    p_direct = sub.add_parser("prompt-direct", help="Send an inline text prompt to Qwen", parents=[parent])
     p_direct.add_argument("-t", "--text", required=True, help="Prompt text to send directly")
     p_direct.add_argument("-o", "--output-path", default=None, help="Output file path")
     p_direct.add_argument("--headless", action="store_true", help="Run browser headlessly")
     p_direct.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── prompt-only ───────────────────────────────────────────────────────────
-    p_only = sub.add_parser("prompt-only", help="Process a prompt file (no attachment)")
+    p_only = sub.add_parser("prompt-only", help="Process a prompt file (no attachment)", parents=[parent])
     p_only.add_argument("-i", "-p", "--prompt-path", required=True, help="Path to prompt markdown/text file")
     p_only.add_argument("-o", "--output-path", default=None, help="Output file path")
     p_only.add_argument("--headless", action="store_true", help="Run browser headlessly")
     p_only.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── prompt-with-attachment ────────────────────────────────────────────────
-    p_attach = sub.add_parser("prompt-with-attachment", help="Process a prompt file with a file attachment")
+    p_attach = sub.add_parser("prompt-with-attachment", help="Process a prompt file with a file attachment", parents=[parent])
     p_attach.add_argument("-i", "-p", "--prompt-path", required=True, help="Path to prompt markdown/text file")
     p_attach.add_argument("-a", "--attachment-path", required=True, help="Path to file to attach")
     p_attach.add_argument("-o", "--output-path", default=None, help="Output file path")
@@ -79,7 +83,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p_attach.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── mcp ───────────────────────────────────────────────────────────────────
-    sub.add_parser("mcp", help="Run as Model Context Protocol (MCP) server over stdio")
+    sub.add_parser("mcp", help="Run as Model Context Protocol (MCP) server over stdio", parents=[parent])
 
     return p.parse_args(argv)
 
@@ -88,6 +92,7 @@ def _build_config(args: argparse.Namespace) -> AppConfig:
     """Build AppConfig from parsed subcommand args using hardcoded defaults."""
     action = args.action
     headless = bool(getattr(args, "headless", False))
+    verbose = bool(getattr(args, "verbose", False))
     dummy_path = Path("/dev/null")
 
     prompt_p: Path | None = None
@@ -140,6 +145,7 @@ def _build_config(args: argparse.Namespace) -> AppConfig:
         session_path=DEFAULT_SESSION,
         log_path=DEFAULT_LOG,
         headless=headless,
+        verbose=verbose,
         prompt_file=prompt_p,
         prompt_path=prompt_p,
         file_path=file_p,
@@ -212,6 +218,8 @@ def _dispatch(
     if cfg is None:
         print(f"{_ERROR_PREFIX} Missing CLI configuration.", file=sys.stderr)
         return 1
+
+    container.observability.setup_observability(log_path=cfg.log_path, verbose=cfg.verbose)
 
     args._cfg = cfg
     result = surface_cli_run_command.handle(

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -39,7 +39,9 @@ _ERROR_PREFIX = "[ERROR]"
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments using subcommand-based interface."""
     parent = argparse.ArgumentParser(add_help=False)
-    parent.add_argument("-v", "--verbose", action="store_true", default=argparse.SUPPRESS, help="Enable verbose debug event logging")
+    parent.add_argument(
+        "-v", "--verbose", action="store_true", default=argparse.SUPPRESS, help="Enable verbose debug event logging"
+    )
 
     p = argparse.ArgumentParser(
         prog="qwen-web-arwaky",
@@ -75,7 +77,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p_only.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── prompt-with-attachment ────────────────────────────────────────────────
-    p_attach = sub.add_parser("prompt-with-attachment", help="Process a prompt file with a file attachment", parents=[parent])
+    p_attach = sub.add_parser(
+        "prompt-with-attachment", help="Process a prompt file with a file attachment", parents=[parent]
+    )
     p_attach.add_argument("-i", "-p", "--prompt-path", required=True, help="Path to prompt markdown/text file")
     p_attach.add_argument("-a", "--attachment-path", required=True, help="Path to file to attach")
     p_attach.add_argument("-o", "--output-path", default=None, help="Output file path")

--- a/modules/shared/src/contract_core_protocol.py
+++ b/modules/shared/src/contract_core_protocol.py
@@ -162,7 +162,7 @@ class IObservabilityProtocol(ABC):
     """Observability capability contract (logging, tracing, hooks)."""
 
     @abstractmethod
-    def setup_observability(self, log_path: Path) -> None:
+    def setup_observability(self, log_path: Path | None = None, verbose: bool = False) -> None:
         """Bootstrap Sentry/OTel/structlog + global hooks."""
 
     @abstractmethod

--- a/modules/shared/src/taxonomy_core_vo.py
+++ b/modules/shared/src/taxonomy_core_vo.py
@@ -411,6 +411,7 @@ class AppConfig:
     circuit_breaker_window: int = 30
 
     retry_failed: bool = False
+    verbose: bool = False
 
     @property
     def status_path(self) -> Path:

--- a/tests/smoke_entry_points.py
+++ b/tests/smoke_entry_points.py
@@ -54,4 +54,3 @@ def test_cli_parse_args_verbose_flag() -> None:
     assert args_v_long.verbose is True
     cfg_v_long = _build_config(args_v_long)
     assert cfg_v_long.verbose is True
-

--- a/tests/smoke_entry_points.py
+++ b/tests/smoke_entry_points.py
@@ -34,3 +34,24 @@ def test_mcp_entry_is_importable() -> None:
 
     assert callable(run_mcp_server)
     assert callable(main)
+
+
+def test_cli_parse_args_verbose_flag() -> None:
+    """The CLI entry point must parse -v and --verbose flags correctly."""
+    from modules.root_cli_main_entry import _build_config, _parse_args
+
+    args_quiet = _parse_args(["prompt-direct", "-t", "hello"])
+    assert getattr(args_quiet, "verbose", False) is False
+    cfg_quiet = _build_config(args_quiet)
+    assert cfg_quiet.verbose is False
+
+    args_v_short = _parse_args(["-v", "prompt-direct", "-t", "hello"])
+    assert args_v_short.verbose is True
+    cfg_v_short = _build_config(args_v_short)
+    assert cfg_v_short.verbose is True
+
+    args_v_long = _parse_args(["prompt-direct", "-t", "hello", "--verbose"])
+    assert args_v_long.verbose is True
+    cfg_v_long = _build_config(args_v_long)
+    assert cfg_v_long.verbose is True
+


### PR DESCRIPTION
## Summary
- Update CLI UI/UX so internal debug event logs are hidden by default.
- Full Qwen AI response text remains printed in full on stdout.
- Added -v / --verbose flag to CLI to enable full debug event logging when needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides debug/info event logs on stderr by default and adds a global -v/--verbose flag to re-enable them. Previously stderr included INFO; now stderr is WARNING+, while the Qwen response still prints fully to stdout. With -v, stderr is DEBUG and file logs remain DEBUG.

- Add `-v/--verbose` to the shared parent parser used by all subcommands; plumb through `AppConfig.verbose`; call `container.observability.setup_observability(log_path=cfg.log_path, verbose=cfg.verbose)` at dispatch. Smoke tests cover short and long flags.
- Observability: `setup_observability(log_path: Path | None = None, verbose: bool = False)` sets stderr to WARNING by default and DEBUG with `-v`; root logger to INFO by default and DEBUG with `-v`; file handler always at DEBUG. The non-`structlog` fallback sets `basicConfig` to WARNING by default and DEBUG with `-v`.

**Migration**
- Update `IObservabilityProtocol.setup_observability(log_path: Path | None = None, verbose: bool = False)` in all implementations.

<sup>Written for commit d93ae85b48955977444351ebd7dda81b3ac91a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

