### PR TITLE
fix: verify self-update reaches latest release

### DIFF
--- a/modules/core/src/capabilities_update_manager.py
+++ b/modules/core/src/capabilities_update_manager.py
@@ -122,26 +122,60 @@ class UpdateManager(IUpdateProtocol):
             source=source,
         )
 
-    def upgrade_package(self, force: ForceFlag = ForceFlag(False)) -> UpdateStepResult:
-        """Upgrade (or reinstall) the package directly from GitHub Releases / Git repo."""
+    def upgrade_package(
+        self,
+        force: ForceFlag = ForceFlag(False),
+        *,
+        target_version: str | None = None,
+    ) -> UpdateStepResult:
+        """Upgrade (or reinstall) the package and verify editable-source freshness."""
         editable_dir = self._editable_source_dir()
+        mode_desc: str
         if editable_dir is not None:
             git_dir = editable_dir / ".git"
+            git_ok = True
+            source_version = self._read_source_version(editable_dir)
             if git_dir.exists():
-                self._run_subprocess(["git", "-C", str(editable_dir), "pull"], timeout_sec=60.0)
-            cmd = [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--no-input",
-                "--disable-pip-version-check",
-                "-e",
-                str(editable_dir),
-            ]
-            mode_desc = f"git pull & editable reinstall from {editable_dir}"
+                git_rc, git_out, git_err = self._run_subprocess(
+                    ["git", "-C", str(editable_dir), "pull", "--ff-only"],
+                    timeout_sec=60.0,
+                )
+                git_ok = git_rc == 0
+                if not git_ok:
+                    log.warning("editable_git_sync_failed detail=%s", _tail(git_err or git_out))
+                source_version = self._read_source_version(editable_dir)
+            source_is_stale = target_version is not None and (
+                source_version is None or compare_versions(source_version, target_version) < 0
+            )
+            if git_ok and not source_is_stale:
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-input",
+                    "--disable-pip-version-check",
+                    "-e",
+                    str(editable_dir),
+                ]
+                mode_desc = f"git pull & editable reinstall from {editable_dir}"
+            else:
+                repo_url = self._github_repo_url(target_version)
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-input",
+                    "--disable-pip-version-check",
+                    "--upgrade",
+                    "--force-reinstall",
+                    "--no-deps",
+                    repo_url,
+                ]
+                mode_desc = f"fallback pip reinstall from GitHub ({repo_url})"
         else:
-            repo_url = f"git+https://github.com/{DEFAULT_GITHUB_REPO}.git"
+            repo_url = self._github_repo_url(target_version)
             cmd = [
                 sys.executable,
                 "-m",
@@ -221,13 +255,30 @@ class UpdateManager(IUpdateProtocol):
                 message=message,
             )
         steps: list[UpdateStepResult] = []
-        pkg_step = self.upgrade_package(ForceFlag(forced))
+        pkg_step = self.upgrade_package(ForceFlag(forced), target_version=check.latest_version)
         steps.append(pkg_step)
         importlib.invalidate_caches()
         browser_step = self.sync_browser(ForceFlag(forced))
         steps.append(browser_step)
-        post_version = self._resolve_installed_version()
+        post_version = self._resolve_installed_version(prefer_metadata=True)
         health_checks = self._postflight_health_checks()
+        if check.latest_version is not None:
+            target_ok = (
+                str(post_version) != "unknown" and compare_versions(str(post_version), check.latest_version) >= 0
+            )
+            if not target_ok:
+                health_checks = (
+                    *health_checks,
+                    UpdateStepResult(
+                        name="health:package_version_target",
+                        executed=True,
+                        success=False,
+                        detail=(
+                            f"installed version {post_version} is behind latest {check.latest_version}; "
+                            "source synchronization did not reach the release target"
+                        ),
+                    ),
+                )
         steps_ok = pkg_step.success and browser_step.success
         checks_ok = all(c.success for c in health_checks)
         healthy = steps_ok and checks_ok
@@ -263,17 +314,41 @@ class UpdateManager(IUpdateProtocol):
         )
 
     # ─── Block 3: Private Helpers ──
-    def _resolve_installed_version(self) -> VersionString:
-        """Resolve installed version dynamically from pyproject.toml or importlib.metadata."""
+    def _resolve_installed_version(self, *, prefer_metadata: bool = False) -> VersionString:
+        """Resolve installed version from package metadata, source, or pip as a fallback."""
+        if prefer_metadata:
+            metadata_version = self._pip_show_version()
+            if metadata_version is not None:
+                return metadata_version
         v = get_package_version(self.package_name)
         if v and v != "0.0.0-dev":
             return VersionString(v)
+        metadata_version = self._pip_show_version()
+        return metadata_version or VersionString(v)
+
+    def _pip_show_version(self) -> VersionString | None:
+        """Read the installed distribution version using the active interpreter."""
         rc, out, _err = self._run_subprocess([sys.executable, "-m", "pip", "show", self.package_name], timeout_sec=60.0)
         if rc == 0:
             for line in out.splitlines():
                 if line.lower().startswith("version:"):
                     return VersionString(line.split(":", 1)[1].strip())
-        return VersionString(v)
+        return None
+
+    def _read_source_version(self, source_dir: Path) -> str | None:
+        """Read a checkout's root project version without importing its code."""
+        with contextlib.suppress(OSError):
+            content = (source_dir / "pyproject.toml").read_text(encoding="utf-8", errors="ignore")
+            match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+            if match:
+                return match.group(1).strip()
+        return None
+
+    def _github_repo_url(self, target_version: str | None = None) -> str:
+        """Build a GitHub source URL, pinning to the discovered release when known."""
+        repo = os.getenv(GITHUB_REPO_ENV, "").strip() or DEFAULT_GITHUB_REPO
+        suffix = f"@v{target_version.lstrip('vV')}" if target_version else ""
+        return f"git+https://github.com/{repo}.git{suffix}"
 
     def _discover_latest(self) -> tuple[str | None, str, str | None]:
         """Return (latest_version, source, error) via GitHub releases exclusively."""
