### PR TITLE
fix: make prompt-file pipeline reliable

### DIFF
--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -191,9 +191,11 @@ class BrowserAdapter(IBrowserProtocol):
         _assert_on_chat_page(page)
 
         # Step 3: Start clean conversation state. Qwen hydrates the model picker
-        # asynchronously after this reset; wait for that UI state before selecting.
+        # asynchronously after this reset; wait for its actual default option rather
+        # than sleeping for a fixed duration.
         self._start_new_chat(page)
-        page.wait_for_timeout(10_000)
+        with contextlib.suppress(Error):
+            self._wait_for_model_picker_ready(page)
 
         # Step 4: Emit lifecycle events
         emitter.emit(EVENT_WEB_LOADED, {"url": page.url})
@@ -234,10 +236,7 @@ class BrowserAdapter(IBrowserProtocol):
                         error=str(exc),
                         attempt=attempt + 1,
                     )
-                    with contextlib.suppress(Error):
-                        page.keyboard.press("Escape")
-                        page.wait_for_timeout(2000)
-                    self.ensure_default_model(page)
+                    self._retry_default_model_selection(page)
                     continue
                 raise ModelSwitchError(
                     f"Cannot read active model from '{MODEL_SELECTOR_BUTTON}' button: {exc}"
@@ -253,13 +252,33 @@ class BrowserAdapter(IBrowserProtocol):
                     require_switch=require_switch,
                     attempt=attempt + 1,
                 )
-                with contextlib.suppress(Error):
-                    page.keyboard.press("Escape")
-                    page.wait_for_timeout(2000)
-                self.ensure_default_model(page)
+                self._retry_default_model_selection(page)
                 continue
             raise ModelSwitchError(f"Default model not active: expected '{DEFAULT_MODEL}', found '{current}'")
         raise ModelSwitchError(f"Default model not active: expected '{DEFAULT_MODEL}'")
+
+    def _wait_for_model_picker_ready(self, page: Page, timeout_ms: int = 15_000) -> None:
+        """Wait until the hydrated picker exposes the configured default option."""
+        picker = self._get_model_trigger(page)
+        picker.wait_for(state="visible", timeout=timeout_ms)
+        picker.click(timeout=5000)
+        try:
+            option: Any = page.get_by_role("option", name=DEFAULT_MODEL)
+            with contextlib.suppress(Error):
+                loc = page.locator(".wms-list__item", has_text=DEFAULT_MODEL).first
+                if loc.is_visible(timeout=1000) is True:
+                    option = loc
+            option.wait_for(state="visible", timeout=timeout_ms)
+        finally:
+            with contextlib.suppress(Error):
+                page.keyboard.press("Escape")
+
+    def _retry_default_model_selection(self, page: Page) -> None:
+        """Close a stale picker, allow hydration, and retry default-model selection."""
+        with contextlib.suppress(Error):
+            page.keyboard.press("Escape")
+            page.wait_for_timeout(2000)
+        self.ensure_default_model(page)
 
     def _get_model_trigger(self, page: Page) -> Any:
         """Return locator for active model selector trigger button/div."""

--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -137,25 +137,34 @@ class BrowserAdapter(IBrowserProtocol):
         navigation_timeout_ms: int,
         load_timeout_ms: int,
     ) -> None:
-        """Navigate to chat.qwen.ai and wait for the DOM to load."""
-        try:
-            page.goto(
-                CHAT_URL,
-                wait_until="domcontentloaded",
-                timeout=navigation_timeout_ms,
-            )
-        except Error as err:
-            log.warning("Initial page.goto failed (%s), retrying navigation...", err)
-            page.wait_for_timeout(1500)
-            page.goto(
-                CHAT_URL,
-                wait_until="domcontentloaded",
-                timeout=navigation_timeout_ms,
-            )
-        try:
-            page.wait_for_load_state("domcontentloaded", timeout=load_timeout_ms)
-        except Error as e:
-            log.warning("Load state wait failed, proceeding: %s", e)
+        """Navigate to chat.qwen.ai without waiting on third-party page assets.
+
+        ``domcontentloaded`` can remain pending when Qwen or an analytics asset
+        stalls. The application only needs the committed chat document before
+        its own DOM readiness checks, so navigation uses ``commit`` and treats
+        the later DOMContentLoaded wait as best-effort. A second commit attempt
+        remains available for transient connection failures.
+        """
+        last_error: Error | None = None
+        for attempt in range(2):
+            try:
+                page.goto(
+                    CHAT_URL,
+                    wait_until="commit",
+                    timeout=navigation_timeout_ms,
+                )
+                try:
+                    page.wait_for_load_state("domcontentloaded", timeout=load_timeout_ms)
+                except Error as err:
+                    log.warning("Load state wait failed, proceeding: %s", err)
+                return
+            except Error as err:
+                last_error = err
+                if attempt == 0:
+                    log.warning("Initial page.goto failed (%s), retrying commit navigation...", err)
+                    page.wait_for_timeout(1500)
+        if last_error is not None:
+            raise last_error
 
     def reset_page(self, page: Page, emitter: LifecycleEmitter) -> None:
         """Reset the page to a clean state by navigating back to chat.qwen.ai."""
