### PR TITLE
fix(review): address CodeRabbit feedback on PR #166

### DIFF
--- a/.agents/skills/qwen-web/SKILL.md
+++ b/.agents/skills/qwen-web/SKILL.md
@@ -179,8 +179,8 @@ Use `--json` in pipelines for machine-readable envelopes.
    VERBATIM inside fenced code blocks. Never use ellipses (`...`), placeholder
    comments (`// rest unchanged`), or references to omitted code."*
 3. **Reason first, produce second.** Ask for a compact analysis section *before* the
-   deliverable. This spends the model's deep-reasoning budget on understanding, and
-   the 900s watchdog covers the cost.
+   deliverable. This spends the model's deep-reasoning budget on understanding; the
+   event-driven monitor waits for the full response (no fixed watchdog cutoff).
 4. **Move bulk into attachments.** Prompt files should carry *instructions*; large
    code, specs, and diffs belong in attachments (PDF/MD/TXT ≤ 100 MB). Use one
    consolidated attachment per run (exactly one attachment is supported per execution).
@@ -368,13 +368,14 @@ Task returned an error / suspicious output
 │      → fix cause → resume slowly (1 task, verify, continue)
 │
 ├─ NetworkTimeoutError / 5xx challenge text?
-│  └─► back off 10–30s → RETRY with timeout_sec × 2 (max 900)
+│  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
 │      → still failing? run `qwen-web-cli doctor`, verify connectivity
 │
 ├─ ResponseDetectionTimeoutError?
 │  └─► Check last lifecycle event in logs:
 │      • stopped before SEND_CLICKED → injection/send problem → retry, then `update`
-│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → retry with 900s
+│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → keep waiting;
+│        only the 4-hour no-terminal-event circuit breaker stops the run
 │
 ├─ Upload/File errors?
 │  └─► verify: exists · regular file · readable · ≤ 100 MB · .pdf/.md/.txt
@@ -478,7 +479,8 @@ MCP client registration (Claude Desktop / Cursor style):
   stops right after `DISPATCH_ACKNOWLEDGED`; a second Chromium process lingers after
   the CLI already exited; `TargetClosedError: Page.wait_for_timeout`.
 - **Safe cleanup order:**
-  1. Prefer letting the run finish (watchdog gives it 900s+).
+  1. Prefer letting the run finish — completion is event-driven; the only
+     automatic stop is the 4-hour no-terminal-event safety circuit breaker.
   2. Prefer in-app cancellation (TUI **Cancel Run**; MCP has no cancel — wait).
   3. Only as a last resort, kill the **exact PID** of the CLI process
      (`kill <pid>`, not `pkill -9 -f`), then verify with

--- a/modules/cli/src/surface_cli_tui_app.py
+++ b/modules/cli/src/surface_cli_tui_app.py
@@ -384,9 +384,11 @@ class FilePickerModal(ModalScreen[str | None]):
         self._current_path: Path = self._start_path
 
     def compose(self) -> ComposeResult:
-        title = "SELECT FOLDER" if self._select_directories else "SELECT FILE"
+        title = "SELECT FILE OR FOLDER" if self._select_directories else "SELECT FILE"
         hint = (
-            "Navigate then click 'Select This Folder'" if self._select_directories else "press Enter on file to select"
+            "press Enter on a file, or click 'Select This Folder'"
+            if self._select_directories
+            else "press Enter on file to select"
         )
         with Vertical(id="modal-container"):
             yield Label(f"[ {title} — {hint} ]", id="modal-title")
@@ -397,8 +399,8 @@ class FilePickerModal(ModalScreen[str | None]):
                 yield Button("Cancel (Esc)", id="btn-cancel-modal")
 
     def on_directory_tree_file_selected(self, event: DirectoryTree.FileSelected) -> None:
-        if not self._select_directories:
-            self.dismiss(str(event.path))
+        # Accept regular files in both modes; folders are picked via the button.
+        self.dismiss(str(event.path))
 
     def on_directory_tree_directory_selected(self, event: DirectoryTree.DirectorySelected) -> None:
         self._current_path = Path(event.path)

