### PR TITLE
fix: add response safety circuit breaker

### DIFF
--- a/modules/core/src/capabilities_stream_monitor.py
+++ b/modules/core/src/capabilities_stream_monitor.py
@@ -18,7 +18,11 @@ from modules.shared.src.taxonomy_core_constant import (
     STOP_BUTTON_SELECTORS,
 )
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter
-from modules.shared.src.taxonomy_core_error import AuthRequiredError, OutputValidationError
+from modules.shared.src.taxonomy_core_error import (
+    AuthRequiredError,
+    OutputValidationError,
+    ResponseDetectionTimeoutError,
+)
 from modules.shared.src.taxonomy_core_event import (
     EVENT_GENERATION_FINISHED,
     EVENT_STREAMING_GENERATION,
@@ -35,6 +39,7 @@ from modules.shared.src.utility_core_events import is_stability_satisfied, shoul
 from modules.shared.src.utility_core_validation import validate_response_content
 
 log = get_logger("capabilities_stream_monitor")
+DEFAULT_SAFETY_TIMEOUT_SEC = 4 * 60 * 60
 
 
 # Block 1: Class Definition & Constructor
@@ -46,7 +51,12 @@ class StreamMonitor(IStreamProtocol):
     def __init__(
         self,
         config: StreamerConfig | None = None,
+        *,
+        safety_timeout_sec: int = DEFAULT_SAFETY_TIMEOUT_SEC,
     ) -> None:
+        if safety_timeout_sec <= 0:
+            raise ValueError("safety_timeout_sec must be greater than zero")
+        self.safety_timeout_sec = int(safety_timeout_sec)
         if config is not None:
             self.polling_interval_sec = PollIntervalSec(config.polling_interval_sec)
             self.stability_checks = StabilityChecks(config.stability_checks)
@@ -126,8 +136,9 @@ class StreamMonitor(IStreamProtocol):
 
         # Step 2: Capture baseline message state
         log.info(
-            "Waiting for AI response until terminal event (timeout hint: %ss; no response cutoff)",
+            "Waiting for AI response until terminal event (timeout hint: %ss; safety circuit breaker: %ss)",
             timeout_sec,
+            self.safety_timeout_sec,
         )
         previous_text: str | None = str(baseline_text) if baseline_text is not None else _dom_latest(page)
 
@@ -140,6 +151,11 @@ class StreamMonitor(IStreamProtocol):
         while True:
             now = time.time()
             elapsed = now - start
+            if elapsed >= self.safety_timeout_sec:
+                raise ResponseDetectionTimeoutError(
+                    "Response safety circuit breaker tripped after "
+                    f"{self.safety_timeout_sec}s without a terminal generation event"
+                )
 
             is_thinking = self.is_thinking_active(page)
             is_complete = self.is_generation_complete(page)

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -147,7 +147,7 @@ Response completion is **event-driven**, not duration-driven. The historical `ti
 - **Terminal event as source of truth**: The monitor waits for stable response text plus an explicit generation-complete state.
 - **Long-running recovery**: Every 30 seconds the browser can reload to resynchronize cloud state. Browser operation timeouts trigger recovery and continue waiting instead of reporting success or truncating the response.
 - **Output-written success gate**: The pipeline emits `EVENT_OUTPUT_COPIED` only after the saver returns and the target output file is verified as readable and non-empty. CLI success/exit code `0` is downstream of that event.
-- **24-hour operation target**: A persistent host can keep the process alive for 24 hours or longer. No response-duration limit is imposed by the monitor; explicit user cancellation and unrecoverable authentication errors remain the only normal stop paths.
+- **24-hour operation target**: A persistent host can keep the process alive for 24 hours or longer. Normal completion remains event-driven; a separate **4-hour safety circuit breaker** only stops a run that has produced no terminal event at all, preventing infinite hangs and resource exhaustion.
 - **Parse-Gated Dispatch**: Document parsing is held automatically until backend `/files/parse` 200 OK is confirmed before sending.
 - **Maximum Attachment Size**: **100 MB** (pre-flight validated).
 

--- a/tests/unit_capability_stream_monitor.py
+++ b/tests/unit_capability_stream_monitor.py
@@ -19,6 +19,7 @@ from modules.shared.src import (
     OutputValidationError,
 )
 from modules.shared.src.taxonomy_core_constant import JS_GET_RESPONSE_TEXT
+from modules.shared.src.taxonomy_core_error import ResponseDetectionTimeoutError
 
 # ─── validate_response_content ──────────────────────────────────────────────
 
@@ -180,6 +181,56 @@ class TestWaitForResponseEdgeCases:
             StreamMonitor().wait_for_response(
                 page, timeout_sec=10, msg_count_before=0, emitter=emitter, dispatch_acknowledged=False
             )
+
+    def test_safety_circuit_breaker_raises_after_configured_budget(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+
+        with (
+            patch("modules.core.src.capabilities_stream_monitor._dom_latest", return_value=None),
+            patch.object(StreamMonitor, "is_thinking_active", return_value=False),
+            patch.object(StreamMonitor, "is_generation_complete", return_value=False),
+            patch("modules.core.src.capabilities_stream_monitor.time") as mock_time,
+        ):
+            mock_time.time.side_effect = [0, 14_400]
+            mock_time.sleep = MagicMock()
+
+            with pytest.raises(ResponseDetectionTimeoutError, match="circuit breaker"):
+                StreamMonitor(safety_timeout_sec=14_400).wait_for_response(
+                    page,
+                    timeout_sec=120,
+                    msg_count_before=1,
+                    emitter=emitter,
+                    polling_interval_sec=0,
+                )
+
+    def test_playwright_timeout_is_recovered_without_failing(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+        response = "A response recovered after a transient browser timeout."
+
+        with (
+            patch(
+                "modules.core.src.capabilities_stream_monitor._dom_latest",
+                side_effect=[None, TimeoutError("temporary"), response, response],
+            ),
+            patch.object(StreamMonitor, "is_generation_complete", return_value=True),
+            patch.object(StreamMonitor, "is_thinking_active", return_value=False),
+            patch("modules.core.src.capabilities_stream_monitor.time") as mock_time,
+        ):
+            mock_time.time.side_effect = [0, 1, 2, 3, 4, 5]
+            mock_time.sleep = MagicMock()
+
+            result = StreamMonitor(safety_timeout_sec=100).wait_for_response(
+                page,
+                timeout_sec=1,
+                msg_count_before=1,
+                emitter=emitter,
+                polling_interval_sec=0,
+                stability_checks=1,
+            )
+
+        assert result == response
 
     def test_timeout_hint_does_not_end_wait_before_terminal_event(self):
         page = MagicMock()


### PR DESCRIPTION
## Summary

This follow-up adds the HIGH RISK Codacy recommendation from PR #144: a four-hour safety circuit breaker for the event-driven response monitor.

## Changes

- Add a default `4 * 60 * 60` second safety budget to `StreamMonitor`.
- Keep normal completion event-driven: stable text plus the explicit generation-complete signal still ends a successful run immediately.
- Raise `ResponseDetectionTimeoutError` only when no terminal generation event arrives before the safety circuit breaker expires, preventing infinite loops and resource exhaustion.
- Preserve transient browser timeout recovery and periodic reload behavior.
- Add regression coverage for the configured 4-hour boundary and Playwright timeout recovery.
- Update the lifecycle documentation to distinguish the 4-hour safety circuit breaker from the normal response completion path.

## Validation

- `ruff format` passed.
- `ruff check` passed.
- `mypy modules` passed.
- `pytest tests/ -q -m 'not slow and not e2e'` passed.
- `git diff --check` passed.

The circuit breaker is a safety stop only; it does not replace event-driven completion and does not interrupt a response that reaches its terminal event earlier.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a four-hour safety circuit breaker to `StreamMonitor` to stop runs that never reach a terminal generation event, preventing infinite hangs and resource exhaustion. Previously the monitor had no cutoff; now it raises `ResponseDetectionTimeoutError` after the safety budget while preserving normal event-driven completion and timeout recovery.

- Adds kw-only `safety_timeout_sec` to `StreamMonitor` (default `4 * 60 * 60`; must be > 0) and logs the configured safety budget.
- `wait_for_response` now raises `ResponseDetectionTimeoutError` when no terminal event arrives before the safety budget; stable text + explicit generation-complete still ends immediately.
- Transient browser timeouts continue to recover; no change to periodic reload behavior.
- Tests cover the 4-hour boundary and Playwright timeout recovery; lifecycle notes updated in `modules/shared/src/taxonomy_skill_constant.py`.

Migration
- If workflows can exceed 4 hours, pass a higher `safety_timeout_sec`.
- Catch `ResponseDetectionTimeoutError` where you previously assumed indefinite waiting.

<sup>Written for commit 35ce050ed94b063c8d9e1841931472add4b3dde2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a four-hour safety timeout for runs that do not receive a terminal completion event.
  * Added clear timeout error handling when the safety limit is reached.
  * Transient browser timeouts are now recovered when a response becomes available.

* **Documentation**
  * Updated skill documentation to explain safety timeout behavior and support for longer-running hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->