### PR TITLE
fix(folder): resolve Rust crate:: imports from the true crate root

### DIFF
--- a/modules/shared/src/utility_folder_compiler.py
+++ b/modules/shared/src/utility_folder_compiler.py
@@ -360,8 +360,17 @@ def _go_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
     return [base] if base.suffix else [base.with_suffix(".go"), base / "main.go"]
 
 
+def _find_crate_root(path: Path) -> Path:
+    """Return the nearest ancestor directory containing ``Cargo.toml``."""
+    for cand in (path, *path.parents):
+        if (cand / "Cargo.toml").is_file():
+            return cand
+    return path
+
+
 def _rust_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
-    """Rust candidates: ``mod x`` and ``use crate::a::b`` relative to crate root."""
+    """Rust candidates: ``mod x`` beside the file; ``use crate::a::b`` relative to
+    the crate root (located by walking up to ``Cargo.toml``)."""
     if spec.startswith("mod:"):
         name = spec[4:]
         return [
@@ -371,11 +380,17 @@ def _rust_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]
             folder_path / name / "mod.rs",
         ]
     parts = spec[4:].split("::")  # strip "use:"
+    roots = {
+        _find_crate_root(base_dir),
+        _find_crate_root(folder_path),
+        folder_path,
+    }
     cands: list[Path] = []
-    for i in range(1, len(parts) + 1):
-        rel = Path(*parts[:i])
-        cands.append(folder_path / rel.with_suffix(".rs"))
-        cands.append(folder_path / rel / "mod.rs")
+    for root in roots:
+        for i in range(1, len(parts) + 1):
+            rel = Path(*parts[:i])
+            cands.append(root / rel.with_suffix(".rs"))
+            cands.append(root / rel / "mod.rs")
     return cands
 
 

--- a/tests/unit_folder_compiler.py
+++ b/tests/unit_folder_compiler.py
@@ -77,6 +77,30 @@ class TestCollectFolderFilesWithImports:
         files2, _ = collect_folder_files_with_imports(target, import_depth=3)
         assert "m3.py" in {f.name for f in files2}
 
+    def test_rust_crate_import_from_outside(self, tmp_path: Path) -> None:
+        # crate root = rust_project/ (Cargo.toml); folder target = src/
+        # models.rs/user.rs di dalam folder; shared/util.rs DI LUAR folder
+        crate = tmp_path / "rust_project"
+        _write(crate / "Cargo.toml", '[package]\nname="demo"\n')
+        _write(crate / "src" / "main.rs", "mod models;\nuse crate::shared::util;\nfn main() { util::run(); }\n")
+        _write(crate / "src" / "models.rs", "pub mod user;\n")
+        _write(crate / "src" / "models" / "user.rs", "pub struct User;\n")
+        _write(crate / "shared" / "util.rs", "pub fn run() {}\n")
+
+        files, origins = collect_folder_files_with_imports(crate / "src")
+        names = {f.name for f in files}
+        assert {"main.rs", "models.rs", "user.rs", "util.rs"} <= names
+        util = next(f for f in files if f.name == "util.rs")
+        assert origins[util] == ("main.rs",)
+
+    def test_typescript_import_from_outside(self, tmp_path: Path) -> None:
+        target = tmp_path / "app"
+        shared = tmp_path / "shared"
+        _write(target / "main.ts", "import { format } from '../shared/format';\nformat(1);\n")
+        _write(shared / "format.ts", "export function format(n: number) { return n.toFixed(2); }\n")
+        files, _ = collect_folder_files_with_imports(target)
+        assert any(f.name == "format.ts" for f in files)
+
     def test_external_stdlib_not_included(self, tmp_path: Path) -> None:
         target = tmp_path / "target"
         _write(target / "a.py", "import os\nimport json\n")


### PR DESCRIPTION
## Perbaikan Resolusi Import Rust

Sebelumnya `use crate::a::b` selalu di-resolve relatif terhadap folder yang di-scan (dianggap crate root). Untuk proyek Rust asli, crate root adalah direktori berisi `Cargo.toml` — yang sering berada DI ATAS folder target (mis. folder `src/`, crate root = project root).

### Perubahan
- `_find_crate_root()`: berjalan naik dari folder target & file peng-import sampai menemukan `Cargo.toml`
- `_rust_candidates()`: resolve `use crate::a::b` terhadap crate root yang sebenarnya → file di luar folder (mis. `../shared/util.rs`) ikut ter-include
- Tetap dukung `mod x;` (relatif ke direktori file) dan folder-scan root

### Verifikasi
- Test baru: `rust crate::` import dari luar folder + `typescript` import dari luar
- Pytest: **314 passed** · Ruff · Mypy · Lint Arwaky 0
- Demo: `use crate::shared::util` → `../shared/util.rs` ter-include *(imported by main.rs)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rust `crate::` imports to resolve from the actual crate root instead of the scanned folder, so files outside the target folder (like sibling modules) are now included.

- Walks up from the folder and importing file to find the nearest `Cargo.toml`.
- Adds tests for Rust and TypeScript imports from outside the scanned folder.

<sup>Written for commit e4ef2b47bf1bd6091a4b6cf4edab308c10ff669b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rust files using crate-relative imports are now resolved from the correct crate root, including imports that reference files outside the scanned folder.
  - Related Rust modules and supporting files are now collected more reliably across crate directory structures.
- **Tests**
  - Added coverage for Rust crate imports from outside the target folder.
  - Added coverage confirming external TypeScript relative imports are collected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->