--- a/modules/core/src/agent_attachment_prompt_orchestrator.py
+++ b/modules/core/src/agent_attachment_prompt_orchestrator.py
@@ -87,6 +87,9 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
             if not p_path.exists():
                 raise FileNotFoundError(f"Input file not found: {p_path}")
 
+            self._observability.bind_run_context(RunId(ctx.run_id), job_name=JobName(p_path.stem))
+            self._observability.attach_run_log(job_name=JobName(p_path.stem), run_id=RunId(ctx.run_id))
+
             att_path = self._folder_adapter.resolve_to_attachment(Path(attachment_file))
 
             out_path = Path(output_file).resolve() if output_file else DEFAULT_OUTPUT / p_path.name
@@ -99,8 +102,6 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
                 output_path=out_path,
                 headless=headless,
             )
-            self._observability.bind_run_context(RunId(ctx.run_id), job_name=JobName(p_path.stem))
-            self._observability.attach_run_log(job_name=JobName(p_path.stem), run_id=RunId(ctx.run_id))
             emitter, state = setup_lifecycle_state(self._observability.get_logger(), PIPELINE_EVENT_SEQUENCE)
 
             t0 = time.time()

--- a/modules/core/src/capabilities_observability_setup.py
+++ b/modules/core/src/capabilities_observability_setup.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import threading
+import types
 from contextlib import nullcontext, suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -198,9 +199,22 @@ class ObservabilitySetup(IObservabilityProtocol):
 
     def _configure_logging(self, log_path: Path, verbose: bool = False) -> None:
         """Configure structlog/stdlib logging (private helper)."""
-        log_level = logging.DEBUG if verbose else logging.WARNING
+        log_level = logging.DEBUG if verbose else logging.INFO
         if structlog is None:
