### PR TITLE
chore(release): bump version to v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.1.0] - 2026-08-19
+
+### Added
+
+- feat(core): make response completion event-driven, with `EVENT_OUTPUT_COPIED` as the verified output-success gate
+- feat(core): add a 4-hour safety circuit breaker that raises `ResponseDetectionTimeoutError` only when no terminal generation event arrives
+- test(core): add regression coverage for delayed responses, transient browser-timeout recovery, output verification, and safety circuit breaking
+
+### Changed
+
+- refactor(core): preserve long-running Qwen generations while using periodic browser reloads for recovery rather than normal response cutoffs
+- chore(release): bump version to `5.1.0` across root and module `pyproject.toml` manifests and embedded skill metadata
+
+---
+
 ## [5.0.0] - 2026-08-19
 
 ### Added

--- a/modules/core/pyproject.toml
+++ b/modules/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-core"
-version = "5.0.0"
+version = "5.1.0"
 description = "qwen-web core feature: capabilities, orchestrators, and DI container"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/mcp/pyproject.toml
+++ b/modules/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-mcp"
-version = "5.0.0"
+version = "5.1.0"
 description = "qwen-web MCP surface layer (tools)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/shared/pyproject.toml
+++ b/modules/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-shared"
-version = "5.0.0"
+version = "5.1.0"
 description = "qwen-web shared taxonomy, contracts, and utilities (domain layer)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -15,7 +15,7 @@ description: >
   analyze documents (PDF/MD/TXT attachments); run long deep-reasoning software
   engineering tasks (up to 15 minutes); or manage Qwen login sessions — via the
   qwen-web-arwaky CLI or MCP tools.
-version: 5.0.0
+version: 5.1.0
 trigger_keywords:
   - qwen
   - chat.qwen.ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwen-web-cli"
-version = "5.0.0"
+version = "5.1.0"
 description = "Production-grade CLI automation and MCP server for chat.qwen.ai"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release 5.1.0

This release packages the event-driven response lifecycle and the safety improvements delivered after v5.0.0.

### Highlights

The response monitor now completes from terminal lifecycle events rather than normal duration cutoffs. Successful output is gated by verified `EVENT_OUTPUT_COPIED` after the target file is readable and non-empty. Long-running Qwen generations continue with periodic browser recovery.

A four-hour safety circuit breaker is included as a resource-protection guard. It raises `ResponseDetectionTimeoutError` only when no terminal generation event arrives for four hours; it does not interrupt normal responses that complete earlier through the event-driven path.

The release also includes regression coverage for delayed responses, transient browser timeout recovery, output verification, and the safety circuit breaker.

### Version files

The release version is `5.1.0` in the root package manifest, core package manifest, MCP package manifest, shared package manifest, and embedded skill metadata. `CHANGELOG.md` includes the 5.1.0 release notes.

### Validation

- `ruff format` passed.
- `ruff check` passed.
- `mypy modules` passed.
- `pytest tests/ -q -m 'not slow and not e2e'` passed.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 5.1.0 updates versions across manifests and ships the event‑driven response lifecycle. Completion now triggers on terminal events instead of duration cutoffs, gates success on verified `EVENT_OUTPUT_COPIED`, preserves long‑running Qwen generations via periodic browser reloads, and adds a 4‑hour circuit breaker that only raises `ResponseDetectionTimeoutError` when no terminal event arrives.

- Set version to `5.1.0` in `pyproject.toml`, `modules/core/pyproject.toml`, `modules/mcp/pyproject.toml`, `modules/shared/pyproject.toml`, and `modules/shared/src/taxonomy_skill_constant.py`; update `CHANGELOG.md` with 5.1.0 notes.
- No functional code changes in this PR; it finalizes the release metadata for previously merged behavior.

<sup>Written for commit 088504b2c8eccc70365777407ffb5ae1741cacc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