@@ -181,8 +190,10 @@ class BrowserAdapter(IBrowserProtocol):
         # Step 2: Verify user authentication
         _assert_on_chat_page(page)
 
-        # Step 3: Start clean conversation state
+        # Step 3: Start clean conversation state. Qwen hydrates the model picker
+        # asynchronously after this reset; wait for that UI state before selecting.
         self._start_new_chat(page)
+        page.wait_for_timeout(10_000)
 
         # Step 4: Emit lifecycle events
         emitter.emit(EVENT_WEB_LOADED, {"url": page.url})
@@ -202,10 +213,14 @@ class BrowserAdapter(IBrowserProtocol):
         the pipeline dispatch the prompt to the wrong model. Raises
         ``ModelSwitchError`` when the switch cannot be confirmed. When the
         best-effort switch reported failure (``require_switch=False``), the
-        verification is retried once before aborting so a slow picker cannot
-        hard-fail the pipeline.
+        verification is retried while the model picker hydrates so a slow picker
+        cannot hard-fail the pipeline prematurely.
         """
-        attempts = 1 if require_switch else 2
+        # Model picker options can arrive after the committed page document,
+        # especially when Qwen's static assets are slow. Keep this readiness gate
+        # bounded and retry selection instead of failing the whole pipeline on the
+        # first stale model label.
+        attempts = 5
         for attempt in range(attempts):
             try:
                 picker = self._get_model_trigger(page)
@@ -219,7 +234,16 @@ class BrowserAdapter(IBrowserProtocol):
                 log.debug("verify_default_model_ok", model=DEFAULT_MODEL)
                 return
             if attempt + 1 < attempts:
-                log.debug("verify_default_model_retry", model=DEFAULT_MODEL, found=current)
+                log.debug(
+                    "verify_default_model_retry",
+                    model=DEFAULT_MODEL,
+                    found=current,
+                    require_switch=require_switch,
+                    attempt=attempt + 1,
+                )
+                with contextlib.suppress(Error):
+                    page.keyboard.press("Escape")
+                    page.wait_for_timeout(2000)
                 self.ensure_default_model(page)
                 continue
             raise ModelSwitchError(f"Default model not active: expected '{DEFAULT_MODEL}', found '{current}'")

--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -227,6 +227,18 @@ class BrowserAdapter(IBrowserProtocol):
                 picker.wait_for(state="visible", timeout=5000)
                 current = (picker.inner_text() or "").replace("\n", " ").strip()
             except Error as exc:
+                if attempt + 1 < attempts:
+                    log.debug(
+                        "verify_default_model_read_retry",
+                        model=DEFAULT_MODEL,
+                        error=str(exc),
+                        attempt=attempt + 1,
+                    )
+                    with contextlib.suppress(Error):
+                        page.keyboard.press("Escape")
+                        page.wait_for_timeout(2000)
+                    self.ensure_default_model(page)
+                    continue
                 raise ModelSwitchError(
                     f"Cannot read active model from '{MODEL_SELECTOR_BUTTON}' button: {exc}"
                 ) from exc
@@ -317,7 +329,7 @@ class BrowserAdapter(IBrowserProtocol):
         try:
             if "/c/" in page.url.lower():
                 log.info("Active chat thread detected (%s). Navigating to root chat URL...", page.url)
-                page.goto(CHAT_URL, wait_until="domcontentloaded", timeout=15_000)
+                self._goto_chat(page, 15_000, 15_000)
                 page.wait_for_timeout(1000)
 
             if click_first_visible_enabled(page, NEW_CHAT_SELECTORS, timeout_ms=3000):

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -214,7 +214,7 @@ class SendDispatcher(ISendProtocol):
                 if int(count_messages(page)) > baseline_count:
                     return True
                 current_text = _latest_message_text(page)
-                if current_text != baseline_text and current_text is not None:
+                if current_text is not None and str(current_text).strip() and current_text != baseline_text:
                     return True
             except (Error, TimeoutError):
                 pass

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import contextlib
 import time
-from typing import Any, cast
 
 from playwright.sync_api import Error, Page
 
@@ -15,7 +14,7 @@ from modules.core.src.utility_core_dom_helper import click_send as _dom_click_se
 from modules.core.src.utility_core_dom_query import count_messages, latest_message_text
 from modules.core.src.utility_core_logger_factory import get_logger
 from modules.shared.src.contract_core_protocol import ISendProtocol
-from modules.shared.src.taxonomy_core_constant import SEND_DISABLED_SELECTORS, TEXTAREA_SELECTOR
+from modules.shared.src.taxonomy_core_constant import TEXTAREA_SELECTOR
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter
 from modules.shared.src.taxonomy_core_error import SendDispatchError
 from modules.shared.src.taxonomy_core_event import EVENT_DISPATCH_ACKNOWLEDGED, EVENT_SEND_CLICKED
@@ -190,7 +189,13 @@ class SendDispatcher(ISendProtocol):
         raise SendDispatchError("Send control dispatch timed out waiting for document parsing or user turn ACK")
 
     def _wait_for_dispatch_ack(self, page: Page, baseline_count: int, timeout_ms: int | None = None) -> bool:
-        """Verify that the click produced a new user turn or reset the composer."""
+        """Verify that the click produced a real new user turn.
+
+        A cleared composer or disabled send button is not sufficient evidence:
+        Qwen can reset either control before the user turn is committed. The
+        acknowledgment must come from a new turn count or a changed message
+        surface so the response monitor cannot wait on a false dispatch.
+        """
         from modules.core.src.utility_core_dom_query import latest_message_text as _latest_message_text
 
         effective_timeout = timeout_ms if timeout_ms is not None else int(self.click_timeout_ms)
@@ -199,17 +204,6 @@ class SendDispatcher(ISendProtocol):
         while time.monotonic() < deadline:
             try:
                 if int(count_messages(page)) > baseline_count:
-                    return True
-                textarea = page.locator(TEXTAREA_SELECTOR).first
-                textarea_count = cast(Any, textarea.count())
-                if not isinstance(textarea_count, int):
-                    return True
-                if textarea_count > 0:
-                    value = textarea.input_value(timeout=100)
-                    if not value.strip():
-                        return True
-                disabled_count = cast(Any, page.locator(SEND_DISABLED_SELECTORS).count())
-                if isinstance(disabled_count, int) and disabled_count > 0:
                     return True
                 current_text = _latest_message_text(page)
                 if current_text != baseline_text and current_text is not None:

--- a/modules/core/src/capabilities_send_dispatcher.py
+++ b/modules/core/src/capabilities_send_dispatcher.py
@@ -151,6 +151,7 @@ class SendDispatcher(ISendProtocol):
             # Step 2: Wait for send button enabled & no active parse toast
             self._wait_for_send_enabled(page, timeout_ms=effective_config.click_timeout_ms)
             baseline_count = int(count_messages(page))
+            baseline_text = latest_message_text(page)
 
             # Step 3: Trigger DOM send click
             if not _dom_click_send(page, _config=effective_config):
@@ -166,7 +167,9 @@ class SendDispatcher(ISendProtocol):
             emitter.emit(EVENT_SEND_CLICKED, details)
 
             # Step 4: Verify dispatch acknowledgment (with Enter fallback if needed)
-            if not self._wait_for_dispatch_ack(page, baseline_count, timeout_ms=int(effective_config.click_timeout_ms)):
+            if not self._wait_for_dispatch_ack(
+                page, baseline_count, baseline_text, timeout_ms=int(effective_config.click_timeout_ms)
+            ):
                 if _is_parse_toast_visible(page):
                     page.wait_for_timeout(1000)
                     continue
@@ -177,7 +180,7 @@ class SendDispatcher(ISendProtocol):
                     with contextlib.suppress(Error, TimeoutError):
                         page.keyboard.press("Enter")
                 if not self._wait_for_dispatch_ack(
-                    page, baseline_count, timeout_ms=int(effective_config.click_timeout_ms)
+                    page, baseline_count, baseline_text, timeout_ms=int(effective_config.click_timeout_ms)
                 ):
                     if _is_parse_toast_visible(page):
                         page.wait_for_timeout(1000)
@@ -188,7 +191,13 @@ class SendDispatcher(ISendProtocol):
 
         raise SendDispatchError("Send control dispatch timed out waiting for document parsing or user turn ACK")
 
-    def _wait_for_dispatch_ack(self, page: Page, baseline_count: int, timeout_ms: int | None = None) -> bool:
+    def _wait_for_dispatch_ack(
+        self,
+        page: Page,
+        baseline_count: int,
+        baseline_text: ResponseText | None,
+        timeout_ms: int | None = None,
+    ) -> bool:
         """Verify that the click produced a real new user turn.
 
         A cleared composer or disabled send button is not sufficient evidence:
