### PR TITLE
chore(release): v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.3.0] - 2026-08-18
+
+### Added
+
+- feat(cli): hide debug event logs by default for quiet terminal UI/UX experience while keeping full Qwen AI output response
+- feat(cli): add `-v` / `--verbose` flag to enable detailed internal event debug logging when needed
+
+### Fixed
+
+- fix(docs): replace webp with animated GIF in `README.md` for GitHub compatibility
+
+---
+
 ## [4.2.0] - 2026-08-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwen-web-cli"
-version = "4.2.0"
+version = "4.3.0"
 description = "Production-grade CLI automation and MCP server for chat.qwen.ai"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## v4.3.0 Release

### Added
- feat(cli): hide debug event logs by default for quiet terminal UI/UX experience while keeping full Qwen AI output response
- feat(cli): add `-v` / `--verbose` flag to enable detailed internal event debug logging when needed

### Fixed
- fix(docs): replace webp with animated GIF in `README.md` for GitHub compatibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses internal debug event logs by default in `qwen-web-cli` and adds `-v`/`--verbose` to opt in. Previously logs printed by default; now they’re hidden unless verbose is set, reducing noise while keeping normal Qwen responses unchanged. Also updates `README.md` to use an animated GIF for GitHub compatibility.

- Migration: If your scripts rely on debug event logs, invoke the CLI with `-v` or `--verbose` to restore them.

<sup>Written for commit 695c8e2f35c4ec1cc5d44336ca98eea5ede3f7d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

