### PR TITLE
feat(folder): import-aware compilation (multi-language)

### DIFF
--- a/modules/core/src/capabilities_folder_compiler.py
+++ b/modules/core/src/capabilities_folder_compiler.py
@@ -13,6 +13,7 @@ from modules.shared.src.contract_core_protocol import IFolderCompileProtocol
 from modules.shared.src.taxonomy_core_constant import MAX_FOLDER_DEPTH
 from modules.shared.src.taxonomy_core_error import FolderCompileError, FolderEmptyError, FolderValidationError
 from modules.shared.src.utility_folder_compiler import (
+    collect_folder_files_with_imports,
     compile_files_to_markdown,
     validate_folder_for_compile,
 )
@@ -41,13 +42,21 @@ class FolderCompiler(IFolderCompileProtocol):
         folder_path: Path,
         output_path: Path | None = None,
         max_depth: int = MAX_FOLDER_DEPTH,
+        include_imports: bool = True,
     ) -> Path:
         """Compile folder contents to a single markdown file.
+
+        When ``include_imports`` is enabled (default), files inside the folder
+        are scanned for import/reference statements (Python, JS/TS, C/C++,
+        Go, Rust, PHP, Ruby, shell) and files imported from outside the folder
+        are resolved and included recursively, marked as ``(imported by ...)``.
 
         Args:
             folder_path: Directory to compile.
             output_path: Optional output file path. Auto-generated if None.
             max_depth: Maximum recursion depth.
+            include_imports: Follow imports of folder files and include
+                external dependencies (cycle-safe, bounded hops).
 
         Returns:
             Path to the compiled markdown file.
@@ -58,11 +67,16 @@ class FolderCompiler(IFolderCompileProtocol):
             FolderCompileError: If compilation fails.
         """
         folder_path = Path(folder_path).resolve()
-        log.info("Compiling folder: %s (max_depth=%d)", folder_path, max_depth)
+        log.info("Compiling folder: %s (max_depth=%d, include_imports=%s)", folder_path, max_depth, include_imports)
 
         try:
-            files = validate_folder_for_compile(folder_path, max_depth=max_depth)
-            log.info("Found %d compilable files", len(files))
+            if include_imports:
+                files, origins = collect_folder_files_with_imports(folder_path, max_depth=max_depth)
+                log.info("Found %d files (%d imported)", len(files), sum(1 for o in origins.values() if o))
+            else:
+                files = validate_folder_for_compile(folder_path, max_depth=max_depth)
+                origins = None
+                log.info("Found %d compilable files", len(files))
         except (FolderValidationError, FolderEmptyError) as e:
             log.error("Folder validation failed: %s", e)
             raise
@@ -74,7 +88,7 @@ class FolderCompiler(IFolderCompileProtocol):
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            markdown_content = compile_files_to_markdown(files, folder_path)
+            markdown_content = compile_files_to_markdown(files, folder_path, origins=origins)
             output_path.write_text(markdown_content, encoding="utf-8")
             log.info("Compiled markdown written to: %s", output_path)
             return output_path