@@ -200,7 +209,6 @@ class SendDispatcher(ISendProtocol):
 
         effective_timeout = timeout_ms if timeout_ms is not None else int(self.click_timeout_ms)
         deadline = time.monotonic() + (effective_timeout / 1000)
-        baseline_text = _latest_message_text(page)
         while time.monotonic() < deadline:
             try:
                 if int(count_messages(page)) > baseline_count:

--- a/tests/unit_browser_adapter.py
+++ b/tests/unit_browser_adapter.py
@@ -187,6 +187,24 @@ def test_ensure_default_model_swallows_error():
     assert BrowserAdapter().ensure_default_model(mock_page) is False
 
 
+def test_verify_default_model_retries_transient_picker_read_failure():
+    from playwright.sync_api import Error as PwError
+
+    from modules.shared.src.taxonomy_core_constant import DEFAULT_MODEL
+
+    mock_page = MagicMock()
+    picker = mock_page.get_by_role.return_value
+    picker.inner_text.side_effect = [PwError("picker not hydrated"), f"Select Model {DEFAULT_MODEL}"]
+    adapter = BrowserAdapter()
+    adapter.ensure_default_model = MagicMock(return_value=False)
+
+    adapter._verify_default_model(mock_page)
+
+    assert picker.inner_text.call_count == 2
+    mock_page.keyboard.press.assert_called_once_with("Escape")
+    adapter.ensure_default_model.assert_called_once_with(mock_page)
+
+
 def test_verify_default_model_ok():
     from modules.shared.src.taxonomy_core_constant import DEFAULT_MODEL
 

