### PR TITLE
refactor: standardize uninstall.sh to XDG Base Directory spec

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,16 +2,17 @@
 # scripts/uninstall.sh — Clean uninstaller for qwen-web-arwaky (XDG Base Directory)
 set -euo pipefail
 
+TOOL_NAME="qwen-web"
 BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
-DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/qwen-web"
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/qwen-web"
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/qwen-web"
-STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/qwen-web"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/$TOOL_NAME"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/$TOOL_NAME"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/$TOOL_NAME"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/$TOOL_NAME"
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 echo "=== Uninstalling qwen-web-arwaky ==="
 
-# Remove bin launchers (full name + short alias + extras)
+# Remove bin launchers
 COMMANDS=("qwen-web-arwaky" "qwa" "qwen-web-cli" "qwc" "qwen-web-mcp")
 for cmd in "${COMMANDS[@]}"; do
     if [ -L "$BIN_DIR/$cmd" ] || [ -f "$BIN_DIR/$cmd" ]; then
@@ -20,7 +21,7 @@ for cmd in "${COMMANDS[@]}"; do
     fi
 done
 
-# Remove in-tree .venv/venv symlink if it points to XDG
+# Remove in-tree .venv/venv symlinks
 for name in ".venv" "venv"; do
     if [ -L "$PROJECT_DIR/$name" ]; then
         rm -f "$PROJECT_DIR/$name"
@@ -28,7 +29,7 @@ for name in ".venv" "venv"; do
     fi
 done
 
-# Remove XDG config & cache (selalu), data & state saat --purge
+# Remove XDG config & cache (always), data & state with --purge
 if [ -d "$CONFIG_DIR" ]; then
     rm -rf "$CONFIG_DIR"
     echo "✓ Removed $CONFIG_DIR"


### PR DESCRIPTION
Standardize uninstall script to follow XDG Base Directory conventions consistently.

Changes:
- Add TOOL_NAME variable for consistency
- Use TOOL_NAME in all directory paths

This aligns with the uninstall scripts in blender-arwaky, lint-arwaky, and vision-arwaky.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the XDG directory paths in `scripts/uninstall.sh` by introducing a `TOOL_NAME` variable that replaces the hardcoded `qwen-web` string. No behavior changes; this aligns the script with the uninstall scripts in `blender-arwaky`, `lint-arwaky`, and `vision-arwaky`.

<sup>Written for commit e94df7464cf090af50e38656f8cc6cb9b85474a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved uninstall script maintainability by centralizing the tool name used in path definitions.
  * Clarified and standardized comments in the uninstall process.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->