### PR TITLE
fix(core): support config parameter in SendDispatcher.click_send

### DIFF
--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -121,8 +121,9 @@ class SendDispatcher(ISendProtocol):
         self,
         page: Page,
         emitter: LifecycleEmitter,
-        _config: SenderConfig | None = None,
+        config: SenderConfig | None = None,
         document_parsed: bool = True,
+        _config: SenderConfig | None = None,
     ) -> None:
         """Click prompt send button in 4 sequential steps:
 
@@ -137,7 +138,7 @@ class SendDispatcher(ISendProtocol):
                 "Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete"
             )
 
-        effective_config = _config or SenderConfig(
+        effective_config = config or _config or SenderConfig(
             click_timeout_ms=int(self.click_timeout_ms),
             try_enter_key_fallback=bool(self.try_enter_key_fallback),
         )

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -138,9 +138,13 @@ class SendDispatcher(ISendProtocol):
                 "Cannot send prompt: document attachment parsing (EVENT_DOCUMENT_PARSED) is incomplete"
             )
 
-        effective_config = config or _config or SenderConfig(
-            click_timeout_ms=int(self.click_timeout_ms),
-            try_enter_key_fallback=bool(self.try_enter_key_fallback),
+        effective_config = (
+            config
+            or _config
+            or SenderConfig(
+                click_timeout_ms=int(self.click_timeout_ms),
+                try_enter_key_fallback=bool(self.try_enter_key_fallback),
+            )
         )
 
         deadline = time.monotonic() + (effective_config.click_timeout_ms / 1000)

--- a/tests/unit_capability_send_dispatcher.py
+++ b/tests/unit_capability_send_dispatcher.py
@@ -43,6 +43,20 @@ class TestClickSendExtended:
         page.keyboard.press.assert_called_once_with("Enter")
         assert emitter.emit.call_count == 2
 
+    def test_click_send_with_config_keyword_arg(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+        loc = MagicMock()
+        loc.count.return_value = 1
+        loc.first.count.return_value = 0
+        loc.first.is_visible.return_value = False
+        page.locator.return_value = loc
+        page.keyboard.press = MagicMock()
+
+        cfg = SenderConfig(click_timeout_ms=100, try_enter_key_fallback=True)
+        _sender().click_send(page, emitter, config=cfg)
+        page.keyboard.press.assert_called_once_with("Enter")
+
     def test_selector_exception_continues(self):
         page = MagicMock()
         emitter = MagicMock(spec=LifecycleEmitter)


### PR DESCRIPTION
## Summary
Fixes TypeError when SendDispatcher.click_send() is called with config=... keyword argument from agent_attachment_prompt_orchestrator.py or protocol consumers.

## Changes
- Updated SendDispatcher.click_send in modules/core/src/capabilities_send_dispatcher.py to support both config and _config parameters matching ISendProtocol.
- Added unit test test_click_send_with_config_keyword_arg in tests/unit_capability_send_dispatcher.py.

## Verification
- All 232 unit tests pass.
- End-to-end prompt-with-attachment execution verified with real Qwen Web browser automation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `config` in `SendDispatcher.click_send` to match `ISendProtocol`, preventing a TypeError when callers pass `config=...`. When both `config` and `_config` are provided, `config` takes precedence; default behavior is unchanged.

**Review notes**
- Expanded method signature and resolved `effective_config = config or _config or SenderConfig(...)`.
- Added unit test for the `config` keyword path.
- Applied `ruff` formatting only; no functional changes.
- No migration required; callers may pass `config` for protocol consistency. Existing `_config` calls continue to work.

<sup>Written for commit bdeed3c7bc9c47330eaa576ba5c9e0306905c8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing sender configuration per send action.
  * Preserved compatibility with existing configuration options.

* **Bug Fixes**
  * Improved send behavior by reliably falling back to the Enter key when no visible send control is available.

* **Tests**
  * Added coverage for per-action configuration and Enter-key fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->