--- a/tests/unit_browser_adapter.py
+++ b/tests/unit_browser_adapter.py
@@ -81,6 +81,18 @@ def test_reset_page_emits_reconnecting():
     mock_page.goto.assert_called_once()
 
 
+def test_goto_chat_uses_commit_when_domcontentloaded_is_slow():
+    from playwright.sync_api import Error as PwError
+
+    mock_page = MagicMock()
+    mock_page.wait_for_load_state.side_effect = PwError("third-party asset stalled")
+
+    BrowserAdapter()._goto_chat(mock_page, navigation_timeout_ms=1000, load_timeout_ms=100)
+
+    assert mock_page.goto.call_args.kwargs["wait_until"] == "commit"
+    assert mock_page.goto.call_args.kwargs["timeout"] == 1000
+
+
 def test_navigate_to_chat_emits_web_loaded():
     mock_page = MagicMock()
     mock_page.url = "https://chat.qwen.ai/"

--- a/tests/unit_capability_send_dispatcher.py
+++ b/tests/unit_capability_send_dispatcher.py
@@ -30,13 +30,14 @@ class TestClickSendExtended:
         emitter = MagicMock(spec=LifecycleEmitter)
 
         # No visible send button (first.count=0) → Enter fallback used.
-        # loc.count=1 simulates the post-send "disabled/sending" indicator so the
-        # dispatch-ack check acknowledges immediately.
+        # The dispatch ACK must come from a real new user turn (message count 2
+        # after the baseline count 1), not from a cleared composer/disabled UI.
         loc = MagicMock()
         loc.count.return_value = 1
         loc.first.count.return_value = 0
         loc.first.is_visible.return_value = False
         page.locator.return_value = loc
+        page.evaluate.side_effect = [1, "", 2]
         page.keyboard.press = MagicMock()
 
         _sender().click_send(page, emitter)
@@ -51,6 +52,7 @@ class TestClickSendExtended:
         loc.first.count.return_value = 0
         loc.first.is_visible.return_value = False
         page.locator.return_value = loc
+        page.evaluate.side_effect = [1, "", 2]
         page.keyboard.press = MagicMock()
 
         cfg = SenderConfig(click_timeout_ms=100, try_enter_key_fallback=True)
@@ -146,6 +148,23 @@ def _page_with_no_send_selector() -> MagicMock:
 
     page.locator.side_effect = locator_factory
     return page
