### PR TITLE
feat(cli): add qwen-web-arwaky and qwa entrypoint aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
 ]
 
 [project.scripts]
+qwen-web-arwaky = "modules.root_cli_main_entry:main"
+qwa = "modules.root_cli_main_entry:main"
 qwen-web-cli = "modules.root_cli_main_entry:main"
 qwc = "modules.root_cli_main_entry:main"
 qwen-web-mcp = "modules.root_mcp_main_entry:main"

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -192,7 +192,7 @@ def setup_bin_links(python_bin: Path) -> None:
     local_bin.mkdir(parents=True, exist_ok=True)
 
     venv_bin_dir = python_bin.parent
-    for name in ("qwen-web-cli", "qwc", "qwen-web-mcp"):
+    for name in ("qwen-web-arwaky", "qwa", "qwen-web-cli", "qwc", "qwen-web-mcp"):
         src = venv_bin_dir / name
         dst = local_bin / name
         if src.exists():


### PR DESCRIPTION
Standardize CLI entrypoints across internal tools ecosystem:
- Add `qwen-web-arwaky` and `qwa` scripts to `pyproject.toml`
- Link `qwen-web-arwaky` and `qwa` in `install.py`
- Maintain backwards compatibility with `qwen-web-cli` and `qwc`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `qwen-web-arwaky` and `qwa` as CLI entrypoint aliases alongside the existing `qwen-web-cli` and `qwc`. This standardizes CLI entrypoints across internal tools and preserves backward compatibility.

- Updates `scripts/install.py` to create symlinks for the new aliases.

<sup>Written for commit 39d9b4529e70c8d384accd3fd8e058d6c92a069f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `qwen-web-arwaky` and `qwa` command-line entry points.
  - Installation now creates executable links for the new commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->