--- a/modules/shared/src/utility_folder_compiler.py
+++ b/modules/shared/src/utility_folder_compiler.py
@@ -142,6 +142,7 @@ def compile_files_to_markdown(
     files: list[Path],
     folder_path: Path,
     title: str | None = None,
+    origins: dict[Path, tuple[str, ...]] | None = None,
 ) -> str:
     """Compile a list of files into a single markdown document.
 
@@ -168,13 +169,19 @@ def compile_files_to_markdown(
 
     lines.append("## File List\n\n")
     for f in files:
-        rel = f.relative_to(folder_path).as_posix()
-        lines.append(f"- `{rel}`\n")
+        rel = _display_rel(f, folder_path)
+        origin = ""
+        if origins and origins.get(f):
+            origin = f" *(imported by {', '.join(origins[f])})*"
+        lines.append(f"- `{rel}`{origin}\n")
     lines.append("\n---\n\n")
 
     for f in files:
-        rel = f.relative_to(folder_path).as_posix()
-        lines.append(f"## {rel}\n\n")
+        rel = _display_rel(f, folder_path)
+        origin = ""
+        if origins and origins.get(f):
+            origin = f" *(imported by {', '.join(origins[f])})*"
+        lines.append(f"## {rel}{origin}\n\n")
 
         try:
             content = f.read_text(encoding="utf-8", errors="replace")
@@ -191,6 +198,288 @@ def compile_files_to_markdown(
         lines.append(f"{fence}\n\n---\n\n")
 
     return "".join(lines)
+
+
+def _display_rel(path: Path, folder_path: Path) -> str:
+    """Return a display path relative to the folder root (../ for external files)."""
+    try:
+        return path.relative_to(folder_path).as_posix()
+    except ValueError:
+        return Path(os.path.relpath(path, folder_path)).as_posix()
+
+
+# ─── Import resolution (multi-language) ─────────────────────────────────────
+
+_IMPORTABLE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".py",
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".cjs",
+        ".c",
+        ".h",
+        ".cpp",
+        ".hpp",
+        ".cc",
+        ".cxx",
+        ".hxx",
+        ".hh",
+        ".go",
+        ".rs",
+        ".php",
+        ".rb",
+        ".sh",
+        ".bash",
+        ".zsh",
+    }
+)
+
+_TS_EXTS = (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs")
+_TS_INDEX_EXTS = (".ts", ".tsx", ".js", ".jsx", ".mjs")
+
+_PY_MODULE = re.compile(r"^\s*(?:from\s+([.\w]+)\s+import\s+[\w,*\s]+|import\s+([.\w]+))", re.MULTILINE)
+_JS_IMPORT = re.compile(
+    r"""(?:import|export)\s+[^'"']*?from\s*['"']([^'"']+)['"']"""
+    r"""|import\s*['"']([^'"']+)['"']"""
+    r"""|require\s*\(\s*['"']([^'"']+)['"']\s*\)""",
+    re.MULTILINE,
+)
+_C_INCLUDE = re.compile(r"^\s*#\s*include\s+\"([^\"]+)\"", re.MULTILINE)
+_GO_IMPORT = re.compile(r"^\s*import\s+(?:[.\w]+\s+)?\"([^\"]+)\"", re.MULTILINE)
+_RUST_MOD = re.compile(r"^\s*mod\s+([\w]+)\s*;", re.MULTILINE)
+_RUST_USE = re.compile(r"^\s*use\s+(?:crate::|super::)?([\w:]+)", re.MULTILINE)
+_PHP_INCLUDE = re.compile(
+    r"""^\s*(?:require|require_once|include|include_once)\s*\(\s*['"']([^'"']+)['"']\s*\)\s*;"""
+    r"""|^\s*(?:require|require_once|include|include_once)\s+['"']([^'"']+)['"']\s*;""",
+    re.MULTILINE,
+)
+_RUBY_REQUIRE = re.compile(
+    r"""^\s*require_relative\s+['"']([^'"']+)['"']|^\s*require\s+['"']([^'"']+)['"']""",
+    re.MULTILINE,
+)
+_SHELL_SOURCE = re.compile(r"^\s*(?:source|\.)\s+([^\s;#]+)", re.MULTILINE)
+
+
+def _parse_imports(filepath: Path) -> list[str]:
+    """Parse local import/reference specifiers from a source file (multi-language).
+
+    Only specifiers that can plausibly point at local files are returned;
+    external packages/stdlib resolve to nothing during lookup and are skipped.
+    """
+    suffix = filepath.suffix.lower()
+    try:
+        content = filepath.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return []
+    specs: list[str] = []
+    if suffix == ".py":
+        for m in _PY_MODULE.finditer(content):
+            spec = m.group(1) or m.group(2)
+            if spec:
+                specs.append(spec)
+    elif suffix in (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"):
+        for m in _JS_IMPORT.finditer(content):
+            spec = next((g for g in m.groups() if g), None)
+            if spec:
+                specs.append(spec)
+    elif suffix in (".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".hxx", ".hh"):
+        specs.extend(_C_INCLUDE.findall(content))
+    elif suffix == ".go":
+        specs.extend(_GO_IMPORT.findall(content))
+    elif suffix == ".rs":
+        for m in _RUST_MOD.finditer(content):
+            specs.append(f"mod:{m.group(1)}")
+        for m in _RUST_USE.finditer(content):
+            specs.append(f"use:{m.group(1)}")
+    elif suffix == ".php":
+        for m in _PHP_INCLUDE.finditer(content):
+            spec = next((g for g in m.groups() if g), None)
+            if spec:
+                specs.append(spec)
+    elif suffix == ".rb":
+        for m in _RUBY_REQUIRE.finditer(content):
+            spec = next((g for g in m.groups() if g), None)
+            if spec:
+                specs.append(spec)
+    elif suffix in (".sh", ".bash", ".zsh"):
+        specs.extend(_SHELL_SOURCE.findall(content))
+    return specs
+
+
+def _py_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
+    """Python candidates: ``a.b`` -> a/b.py | a/b/__init__.py; ``.a``/``..a`` relative."""
+    if spec.startswith("."):
+        dots = len(spec) - len(spec.lstrip("."))
+        mod = spec.lstrip(".")
+        rel_dir = base_dir
+        for _ in range(dots - 1):
+            rel_dir = rel_dir.parent
+        if not mod:
+            return [rel_dir / "__init__.py"]
+        parts = Path(*mod.split("."))
+        return [rel_dir / parts.with_suffix(".py"), rel_dir / parts / "__init__.py"]
+    parts = Path(*spec.split("."))
+    cands: list[Path] = []
+    # Resolve against the common project root (parent of the scanned folder),
+    # the scanned folder itself, and the importing file's directory.
+    for root in (folder_path.parent, folder_path, base_dir):
+        cands.append(root / parts.with_suffix(".py"))
+        cands.append(root / parts / "__init__.py")
+    return cands
+
+
+def _ts_candidates(base_dir: Path, spec: str) -> list[Path]:
+    """JS/TS candidates: relative specs only; bare names resolve to node_modules."""
+    if not (spec.startswith("./") or spec.startswith("../")):
+        return []
+    base = (base_dir / spec).resolve()
+    if base.suffix:
+        return [base]
+    cands: list[Path] = [base.with_suffix(ext) for ext in _TS_EXTS]
+    cands.extend(base / f"index{ext}" for ext in _TS_INDEX_EXTS)
+    return cands
+
+
+def _c_candidates(base_dir: Path, spec: str) -> list[Path]:
+    """C/C++ candidates: quote includes resolve relative to the including file."""
+    base = base_dir / spec
+    if base.suffix:
+        return [base]
+    return [base, base.with_suffix(".h"), base.with_suffix(".hpp"), base.with_suffix(".c"), base.with_suffix(".cpp")]
+
+
+def _go_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
+    """Go candidates: relative imports plus direct module-path mapping under root."""
+    if spec.startswith("./") or spec.startswith("../"):
+        base = (base_dir / spec).resolve()
+        return [base] if base.suffix else [base.with_suffix(".go"), base / "main.go"]
+    base = folder_path / spec
+    return [base] if base.suffix else [base.with_suffix(".go"), base / "main.go"]
+
+
+def _rust_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
+    """Rust candidates: ``mod x`` and ``use crate::a::b`` relative to crate root."""
+    if spec.startswith("mod:"):
+        name = spec[4:]
+        return [
+            base_dir / f"{name}.rs",
+            base_dir / name / "mod.rs",
+            folder_path / f"{name}.rs",
+            folder_path / name / "mod.rs",
+        ]
+    parts = spec[4:].split("::")  # strip "use:"
+    cands: list[Path] = []
+    for i in range(1, len(parts) + 1):
+        rel = Path(*parts[:i])
+        cands.append(folder_path / rel.with_suffix(".rs"))
+        cands.append(folder_path / rel / "mod.rs")
+    return cands
+
+
+def _php_candidates(base_dir: Path, spec: str) -> list[Path]:
+    base = base_dir / spec
+    if base.suffix:
+        return [base]
+    return [base.with_suffix(".php"), base / "index.php"]
+
+
+def _ruby_candidates(base_dir: Path, spec: str) -> list[Path]:
+    base = base_dir / spec
+    if base.suffix:
+        return [base]
+    return [base.with_suffix(".rb"), base / "index.rb"]
+
+
+def _shell_candidates(base_dir: Path, spec: str) -> list[Path]:
+    base = base_dir / spec
+    if base.suffix:
+        return [base]
+    return [base, base.with_suffix(".sh"), base.with_suffix(".bash")]
+
+
+def _resolve_import(filepath: Path, spec: str, folder_path: Path) -> Path | None:
+    """Resolve one import specifier to an existing local file, or None."""
+    suffix = filepath.suffix.lower()
+    base_dir = filepath.parent
+    cands: list[Path] = []
+    if suffix == ".py":
+        cands = _py_candidates(base_dir, folder_path, spec)
+    elif suffix in (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"):
+        cands = _ts_candidates(base_dir, spec)
+    elif suffix in (".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".hxx", ".hh"):
+        cands = _c_candidates(base_dir, spec)
+    elif suffix == ".go":
+        cands = _go_candidates(base_dir, folder_path, spec)
+    elif suffix == ".rs":
+        cands = _rust_candidates(base_dir, folder_path, spec)
+    elif suffix == ".php":
+        cands = _php_candidates(base_dir, spec)
+    elif suffix == ".rb":
+        cands = _ruby_candidates(base_dir, spec)
+    elif suffix in (".sh", ".bash", ".zsh"):
+        cands = _shell_candidates(base_dir, spec)
+    for cand in cands:
+        try:
+            if cand.is_file():
+                return cand.resolve()
+        except OSError:
+            continue
+    return None
+
+
+def collect_folder_files_with_imports(
+    folder_path: Path,
+    max_depth: int = MAX_FOLDER_DEPTH,
+    import_depth: int = 3,
+) -> tuple[list[Path], dict[Path, tuple[str, ...]]]:
+    """Collect in-folder files plus files they import from outside the folder.
+
+    Imports are parsed per language (Python, JS/TS, C/C++, Go, Rust, PHP,
+    Ruby, shell) and resolved relative to the importing file (and the folder
+    root where the language allows). External dependencies are included
+    recursively with cycle protection, up to ``import_depth`` hops.
+
+    Returns:
+        ``(files, origins)``: ordered list to compile and a mapping of each
+        external file to the display names of its importers (in-folder files
+        map to an empty tuple).
+
+    Raises:
+        FolderValidationError: If the folder is invalid.
+        FolderEmptyError: If the folder contains no compilable files.
+    """
+    folder_path = Path(folder_path).resolve()
+    base_files = validate_folder_for_compile(folder_path, max_depth=max_depth)
+    files: list[Path] = list(base_files)
+    origins: dict[Path, tuple[str, ...]] = {f: () for f in base_files}
+    seen: set[Path] = set(files)
+    frontier: list[Path] = list(files)
+    for _ in range(import_depth):
+        next_frontier: list[Path] = []
+        for f in frontier:
+            for spec in _parse_imports(f):
+                resolved = _resolve_import(f, spec, folder_path)
+                if resolved is None or resolved in seen:
+                    continue
+                if resolved.suffix.lower() not in _IMPORTABLE_SUFFIXES:
+                    continue
+                # External files: skip imports living inside excluded
+                # directories (node_modules, build, dist, venv, ...).
+                if any(part in EXCLUDED_DIR_NAMES for part in resolved.parts):
+                    continue
+                seen.add(resolved)
+                next_frontier.append(resolved)
+                importer = _display_rel(f, folder_path)
+                merged = (*origins.get(resolved, ()), importer)
+                origins[resolved] = tuple(dict.fromkeys(merged))
+        if not next_frontier:
+            break
+        frontier = next_frontier
+        files.extend(next_frontier)
+    return files, origins
 
 
 def validate_folder_for_compile(folder_path: Path, max_depth: int = MAX_FOLDER_DEPTH) -> list[Path]:
@@ -217,6 +506,7 @@ def validate_folder_for_compile(folder_path: Path, max_depth: int = MAX_FOLDER_D
 
 __all__ = [
     "collect_folder_files",
+    "collect_folder_files_with_imports",
     "compile_files_to_markdown",
     "validate_folder_for_compile",
 ]

--- a/tests/unit_folder_compiler.py
+++ b/tests/unit_folder_compiler.py
@@ -1,0 +1,120 @@
+"""Unit tests: import-aware folder compilation (multi-language)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.core.src.capabilities_folder_compiler import FolderCompiler
+from modules.shared.src.utility_folder_compiler import (
+    collect_folder_files_with_imports,
+    compile_files_to_markdown,
+)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestCollectFolderFilesWithImports:
+    def test_python_import_from_outside_folder(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        ext = tmp_path / "utils"
+        _write(target / "a.py", "from utils.helper import run\n\ndef main():\n    run()\n")
+        _write(ext / "helper.py", "def run():\n    print('hi')\n")
+
+        files, origins = collect_folder_files_with_imports(target)
+        names = {f.name for f in files}
+        assert "a.py" in names
+        assert "helper.py" in names
+        helper = next(f for f in files if f.name == "helper.py")
+        assert origins[helper] == ("a.py",)
+
+    def test_python_relative_import(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "pkg" / "a.py", "from .util import x\n")
+        _write(target / "pkg" / "util.py", "x = 1\n")
+        files, _ = collect_folder_files_with_imports(target)
+        assert any(f.name == "util.py" for f in files)
+
+    def test_js_import_from_outside(self, tmp_path: Path) -> None:
+        target = tmp_path / "app"
+        lib = tmp_path / "lib"
+        _write(target / "index.js", "import { helper } from '../lib/helper';\nconsole.log(helper());\n")
+        _write(lib / "helper.js", "export function helper() { return 1; }\n")
+        files, origins = collect_folder_files_with_imports(target)
+        names = {f.name for f in files}
+        assert "index.js" in names
+        assert "helper.js" in names
+
+    def test_c_include_from_outside(self, tmp_path: Path) -> None:
+        target = tmp_path / "src"
+        inc = tmp_path / "include"
+        _write(target / "main.c", '#include "../include/header.h"\nint main() { return 0; }\n')
+        _write(inc / "header.h", "#ifndef HEADER_H\n#define HEADER_H\n#endif\n")
+        files, _ = collect_folder_files_with_imports(target)
+        assert any(f.name == "header.h" for f in files)
+
+    def test_cycle_protection(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "import b\n")
+        _write(tmp_path / "b.py", "import a\n")
+        files, _ = collect_folder_files_with_imports(target)
+        # a.py in folder, b.py imported once (no infinite loop)
+        assert [f.name for f in files].count("b.py") == 1
+
+    def test_import_depth_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "import m1\n")
+        _write(tmp_path / "m1.py", "import m2\n")
+        _write(tmp_path / "m2.py", "import m3\n")
+        _write(tmp_path / "m3.py", "x = 1\n")
+        files, _ = collect_folder_files_with_imports(target, import_depth=1)
+        names = {f.name for f in files}
+        assert "m1.py" in names
+        assert "m2.py" not in names  # beyond import_depth=1
+        files2, _ = collect_folder_files_with_imports(target, import_depth=3)
+        assert "m3.py" in {f.name for f in files2}
+
+    def test_external_stdlib_not_included(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "import os\nimport json\n")
+        files, _ = collect_folder_files_with_imports(target)
+        names = {f.name for f in files}
+        assert names == {"a.py"}
+
+
+class TestCompileMarkdownOrigins:
+    def test_external_file_marked_imported_by(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "from utils.helper import run\n")
+        _write(tmp_path / "utils" / "helper.py", "def run(): pass\n")
+
+        files, origins = collect_folder_files_with_imports(target)
+        md = compile_files_to_markdown(files, target, origins=origins)
+        assert "*(imported by a.py)*" in md
+        assert "../utils/helper.py" in md
+
+
+class TestFolderCompilerImportAware:
+    def test_compile_folder_include_imports(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "from utils.helper import run\nrun()\n")
+        _write(tmp_path / "utils" / "helper.py", "def run(): pass\n")
+
+        compiler = FolderCompiler(input_dir=tmp_path / "out")
+        out = compiler.compile_folder(target, include_imports=True)
+        content = out.read_text(encoding="utf-8")
+        assert "helper.py" in content
+        assert "imported by" in content
+
+    def test_compile_folder_without_imports(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        _write(target / "a.py", "from utils.helper import run\n")
+        _write(tmp_path / "utils" / "helper.py", "def run(): pass\n")
+
+        compiler = FolderCompiler(input_dir=tmp_path / "out")
+        out = compiler.compile_folder(target, include_imports=False)
+        content = out.read_text(encoding="utf-8")
+        assert "helper.py" not in content


### PR DESCRIPTION
## Fitur Baru: Import-Aware Folder Compilation

Folder yang dikompilasi jadi markdown kini **otomatis menyertakan file yang di-import dari LUAR folder target**, multi-bahasa.

### Contoh
```
target/
  ├── a.py    → "from utils.helper import run"   ← import luar
  ├── app.js  → "import { helper } from '../lib/helper'"
  └── main.c  → '#include "../include/header.h"'
```
Hasil compile menyertakan `../utils/helper.py`, `../lib/helper.js`, `../include/header.h` — ditandai `*(imported by a.py)*`.

### Dukungan Bahasa
| Bahasa | Pola import |
|---|---|
| Python | `import a.b`, `from a.b import c`, relatif `.`/`..` |
| JS/TS | `import ... from`, `import 'x'`, `require('x')`, `export ... from` |
| C/C++ | `#include "file.h"` (quote = lokal) |
| Go | `import "./pkg"`, pemetaan modul lokal |
| Rust | `mod x;`, `use crate::a::b;` |
| PHP | `require/include/require_once/include_once` |
| Ruby | `require`, `require_relative` |
| Shell | `source`, `. file` |

### Detail Implementasi
- `collect_folder_files_with_imports()`: BFS dengan **proteksi cycle** + batas `import_depth` (default 3 hop)
- Resolusi: project root (parent folder target) → folder target → direktori file peng-import
- **Skip**: stdlib/package eksternal yang tak ter-resolve lokal, direktori excluded (node_modules, build, dist, venv)
- `compile_files_to_markdown()`: penanda `(imported by ...)` + path relatif `../`
- `FolderCompiler.compile_folder(include_imports=True)` — **default aktif** untuk attachment folder

### Verifikasi
- ✅ Lint Arwaky: 0 violations
- ✅ Ruff + mypy: pass
- ✅ Pytest: **312 passed** (10 test baru)
- ✅ Demo end-to-end: Python + JS + C

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes folder compilation import-aware: files that import code from outside the target folder are now resolved and included in the compiled markdown, marked as `(imported by ...)`. Previously only files inside the folder were compiled.

**New Features**
- `collect_folder_files_with_imports()` resolves imports for Python, JS/TS, C/C++, Go, Rust, PHP, Ruby, and shell with cycle protection and a default 3-hop depth limit.
- External files appear in the markdown marked `*(imported by ...)*` with `../`-relative paths.
- `FolderCompiler.compile_folder()` now includes imports by default; pass `include_imports=False` to keep the old behavior.

<sup>Written for commit 6002c1b8072ca3928201e8243f0200d579699834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Folder compilation now includes files referenced through imports by default.
  - Supports import discovery across Python, JavaScript/TypeScript, C/C++, Go, Rust, PHP, Ruby, and shell files.
  - Generated Markdown identifies the files that reference each included file.
  - Import traversal follows relative and external project files while respecting depth limits, excluded directories, and circular dependencies.
  - Added an option to disable import inclusion when compiling a folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->