+
+
+def test_composer_reset_alone_is_not_dispatch_ack():
+    page = MagicMock()
+    emitter = MagicMock(spec=LifecycleEmitter)
+    loc = MagicMock()
+    loc.count.return_value = 1
+    loc.first.count.return_value = 0
+    loc.first.is_visible.return_value = False
+    loc.first.is_enabled.return_value = False
+    loc.first.input_value.return_value = ""
+    page.locator.return_value = loc
+    page.evaluate.return_value = 1
+    page.keyboard.press = MagicMock()
+
+    with pytest.raises(SendDispatchError, match="did not acknowledge the user turn"):
+        _sender().click_send(page, emitter)
 
 
 def test_no_visible_selector_does_not_press_enter_when_instance_fallback_disabled():

--- a/tests/unit_capability_send_dispatcher.py
+++ b/tests/unit_capability_send_dispatcher.py
@@ -44,6 +44,21 @@ class TestClickSendExtended:
         page.keyboard.press.assert_called_once_with("Enter")
         assert emitter.emit.call_count == 2
 
+    def test_changed_message_text_acknowledges_when_count_is_unchanged(self):
+        page = MagicMock()
+        emitter = MagicMock(spec=LifecycleEmitter)
+        loc = MagicMock()
+        loc.count.return_value = 1
+        loc.first.count.return_value = 1
+        loc.first.is_visible.return_value = True
+        loc.first.is_enabled.return_value = True
+        page.locator.return_value = loc
+        page.evaluate.side_effect = [1, "before", 1, "after"]
+
+        _sender().click_send(page, emitter)
+
+        assert emitter.emit.call_count == 2
+
     def test_click_send_with_config_keyword_arg(self):
         page = MagicMock()
         emitter = MagicMock(spec=LifecycleEmitter)

--- a/tests/unit_utility_dom_query.py
+++ b/tests/unit_utility_dom_query.py
@@ -37,6 +37,7 @@ class TestSenderRemaining:
         loc.first.count.return_value = 0
         loc.first.is_visible.return_value = False
         page.locator.return_value = loc
+        page.evaluate.side_effect = [1, "", 2]
         click_send(page, emitter, config=cfg)
         emitter.emit.assert_called()
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining prompt-file pipeline failure observed after the v5.1.0 release.

## Root causes and fixes

- **False dispatch acknowledgement:** composer clearing and a disabled send button are transient UI effects, not proof that Qwen accepted a user turn. Dispatch acknowledgement now requires a real user-turn surface change, such as an increased user-message count or changed message text.
- **Navigation timeout:** chat navigation now waits for the document commit instead of `domcontentloaded`, preventing third-party analytics/assets from stalling the automation lifecycle.
- **Slow model-picker hydration:** after `_start_new_chat`, Qwen can take several seconds to hydrate the model picker. The adapter now waits for that readiness state and retries model verification/selection up to five times with a two-second delay and Escape between attempts.

## Tests

- Added a regression test proving that a composer reset alone is not a dispatch acknowledgement.
- Added a regression test proving navigation uses `wait_until="commit"` when `domcontentloaded` is slow.
- Updated dispatch-ack fixtures to model a real user-turn acknowledgement.
- Local checks pass: `ruff format`, `ruff check`, `mypy modules`, and `pytest tests/ -q -m 'not slow and not e2e'` (229 passed).
- Live prompt-file pipeline passed and wrote `.qwen-web/output/pipeline_prompt_file_510_final.md` successfully.

The diagnostic probe and workspace-generated `.agents/` changes are intentionally excluded from this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the prompt-file pipeline reliable by hardening send acknowledgment, navigation, and model-picker readiness. Previously, a cleared composer or disabled send could count as a send and navigation could stall on domcontentloaded; now acknowledgment requires a real user-turn change and navigation no longer waits on third‑party assets.

- Dispatch acknowledgment now requires a new message count or changed latest message text; removed checks for cleared composer/disabled send to prevent false sends.
- Chat navigation uses wait_until="commit" with a retry and a best‑effort domcontentloaded wait; applies on initial load and when exiting an active thread.
- After starting a new chat, wait up to 15s for model picker hydration; default model verification retries up to 5 times, closing the picker with Escape and re-attempting selection.

Side effects: startup may take up to ~15s on slow picker hydration; send acknowledgment is stricter (no API changes).

<sup>Written for commit 524245d6e3ff9b9438863c13bcc3f4e348e6baed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat navigation reliability during delayed page loads and transient navigation failures.
  * Strengthened default model selection with additional verification and retry handling.
  * Improved send confirmation accuracy by requiring evidence that the message was actually dispatched.
  * Prevented composer clearing or send-control changes from being incorrectly treated as successful delivery.

* **Tests**
  * Added regression coverage for navigation fallback, model-selection retries, and false-positive send acknowledgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->