-            logging.basicConfig(level=log_level)
+            # Fallback: wire a stdlib JSON formatter + file handler so per-run
+            # logs still work when structlog is not installed.
+            self._formatter = _make_json_formatter()
+            root = logging.getLogger()
+            root.setLevel(log_level)
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            stderr_handler.setFormatter(self._formatter)
+            root.addHandler(stderr_handler)
+            try:
+                file_handler = logging.FileHandler(log_path / "app.jsonl", encoding="utf-8")
+                file_handler.setFormatter(self._formatter)
+                root.addHandler(file_handler)
+            except OSError:
+                pass
             return
 
         shared_processors: list[Any] = [
@@ -283,6 +297,9 @@ class ObservabilitySetup(IObservabilityProtocol):
             if self._formatter is not None:
                 handler = logging.FileHandler(path, encoding="utf-8")
                 handler.setFormatter(self._formatter)
+                # Keep only records whose bound run_id matches this run so
+                # overlapping runs never leak records into each other's log.
+                handler.addFilter(_make_run_id_filter(str(run_id)))
                 logging.getLogger().addHandler(handler)
                 self._run_handlers[str(run_id)] = handler
             return path
@@ -338,6 +355,43 @@ def _start_span(name: str) -> Any:
     if tracer is None:
         return nullcontext()
     return tracer.start_as_current_span(name)
+
+
+def _json_format(record: logging.LogRecord) -> str:
+    """Render a stdlib LogRecord as a single JSON line (structlog-free)."""
+    payload: dict[str, Any] = {
+        "event": record.getMessage(),
+        "level": record.levelname.lower(),
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "logger": record.name,
+    }
+    if record.exc_info:
+        payload["exc_info"] = logging.Formatter().formatException(record.exc_info)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _make_json_formatter() -> Any:
+    """Return a JSON-lines formatter-compatible object (no class definitions)."""
+    return types.SimpleNamespace(format=_json_format)
+
+
+def _make_run_id_filter(run_id: str) -> Any:
+    """Return a filter that keeps only records bound to ``run_id``.
+
+    Reads the structlog contextvars in the emitting thread so that concurrent
+    runs (TUI slots, MCP background jobs) never cross-write per-run logs.
+    """
+
+    def _filter(_record: logging.LogRecord) -> bool:
+        if structlog is None:
+            return True
+        try:
+            ctx = structlog.contextvars.get_contextvars()
+        except Exception:
+            return False
+        return str(ctx.get("run_id", "")) == run_id
+
+    return types.SimpleNamespace(filter=_filter)
 
 
 def add_trace_context(_logger: Any, _method: str, event_dict: dict[str, Any]) -> dict[str, Any]:

--- a/modules/mcp/src/surface_mcp_tool_command.py
+++ b/modules/mcp/src/surface_mcp_tool_command.py
@@ -8,6 +8,7 @@ and session management tools (check_session, delete_session).
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +69,47 @@ def _format_success_payload(
     if extra:
         payload.update(extra)
     return json.dumps(payload, indent=2)
+
+
+def _get_workspace_root() -> Path:
+    """Workspace root bounding attachment paths (env override, else cwd)."""
+    root = os.environ.get("QWEN_WORKSPACE_ROOT")
+    return Path(root).expanduser().resolve() if root else Path.cwd().resolve()
+
+
+def _validate_attachment_path(raw: str) -> tuple[Path | None, str | None]:
+    """Resolve and validate an attachment path for MCP tool calls.
+
+    Returns ``(path, None)`` on success or ``(None, error_payload)`` on
+    failure. Rejects non-existent paths, special nodes (FIFO/socket/device),
+    and paths outside the configured workspace root.
+    """
+    a_path = Path(raw).expanduser().resolve()
+    if not a_path.exists():
+        return None, _format_error_payload(
+            code="FILE_NOT_FOUND",
+            message=f"Attachment file or folder not found: {a_path}",
+            hint="Check attachment_file path. Can be a file or directory.",
+            field="attachment_file",
+        )
+    if not (a_path.is_file() or a_path.is_dir()):
+        return None, _format_error_payload(
+            code="INVALID_PATH",
+            message=f"Attachment path is not a regular file or directory: {a_path}",
+            hint="FIFOs, sockets, and device nodes are not supported.",
+            field="attachment_file",
+        )
+    root = _get_workspace_root()
+    try:
+        a_path.relative_to(root)
+    except ValueError:
+        return None, _format_error_payload(
+            code="PATH_OUTSIDE_WORKSPACE",
+            message=f"Attachment path is outside the workspace root: {a_path}",
+            hint=f"Place files under {root} or set QWEN_WORKSPACE_ROOT.",
+            field="attachment_file",
+        )
+    return a_path, None
 
 
 def _format_error_payload(
@@ -256,14 +298,10 @@ class McpToolCommand:
                 field="prompt_file",
             )
 
-        a_path = Path(attachment_file).expanduser().resolve()
-        if not a_path.exists() and not a_path.is_dir():
-            return _format_error_payload(
-                code="FILE_NOT_FOUND",
-                message=f"Attachment file or folder not found: {a_path}",
-                hint="Check attachment_file path. Can be a file or directory.",
-                field="attachment_file",
-            )
+        a_path, a_err = _validate_attachment_path(attachment_file)
+        if a_err is not None:
+            return a_err
+        assert a_path is not None
 
         out_path = Path(output_file).expanduser().resolve() if output_file else None
 

--- a/modules/shared/src/contract_core_protocol.py
+++ b/modules/shared/src/contract_core_protocol.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from playwright.sync_api import ElementHandle, Page
 
+from modules.shared.src.taxonomy_core_constant import MAX_FOLDER_DEPTH
 from modules.shared.src.taxonomy_core_entity import LifecycleEmitter
 from modules.shared.src.taxonomy_core_event import EventMessage
 from modules.shared.src.taxonomy_core_vo import (
@@ -72,7 +73,7 @@ class IFolderCompileProtocol(ABC):
         self,
         folder_path: Path,
         output_path: Path | None = None,
-        max_depth: int = 5,
+        max_depth: int = MAX_FOLDER_DEPTH,
     ) -> Path:
         """Compile folder contents to a single markdown file.
 
@@ -97,7 +98,7 @@ class IFolderToAttachmentProtocol(ABC):
     def resolve_to_attachment(
         self,
         path: Path,
-        max_depth: int = 5,
+        max_depth: int = MAX_FOLDER_DEPTH,
     ) -> Path:
         """Resolve a path to an attachment-ready file (compile folders to markdown)."""
 

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -186,8 +186,8 @@ Use `--json` in pipelines for machine-readable envelopes.
    VERBATIM inside fenced code blocks. Never use ellipses (`...`), placeholder
    comments (`// rest unchanged`), or references to omitted code."*
 3. **Reason first, produce second.** Ask for a compact analysis section *before* the
-   deliverable. This spends the model's deep-reasoning budget on understanding, and
-   the 900s watchdog covers the cost.
+   deliverable. This spends the model's deep-reasoning budget on understanding; the
+   event-driven monitor waits for the full response (no fixed watchdog cutoff).
 4. **Move bulk into attachments.** Prompt files should carry *instructions*; large
    code, specs, and diffs belong in attachments (PDF/MD/TXT ≤ 100 MB). Use one
    consolidated attachment per run (exactly one attachment is supported per execution).
@@ -375,13 +375,14 @@ Task returned an error / suspicious output
 │      → fix cause → resume slowly (1 task, verify, continue)
 │
 ├─ NetworkTimeoutError / 5xx challenge text?
-│  └─► back off 10–30s → RETRY with timeout_sec × 2 (max 900)
+│  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
 │      → still failing? run `qwen-web-cli doctor`, verify connectivity
 │
 ├─ ResponseDetectionTimeoutError?
 │  └─► Check last lifecycle event in logs:
 │      • stopped before SEND_CLICKED → injection/send problem → retry, then `update`
-│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → retry with 900s
+│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → keep waiting;
+│        only the 4-hour no-terminal-event circuit breaker stops the run
 │
 ├─ Upload/File errors?
 │  └─► verify: exists · regular file · readable · ≤ 100 MB · .pdf/.md/.txt
@@ -485,7 +486,8 @@ MCP client registration (Claude Desktop / Cursor style):
   stops right after `DISPATCH_ACKNOWLEDGED`; a second Chromium process lingers after
   the CLI already exited; `TargetClosedError: Page.wait_for_timeout`.
 - **Safe cleanup order:**
-  1. Prefer letting the run finish (watchdog gives it 900s+).
+  1. Prefer letting the run finish — completion is event-driven; the only
+     automatic stop is the 4-hour no-terminal-event safety circuit breaker.
   2. Prefer in-app cancellation (TUI **Cancel Run**; MCP has no cancel — wait).
   3. Only as a last resort, kill the **exact PID** of the CLI process
      (`kill <pid>`, not `pkill -9 -f`), then verify with

--- a/modules/shared/src/utility_folder_compiler.py
+++ b/modules/shared/src/utility_folder_compiler.py
@@ -14,9 +14,18 @@ from modules.shared.src.taxonomy_core_constant import CODE_EXTENSIONS, EXCLUDED_
 from modules.shared.src.taxonomy_core_error import FolderEmptyError, FolderValidationError
 
 
-def _is_excluded(path: Path) -> bool:
-    """Return True if the path is inside an excluded directory."""
-    return any(part in EXCLUDED_DIR_NAMES for part in path.parts)
+def _is_excluded(path: Path, root: Path) -> bool:
+    """Return True if the path is inside an excluded directory below ``root``.
+
+    Only components below the scan root are inspected so that a project under
+    an ancestor directory named ``build``/``dist``/``venv`` etc. is not
+    rejected wholesale.
+    """
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return True
+    return any(part in EXCLUDED_DIR_NAMES for part in relative.parts)
 
 
 def _is_text_file(filepath: Path) -> bool:
@@ -74,7 +83,7 @@ def collect_folder_files(
             return
 
         for entry in entries:
-            if _is_excluded(entry):
+            if _is_excluded(entry, folder_path):
                 continue
 
             if entry.is_file():

--- a/tests/integration_prompt_template.py
+++ b/tests/integration_prompt_template.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from modules.mcp.src.surface_mcp_tool_command import McpToolCommand
 from modules.root_cli_main_entry import _build_config, _parse_args
 
@@ -61,7 +63,8 @@ class TestMcpPromptTemplateIntegration:
         called_prompt = mock_file_only.process_prompt_file_only.call_args[0][0]
         assert str(called_prompt).endswith("frontend.md")
 
-    def test_mcp_attachment_with_role(self, tmp_path: Path) -> None:
+    def test_mcp_attachment_with_role(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QWEN_WORKSPACE_ROOT", str(tmp_path))
         dummy_att = tmp_path / "code.py"
         dummy_att.write_text("print('hello')")
 


### PR DESCRIPTION
## Ringkasan

Menindaklanjuti review CodeRabbit pada PR #166 (8 dari 10 komentar; 2 sudah ter-fix di commit CI sebelumnya).

### Perbaikan

1. **Observability — fallback structlog** (`capabilities_observability_setup.py`)
   - Saat structlog tidak tersedia, `_configure_logging` kini memasang stdlib JSON formatter + handler `app.jsonl` sehingga per-run log tetap berfungsi.

2. **Observability — isolasi run paralel (security, CWE-200)**
   - Handler per-run kini difilter `run_id` (baca structlog contextvars di thread emitter) → run yang tumpang-tindih tidak pernah saling menulis prompt/response ke log milik run lain. Terverifikasi dengan 2 thread paralel.

3. **MCP — batasi attachment ke workspace root (security)**
   - `attachment_file` wajib berada di dalam workspace root (`QWEN_WORKSPACE_ROOT` env, fallback cwd) — ditolak sebelum jalur async maupun sync.
   - Tolak special node (FIFO/socket/device) dengan kode `INVALID_PATH`.

4. **TUI picker** (`surface_cli_tui_app.py`)
   - Browse attachment kini menerima **file DAN folder** (dismiss pada file selection, tombol "Select This Folder" untuk direktori).

5. **Orchestrator attachment**
   - `bind_run_context` + `attach_run_log` dipindah sebelum `resolve_to_attachment` → error validasi/kompilasi folder ikut tercatat di per-run log.

6. **Folder compiler** (`utility_folder_compiler.py`)
   - `_is_excluded(path, root)` hanya memeriksa komponen path di bawah scan root → folder di bawah ancestor bernama `dist`/`build`/`venv`/`.cache` tidak lagi ditolak salah.

7. **Contract** — `max_depth` memakai konstanta `MAX_FOLDER_DEPTH`.

8. **SKILL.md** — hapus panduan watchdog 900s yang usang; dokumentasikan completion event-driven + circuit breaker 4 jam tanpa terminal event (sinkron dengan `EMBEDDED_SKILL_MD`).

### Verifikasi
- ✅ Lint Arwaky: **0 violations**
- ✅ Ruff check + format: **pass**
- ✅ Mypy: **no issues (75 files)**
- ✅ Pytest: **302 passed**
- ✅ Uji fungsional isolasi run paralel & fallback formatter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses CodeRabbit feedback on PR #166 with fixes to logging, attachment handling, folder compilation, and stale documentation.

- Adds a stdlib JSON formatter fallback so per-run logs still work when `structlog` is unavailable; default log level changed from WARNING to INFO.
- Filters per-run log handlers by `run_id` so overlapping parallel runs never write into each other's logs.
- Restricts MCP `attachment_file` to the workspace root (`QWEN_WORKSPACE_ROOT` env or cwd) and rejects FIFO, socket, and device nodes before dispatch.
- TUI attachment picker now accepts both files and folders in directory mode.
- Binds run context and attaches run log before folder resolution, so validation and compile errors are recorded.
- Folder compiler exclusion check now only inspects components below the scan root, preventing false rejection when ancestors are named `dist`, `build`, etc.
- Reuses `MAX_FOLDER_DEPTH` constant for `max_depth` defaults.
- Removes outdated 900s watchdog guidance from `SKILL.md` and documents event-driven completion with a 4-hour circuit breaker.

<sup>Written for commit 941216a77c3643c2f6821ec2264d2cf03f713844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File selection now supports choosing individual files in both file and folder browsing modes.
  - Attachment paths are restricted to the active workspace and reject unsupported filesystem entries.

- **Bug Fixes**
  - Folder scanning now applies exclusion rules relative to the selected scan location.
  - Run-specific logs are more reliably separated during concurrent activity.

- **Documentation**
  - Completion and retry guidance now reflects event-driven monitoring, with a four-hour safety limit instead of a fixed timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->