### PR TITLE
fix: align local MCP config with current qwen-web-mcp entrypoint

### DIFF
--- a/mcp.local.json
+++ b/mcp.local.json
@@ -1,10 +1,1 @@
-{
-  "mcpServers": {
-    "qwen-web-cli": {
-      "command": "qwc",
-      "args": [
-        "--mcp"
-      ]
-    }
-  }
-}
+{"mcpServers":{"qwen-web-mcp":{"command":"qwen-web-mcp","args":[]}}}


### PR DESCRIPTION
## What

`mcp.local.json` still pointed to the old CLI wrapper path `qwc --mcp`.

## Change

Use the current dedicated entrypoint `qwen-web-mcp` instead.

```diff
-{"mcpServers":{"qwen-web-cli":{"command":"qwc","args":["--mcp"]}}}
+{"mcpServers":{"qwen-web-mcp":{"command":"qwen-web-mcp","args":[]}}}
```

## Why

Current source uses `modules/root_mcp_main_entry.py` and `pyproject.toml` exposes `qwen-web-mcp` as the MCP server entrypoint. The local MCP config should match that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the local MCP config with the current MCP server entrypoint. Previously `mcp.local.json` launched `qwc --mcp` under `qwen-web-cli`; now it runs `qwen-web-mcp` with no args, matching the `pyproject.toml` entrypoint and preventing launch mismatches.

**Rollout**
- If you maintain a local override, replace `qwen-web-cli`/`qwc --mcp` with `qwen-web-mcp`.

<sup>Written for commit e4f09df112e0a513b4266eb300fa0d62a6cdfb10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Qwen web integration configuration to use the newer MCP server command.
  * Simplified the integration setup by removing unnecessary command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->