### PR TITLE
chore(release): v5.2.0

### DIFF
--- a/.github/workflows/tag-release-prs.yml
+++ b/.github/workflows/tag-release-prs.yml
@@ -83,6 +83,3 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --ref "v${RELEASE_VERSION}" \
             -f "tag=v${RELEASE_VERSION}"
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "v${RELEASE_VERSION}" \
-            -f "tag=v${RELEASE_VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [5.2.0] - 2026-08-20
+
+### Added
+
+- test(core): add regression coverage for prompt-file dispatch acknowledgement, slow model-picker hydration, changed-message ACKs, and commit-based navigation
+
+### Fixed
+
+- fix(core): require a real user-turn signal instead of treating composer reset or a disabled send control as dispatch acknowledgement
+- fix(core): capture the pre-click message baseline so changed-message ACK detection cannot self-baseline after dispatch
+- fix(core): use commit-based chat navigation and readiness-based model-picker selection with retry handling for slow Qwen hydration
+- fix(ci): repair the release tag workflow so the release build dispatch command is not duplicated
+
+### Changed
+
+- chore(release): bump version to `5.2.0` across root and module manifests, lock metadata, and embedded skill metadata
+
+---
+
 ## [5.1.0] - 2026-08-19
 
 ### Added

--- a/modules/core/pyproject.toml
+++ b/modules/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-core"
-version = "5.1.0"
+version = "5.2.0"
 description = "qwen-web core feature: capabilities, orchestrators, and DI container"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/mcp/pyproject.toml
+++ b/modules/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-mcp"
-version = "5.1.0"
+version = "5.2.0"
 description = "qwen-web MCP surface layer (tools)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/shared/pyproject.toml
+++ b/modules/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-shared"
-version = "5.1.0"
+version = "5.2.0"
 description = "qwen-web shared taxonomy, contracts, and utilities (domain layer)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -15,7 +15,7 @@ description: >
   analyze documents (PDF/MD/TXT attachments); run long deep-reasoning software
   engineering tasks (up to 15 minutes); or manage Qwen login sessions — via the
   qwen-web-arwaky CLI or MCP tools.
-version: 5.1.0
+version: 5.2.0
 trigger_keywords:
   - qwen
   - chat.qwen.ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwen-web-cli"
-version = "5.1.0"
+version = "5.2.0"
 description = "Production-grade CLI automation and MCP server for chat.qwen.ai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1021,7 +1021,7 @@ wheels = [
 
 [[package]]
 name = "qwen-web-cli"
-version = "5.0.0"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Release v5.2.0

This release packages the prompt-pipeline reliability improvements merged since v5.1.0.

### Included changes

- Requires a real user-turn signal for dispatch acknowledgement instead of treating composer reset or a disabled send control as proof of dispatch.
- Captures the pre-click message baseline for changed-message acknowledgement detection.
- Uses commit-based chat navigation to avoid stalls from third-party assets.
- Waits for a real hydrated model-picker option and retries default-model selection when Qwen UI hydration is slow.
- Adds regression coverage for dispatch acknowledgement, changed-message detection, picker-read retry, and navigation behavior.
- Bumps the root package, core/shared/MCP manifests, lock metadata, and embedded skill metadata to 5.2.0.
- Repairs the duplicate release-build dispatch command in the tag-release workflow.

### Validation

Local `uv lock --check`, Ruff format/check, MyPy, and the non-slow/non-e2e test suite pass. The three live pipelines were also rerun successfully on main: direct prompt, prompt-file, and prompt-with-attachment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v5.2.0 to harden prompt-pipeline reliability and fix the tag-release workflow. Previously, dispatch acknowledgement could be inferred from a composer reset or disabled send control; now it requires a real user-turn signal. Changed-message ACK compares against a pre-click baseline, chat navigation uses commit-based routes, and default-model selection waits/retries until the model picker hydrates.

- Bumps versions to 5.2.0 in `qwen-web-cli`, `qwen-web-core`, `qwen-web-shared`, `qwen-web-mcp`, embedded skill metadata, and `uv.lock`.
- Removes the duplicate release-build dispatch in `.github/workflows/tag-release-prs.yml`.
- Adds regression tests for dispatch ACK, changed-message detection, model-picker hydration, and navigation.
- No migration required; pipelines and local checks pass.

<sup>Written for commit 130d265f7746d65305a347100afb0c92d8f0988f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 5.2.0 is now available.
  * Updated release notes include improvements to chat navigation, message handling, dispatch acknowledgements, model-picker loading, and release reliability.
* **Chores**
  * Updated package and embedded skill metadata versions to 5.2.0.
  * Simplified automated release workflow dispatching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->