### PR TITLE
fix: add XDG uninstall.sh & clean all launchers on reinstall

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -101,7 +101,7 @@ def uninstall_previous(python_bin: Path) -> None:
 
     if sys.platform != "win32":
         local_bin = get_local_bin_dir()
-        for name in ("qwen-web-cli", "qwc", "qwen-web-mcp"):
+        for name in ("qwen-web-arwaky", "qwa", "qwen-web-cli", "qwc", "qwen-web-mcp"):
             target = local_bin / name
             if target.is_symlink() or target.exists():
                 with contextlib.suppress(OSError):

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/uninstall.sh — Clean uninstaller for qwen-web-arwaky (XDG Base Directory)
+set -euo pipefail
+
+BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/qwen-web"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/qwen-web"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/qwen-web"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/qwen-web"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "=== Uninstalling qwen-web-arwaky ==="
+
+# Remove bin launchers (full name + short alias + extras)
+COMMANDS=("qwen-web-arwaky" "qwa" "qwen-web-cli" "qwc" "qwen-web-mcp")
+for cmd in "${COMMANDS[@]}"; do
+    if [ -L "$BIN_DIR/$cmd" ] || [ -f "$BIN_DIR/$cmd" ]; then
+        rm -f "$BIN_DIR/$cmd"
+        echo "✓ Removed $BIN_DIR/$cmd"
+    fi
+done
+
+# Remove in-tree .venv/venv symlink if it points to XDG
+for name in ".venv" "venv"; do
+    if [ -L "$PROJECT_DIR/$name" ]; then
+        rm -f "$PROJECT_DIR/$name"
+        echo "✓ Removed $PROJECT_DIR/$name symlink"
+    fi
+done
+
+# Remove XDG config & cache (selalu), data & state saat --purge
+if [ -d "$CONFIG_DIR" ]; then
+    rm -rf "$CONFIG_DIR"
+    echo "✓ Removed $CONFIG_DIR"
+fi
+if [ -d "$CACHE_DIR" ]; then
+    rm -rf "$CACHE_DIR"
+    echo "✓ Removed $CACHE_DIR"
+fi
+if [[ "${1:-}" == "--purge" ]]; then
+    for d in "$DATA_DIR" "$STATE_DIR"; do
+        if [ -d "$d" ]; then
+            rm -rf "$d"
+            echo "✓ Purged $d"
+        fi
+    done
+fi
+
+echo "Uninstall complete."


### PR DESCRIPTION
Perbaikan kepatuhan XDG untuk qwen-web-arwaky:
- **Baru**: `scripts/uninstall.sh` (sebelumnya tidak ada script uninstall)
  - Hapus launcher `qwen-web-arwaky`, `qwa`, `qwen-web-cli`, `qwc`, `qwen-web-mcp`
  - Bersihkan `$XDG_CONFIG_HOME/qwen-web` dan `$XDG_CACHE_HOME/qwen-web`
  - Data/state hanya saat `--purge`
- `install.py` `uninstall_previous()`: kini juga menghapus `qwen-web-arwaky` dan `qwa` dari $XDG_BIN_HOME

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a proper uninstall script and makes reinstall clean up all launcher names.

- New `scripts/uninstall.sh` removes all five launchers and XDG config/cache, with `--purge` for data/state.
- `install.py` now also removes `qwen-web-arwaky` and `qwa` during reinstall.

<sup>Written for commit 27920d2a7dc4dc04245a83dccdfbfcf09b0bcb78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an uninstall command for non-Windows systems that removes installed launchers, project links, configuration, and cache files.
  - Added an optional purge mode to also remove application data and state directories, with removal progress reported.

- **Bug Fixes**
  - Uninstallation now also removes the `qwen-web-arwaky` and `qwa` command links from the local binaries directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->