@@ -400,7 +475,7 @@ class UpdateManager(IUpdateProtocol):
                 ),
             )
         )
-        version = self._resolve_installed_version()
+        version = self._resolve_installed_version(prefer_metadata=True)
         version_ok = str(version) != "unknown"
         checks.append(
             UpdateStepResult(

--- a/tests/unit_surface_cli_update_command.py
+++ b/tests/unit_surface_cli_update_command.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from modules.cli.src import surface_cli_update_command
@@ -118,6 +120,69 @@ class TestUpdateManagerRealFlow(unittest.TestCase):
         self.assertEqual(res.latest_version, "4.5.2")
         self.assertTrue(res.update_available)
         self.assertEqual(res.source, "github")
+
+    def test_perform_update_rejects_stale_post_update_version(self) -> None:
+        with (
+            patch.object(
+                self.manager,
+                "_resolve_installed_version",
+                side_effect=[VersionString("5.0.0"), VersionString("5.0.0")],
+            ),
+            patch.object(
+                self.manager,
+                "check_update",
+                return_value=UpdateCheckResult(
+                    package_name="qwen-web-cli",
+                    current_version="5.0.0",
+                    latest_version="5.2.0",
+                    update_available=True,
+                    source="github",
+                ),
+            ),
+            patch.object(
+                self.manager,
+                "upgrade_package",
+                return_value=UpdateStepResult("package_upgrade", True, True, "fallback reinstall"),
+            ) as mock_upgrade,
+            patch.object(
+                self.manager,
+                "sync_browser",
+                return_value=UpdateStepResult("browser_sync", True, True, "chromium ok"),
+            ),
+            patch.object(
+                self.manager,
+                "_postflight_health_checks",
+                return_value=(UpdateStepResult("health:check", True, True, "ok"),),
+            ),
+        ):
+            report = self.manager.perform_update(ForceFlag(False))
+
+        self.assertFalse(report.healthy)
+        mock_upgrade.assert_called_once_with(ForceFlag(False), target_version="5.2.0")
+        self.assertTrue(
+            any(check.name == "health:package_version_target" and not check.success for check in report.health_checks)
+        )
+        self.assertIn("behind latest 5.2.0", report.message)
+
+    def test_upgrade_package_falls_back_to_pinned_release_for_stale_editable_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            (source / ".git").mkdir()
+            (source / "pyproject.toml").write_text('version = "5.0.0"\n', encoding="utf-8")
+            with (
+                patch.object(self.manager, "_editable_source_dir", return_value=source),
+                patch.object(self.manager, "_run_subprocess", side_effect=[(0, "", ""), (0, "", "")]) as run,
+            ):
+                result = self.manager.upgrade_package(target_version="5.2.0")
+
+        self.assertTrue(result.success)
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(commands[0], ["git", "-C", str(source), "pull", "--ff-only"])
+        self.assertIn(
+            "git+https://github.com/rakaarwaky/qwen-web-arwaky.git@v5.2.0",
+            commands[1],
+        )
+        self.assertIn("--force-reinstall", commands[1])
 
     @patch.object(UpdateManager, "upgrade_package")
     @patch.object(UpdateManager, "sync_browser")


### PR DESCRIPTION
## Summary

This fixes a false-success path in `qwen-web-cli update` where an editable checkout could remain on an older release while the updater reported that the environment was synchronized.

## Changes

- Treats a failed editable `git pull --ff-only` as a synchronization failure instead of ignoring its return code.
- Detects when the editable checkout's `pyproject.toml` version is behind the GitHub release discovered by the updater.
- Falls back to a pinned GitHub release installation (`@vX.Y.Z`) when the editable source is stale or cannot be synchronized.
- Reads post-update package metadata with the active interpreter and adds a health gate requiring the installed version to reach the discovered release target.
- Adds regression coverage for stale editable source fallback and for rejecting a post-update version that remains behind the latest release.

## Validation

Local Ruff format/check, MyPy, and the complete non-slow/non-e2e test suite pass. After this PR merges, the existing release automation will derive the next patch release from the conventional `fix:` commit, so future users can update by running only `qwen-web-cli update`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false-success in `qwen-web-cli update` where an editable checkout could stay behind the latest release. The updater now verifies the installed version reaches the discovered release and falls back to a pinned GitHub release when the source is stale or cannot sync.

- Treats a failed editable `git pull --ff-only` as a sync failure and logs a warning.
- Compares the editable source `pyproject.toml` version to the target; if behind, installs from GitHub pinned to `@vX.Y.Z`.
- Reads post-update version from package metadata and adds a health check requiring the installed version to meet or exceed the target release.
- Extends internal `upgrade_package` to accept a `target_version` and adds helpers for source-version read, repo URL pinning, and metadata resolution.
- Adds unit tests for stale editable fallback and for rejecting post-update versions that remain behind the latest release.

<sup>Written for commit 191f6ed7778165a09278abe8004e81dc07edb2f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package updates from editable Git sources by synchronizing changes and validating version freshness.
  * Added fallback installation from a pinned release when source synchronization fails or is outdated.
  * Ensured updates are rejected when the installed version remains below the target release.
  * Improved post-update version detection and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->