### PR TITLE
feat(folder): resolve tsconfig path aliases in TS/JS imports

### DIFF
--- a/modules/shared/src/utility_folder_compiler.py
+++ b/modules/shared/src/utility_folder_compiler.py
@@ -6,8 +6,10 @@ Collects code/md files from a folder and compiles them into a single markdown fi
 
 from __future__ import annotations
 
+import json
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 
 from modules.shared.src.taxonomy_core_constant import CODE_EXTENSIONS, EXCLUDED_DIR_NAMES, MAX_FOLDER_DEPTH
@@ -331,16 +333,85 @@ def _py_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
     return cands
 
 
-def _ts_candidates(base_dir: Path, spec: str) -> list[Path]:
-    """JS/TS candidates: relative specs only; bare names resolve to node_modules."""
-    if not (spec.startswith("./") or spec.startswith("../")):
-        return []
-    base = (base_dir / spec).resolve()
-    if base.suffix:
-        return [base]
-    cands: list[Path] = [base.with_suffix(ext) for ext in _TS_EXTS]
-    cands.extend(base / f"index{ext}" for ext in _TS_INDEX_EXTS)
-    return cands
+def _find_tsconfig(start: Path) -> Path | None:
+    """Return the nearest ``tsconfig.json`` walking up from ``start``."""
+    for cand in (start, *start.parents):
+        candidate = cand / "tsconfig.json"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+@lru_cache(maxsize=8)
+def _load_tsconfig_paths(tsconfig_path: Path) -> tuple[Path, dict[str, list[str]]]:
+    """Load ``(baseUrl_dir, paths)`` from a tsconfig, resolving one ``extends`` level."""
+    base_dir = tsconfig_path.parent
+    try:
+        data = json.loads(tsconfig_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return base_dir, {}
+    compiler = data.get("compilerOptions") or {}
+    extends = data.get("extends")
+    if isinstance(extends, str):
+        ext_path = (base_dir / extends).resolve()
+        if not ext_path.suffix:
+            ext_path = ext_path.with_suffix(".json")
+        if ext_path.is_file():
+            ext_base, ext_paths = _load_tsconfig_paths(ext_path)
+            merged = dict(ext_paths)
+            merged.update(compiler.get("paths") or {})
+            base_url = compiler.get("baseUrl") or "."
+            return (ext_base / base_url).resolve(), merged
+    paths = compiler.get("paths") or {}
+    base_url = compiler.get("baseUrl") or "."
+    return (base_dir / base_url).resolve(), paths
+
+
+def _ts_candidates(base_dir: Path, folder_path: Path, spec: str) -> list[Path]:
+    """JS/TS candidates: relative specs plus tsconfig ``paths`` aliases.
+
+    Bare specifiers that match no alias resolve to node_modules and are skipped.
+    """
+    if spec.startswith("./") or spec.startswith("../"):
+        base = (base_dir / spec).resolve()
+        if base.suffix:
+            return [base]
+        cands: list[Path] = [base.with_suffix(ext) for ext in _TS_EXTS]
+        cands.extend(base / f"index{ext}" for ext in _TS_INDEX_EXTS)
+        return cands
+
+    # Path aliases from tsconfig.json (e.g. "@/*": ["src/*"], "@lib/x": ["lib/x.ts"])
+    for root in {base_dir, folder_path}:
+        tsconfig = _find_tsconfig(root)
+        if tsconfig is None:
+            continue
+        base_url, paths = _load_tsconfig_paths(tsconfig)
+        for pattern, targets in paths.items():
+            if "*" in pattern:
+                prefix, suffix = pattern.split("*", 1)
+                if not spec.startswith(prefix):
+                    continue
+                if suffix and not spec.endswith(suffix):
+                    continue
+                wildcard = spec[len(prefix) : len(spec) - len(suffix)]
+            else:
+                if spec != pattern:
+                    continue
+                wildcard = ""
+            alias_cands: list[Path] = []
+            for target in targets:
+                filled = target.replace("*", wildcard)
+                base = Path(filled)
+                if not base.is_absolute():
+                    base = (base_url / base).resolve()
+                if base.suffix:
+                    alias_cands.append(base)
+                else:
+                    alias_cands.extend(base.with_suffix(ext) for ext in _TS_EXTS)
+                    alias_cands.extend(base / f"index{ext}" for ext in _TS_INDEX_EXTS)
+            if alias_cands:
+                return alias_cands
+    return []
 
 
 def _c_candidates(base_dir: Path, spec: str) -> list[Path]:
@@ -423,7 +494,7 @@ def _resolve_import(filepath: Path, spec: str, folder_path: Path) -> Path | None
     if suffix == ".py":
         cands = _py_candidates(base_dir, folder_path, spec)
     elif suffix in (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"):
-        cands = _ts_candidates(base_dir, spec)
+        cands = _ts_candidates(base_dir, folder_path, spec)
     elif suffix in (".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".hxx", ".hh"):
         cands = _c_candidates(base_dir, spec)
     elif suffix == ".go":

--- a/tests/unit_folder_compiler.py
+++ b/tests/unit_folder_compiler.py
@@ -101,6 +101,30 @@ class TestCollectFolderFilesWithImports:
         files, _ = collect_folder_files_with_imports(target)
         assert any(f.name == "format.ts" for f in files)
 
+    def test_tsconfig_path_alias_from_outside(self, tmp_path: Path) -> None:
+        # tsconfig: "@lib/*" -> "lib/*" (baseUrl = project root)
+        project = tmp_path / "ts_project"
+        _write(project / "tsconfig.json", '{"compilerOptions": {"baseUrl": ".", "paths": {"@lib/*": ["lib/*"]}}}')
+        _write(project / "src" / "main.ts", "import { helper } from '@lib/helper';\nhelper();\n")
+        _write(project / "lib" / "helper.ts", "export function helper() { return 1; }\n")
+
+        files, origins = collect_folder_files_with_imports(project / "src")
+        names = {f.name for f in files}
+        assert "main.ts" in names
+        assert "helper.ts" in names
+        helper = next(f for f in files if f.name == "helper.ts")
+        assert origins[helper] == ("main.ts",)
+
+    def test_tsconfig_exact_alias(self, tmp_path: Path) -> None:
+        # alias tanpa wildcard: "utils" -> "lib/utils.ts"
+        project = tmp_path / "ts_project"
+        _write(project / "tsconfig.json", '{"compilerOptions": {"baseUrl": ".", "paths": {"utils": ["lib/utils.ts"]}}}')
+        _write(project / "src" / "main.ts", "import { x } from 'utils';\n")
+        _write(project / "lib" / "utils.ts", "export const x = 1;\n")
+
+        files, _ = collect_folder_files_with_imports(project / "src")
+        assert any(f.name == "utils.ts" for f in files)
+
     def test_external_stdlib_not_included(self, tmp_path: Path) -> None:
         target = tmp_path / "target"
         _write(target / "a.py", "import os\nimport json\n")


### PR DESCRIPTION
## Fitur: Path Alias tsconfig

Import TypeScript/JS yang memakai **path alias tsconfig** kini ter-resolve dan file-nya ikut ter-include.

### Contoh
```jsonc
// tsconfig.json
{ "compilerOptions": { "baseUrl": ".", "paths": { "@lib/*": ["lib/*"] } } }
```
```ts
// src/main.ts
import { helper } from '@lib/helper';   // → lib/helper.ts (di luar folder src/)
```
Hasil compile: `../lib/helper.ts *(imported by main.ts)*` ✅

### Implementasi
- `_find_tsconfig()` — cari `tsconfig.json` terdekat (naik dari file & folder scan)
- `_load_tsconfig_paths()` — parse `baseUrl` + `paths`, dukung `extends` 1 level, di-cache
- `_ts_candidates()` — cocokkan specifier non-relatif ke pola alias:
  - Wildcard: `"@/*": ["src/*"]`
  - Exact: `"utils": ["lib/utils.ts"]`
  - Resolusi relatif `baseUrl`, ekstensi `.ts/.tsx/.js/...`, `index.*`
- Specifier yang tak cocok alias → tetap di-skip (node_modules)

### Verifikasi
- Test baru: wildcard alias dari luar folder + exact alias
- Pytest: **316 passed** · Ruff · Mypy · Lint Arwaky 0
- Demo: `@lib/helper` → `../lib/helper.ts` ter-include

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves TypeScript/JavaScript imports that use tsconfig path aliases, so aliased files now get included in the compiled output instead of being skipped as bare `node_modules` imports.

- Matches non-relative specifiers against `compilerOptions.paths` from the nearest `tsconfig.json`, supporting wildcard (`"@/*"`) and exact aliases.
- Resolves aliases against `baseUrl` and applies the existing extension/`index.*` resolution.
- Loads `baseUrl` and `paths` with one level of `extends` support and caches the result per tsconfig.
- Specifiers that match no alias still skip to `node_modules` as before.
- Adds tests for a wildcard alias pointing outside the scanned folder and an exact alias.

<sup>Written for commit 64b80ab5240ded902ab93dd392665a3a4fd5eacf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript and JavaScript imports now support path aliases defined in `tsconfig.json`.
  * Alias resolution supports wildcard and exact mappings, including configurations inherited through one level of extension.

* **Bug Fixes**
  * Improved project file collection for aliased imports located outside the importing file’s directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->