### PR TITLE
fix(cli): UI/UX hardening (P0-P3) + remove legacy qwc command

### DIFF
--- a/.agents/skills/qwen-web/SKILL.md
+++ b/.agents/skills/qwen-web/SKILL.md
@@ -111,7 +111,7 @@ All tools speak stdio MCP and return structured JSON envelopes:
 ### 2.2 Exact invocation payloads
 
 > **📁 Workspace rule: put ALL prompt/attachment/output files under `.qwen-web/`**
-> (`qwen-web-cli init` creates it in the cwd — already `.gitignore`d). Use
+> (`qwen-web-arwaky init` creates it in the cwd — already `.gitignore`d). Use
 > `.qwen-web/input/...` and `.qwen-web/output/...`; NEVER create a bare `input/`
 > or `output/` folder in the repo root. `output/` inside `.qwen-web/` is a symlink
 > to the XDG output dir, so results persist outside the repo.
@@ -149,7 +149,7 @@ Response completion is **event-driven**, not duration-driven. The historical `ti
 ### 2.4 CLI reference (equivalent surface for scripting & CI)
 
 ```bash
-# Primary command: qwa (or qwen-web-arwaky / qwc / qwen-web-cli)
+# Primary command: qwa (or qwen-web-arwaky)
 qwa doctor [--json]                        # environment health checks
 qwa init [--dir TARGET]                    # workspace provisioning (.qwen-web/ in cwd)
 qwa login                                  # headed manual login / CAPTCHA
@@ -157,7 +157,7 @@ qwa update [--check] [--force]             # self-update + Chromium sync
 qwa prompt-direct -t "..." [-o OUT] [--headless] [--json]
 qwa prompt-only   -i .qwen-web/input/PROMPT.md [-o OUT] [--headless] [--json]
 qwa prompt-with-attachment -i .qwen-web/input/PROMPT.md -a FILE [-o OUT] [--headless] [--json]
-qwen-web-cli mcp                                    # run MCP server over stdio
+qwen-web-arwaky mcp                                    # run MCP server over stdio
 ```
 
 Paths: always use `.qwen-web/input/...` for prompts/attachments and
@@ -334,18 +334,18 @@ Attached: the full diff (or consolidated changed files).
 
 | Exception / MCP code | Meaning | Agent action | Retryable? |
 | :--- | :--- | :--- | :--- |
-| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-cli login`), then retry the original task | ✅ after login |
+| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-arwaky login`), then retry the original task | ✅ after login |
 | `OutputValidationError` w/ "verify you are human" | CAPTCHA / bot challenge | `setup_session` headed; human solves CAPTCHA; retry | ✅ after human |
 | `OutputValidationError` (502/504/service unavailable) | Transient server error | Back off 10–30s, retry once | ✅ |
 | `NetworkTimeoutError` | Browser network timeout | Retry with `timeout_sec × 2`; if repeated → `doctor` | ✅ |
 | `ResponseDetectionTimeoutError` | Dispatch succeeded but no answer detected | Retry with larger timeout; simplify prompt; check logs for last lifecycle event | ✅ |
 | `CircuitBreakerOpenError` | ≥5 failures within 30s window | **Stop.** Back off ≥30s, diagnose root cause, then resume | ⏸ after backoff |
-| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-cli update`, retry | ⚠️ |
+| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-arwaky update`, retry | ⚠️ |
 | `FileValidationError` | Attachment missing / unreadable / >100 MB | Fix path/permissions/size; retry | ✅ after fix |
 | `UploadFailureError` | Attachment could not be verified as uploaded | Retry once; if repeated, convert attachment to `.md`/`.txt` | ✅ |
 | `SendDispatchError` | Send click + Enter fallback both failed | Check parse-toast state; retry; `doctor` if repeated | ✅ |
 | `ModelSwitchError` | Default model `Qwen3.8-Max` could not be verified | Retry once; check account model access | ⚠️ |
-| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-cli update` | ✅ after fix |
+| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-arwaky update` | ✅ after fix |
 | `FILE_NOT_FOUND` / `VALIDATION_ERROR` (MCP) | Bad tool arguments | Fix the flagged `field` from the error envelope; never blind-retry | ❌ fix first |
 
 Built-in guardrails you inherit automatically: client-side rate limiter (60 req/min),
@@ -369,7 +369,7 @@ Task returned an error / suspicious output
 │
 ├─ NetworkTimeoutError / 5xx challenge text?
 │  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
-│      → still failing? run `qwen-web-cli doctor`, verify connectivity
+│      → still failing? run `qwen-web-arwaky doctor`, verify connectivity
 │
 ├─ ResponseDetectionTimeoutError?
 │  └─► Check last lifecycle event in logs:
@@ -382,7 +382,7 @@ Task returned an error / suspicious output
 │      → RETRY once → if still failing, convert content to consolidated .md
 │
 ├─ BrowserLaunchError / PromptInjectionError / ModelSwitchError?
-│  └─► `qwen-web-cli doctor` → `qwen-web-cli update` (package + Chromium sync) → RETRY
+│  └─► `qwen-web-arwaky doctor` → `qwen-web-arwaky update` (package + Chromium sync) → RETRY
 │
 └─ MCP VALIDATION_ERROR / FILE_NOT_FOUND?
    └─► read `error.field` + `error.hint`; correct arguments; do NOT retry unchanged
@@ -426,7 +426,7 @@ MCP client registration (Claude Desktop / Cursor style):
 {
   "mcpServers": {
     "qwen-web": {
-      "command": "qwen-web-cli",
+      "command": "qwen-web-arwaky",
       "args": ["mcp"]
     }
   }
@@ -436,11 +436,11 @@ MCP client registration (Claude Desktop / Cursor style):
 ### 5.2 Combining CLI + MCP in one workflow
 
 1. **Bootstrap (once per machine, human-supervised):**
-   `qwen-web-cli doctor` → `qwen-web-cli login` → `qwen-web-cli init`
+   `qwen-web-arwaky doctor` → `qwen-web-arwaky login` → `qwen-web-arwaky init`
 2. **Autonomous steady state (agent via MCP):**
    `check_session` → `process_*` tools → verify `.meta.json` → chain next task.
 3. **Recovery (agent escalates to CLI/human):**
-   `setup_session` for CAPTCHA; `qwen-web-cli update` for UI drift; `doctor --json` for diagnostics.
+   `setup_session` for CAPTCHA; `qwen-web-arwaky update` for UI drift; `doctor --json` for diagnostics.
 
 ### 5.3 File attachment strategy
 
@@ -464,7 +464,7 @@ MCP client registration (Claude Desktop / Cursor style):
    to the user instead of looping.
 5. **Log forensics:** `app.jsonl` (JSONL events) + `status.json` (machine-readable run
    state) live in the OS state dir (`~/.local/state/qwen-web/log` on Linux).
-6. **Keep the engine current:** `qwen-web-cli update --check` regularly; run
+6. **Keep the engine current:** `qwen-web-arwaky update --check` regularly; run
 7. **Headless discipline:** keep `headless: true` for all production tasks; headed
    browsers are exclusively for `login` / `setup_session` / CAPTCHA resolution.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           uv pip install --python .venv/bin/python dist/*.whl
 
       - name: Verify CLI entry point
-        run: .venv/bin/qwen-web-cli --help | grep -q "Automate chat.qwen.ai"
+        run: .venv/bin/qwen-web-arwaky --help | grep -q "Automate chat.qwen.ai"
 
       - name: Verify MCP entry point imports
         # The MCP server blocks on stdio, so verify import instead of running it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,11 @@ lint_arwaky.config.yaml, pyproject.toml, requirements.txt
 pip install -r requirements.txt
 python3 -m playwright install chromium
 
-qwen-web-cli                                                    # interactive TUI
-qwen-web-cli prompt-direct -t "Hello" -o output.md --headless # direct inline
-qwen-web-cli prompt-only -i prompt.md -o output.md --headless # single prompt file
-qwen-web-cli prompt-with-attachment -i p.md -a att.file --headless # prompt with attachment
-qwen-web-cli login                                             # login session
+qwen-web-arwaky                                                    # interactive TUI
+qwen-web-arwaky prompt-direct -t "Hello" -o output.md --headless # direct inline
+qwen-web-arwaky prompt-only -i prompt.md -o output.md --headless # single prompt file
+qwen-web-arwaky prompt-with-attachment -i p.md -a att.file --headless # prompt with attachment
+qwen-web-arwaky login                                             # login session
 qwen-web-mcp                                                   # MCP server
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Rename primary CLI command from `qwen-web-cli` (alias `qwc`) to `qwen-web-arwaky` (alias `qwa`); legacy `qwen-web-cli` / `qwc` entry points and references removed.
+
 ## [5.2.2] - 2026-08-20
 
 ### Fixed

--- a/PRD.md
+++ b/PRD.md
@@ -80,7 +80,7 @@ compose these FRs, not additional core FRs.
   *Accept*: stable response is returned instantly upon generation completion; long 15-minute streaming runs complete without network connection resets; challenge keywords raise `AuthRequiredError` / `OutputValidationError`.
 - [X]  **FR-007 Workspace Provisioner** — First-run XDG dirs,
   `.agents/skills/qwen-web/SKILL.md`, `.qwen-web` symlinks (automatically replaces stale local directories with XDG symlinks), `.gitignore`.
-  *Accept*: `qwen-web-cli init` is idempotent and maintains valid symlinks to XDG targets.
+  *Accept*: `qwen-web-arwaky init` is idempotent and maintains valid symlinks to XDG targets.
 - [X]  **FR-008 Observability Setup** — structlog + optional OTLP traces +
   optional Sentry + process excepthooks; missing telemetry must not block
   start.
@@ -92,7 +92,7 @@ compose these FRs, not additional core FRs.
 
 - [X]  **Multi-mode execution**: Batch (folder), Watcher (continuous poll),
   Single (one file), and raw `send_prompt` — all via `ICoreAggregate`.
-- [X]  **Persistent session login**: `qwen-web-cli login` validates a saved profile
+- [X]  **Persistent session login**: `qwen-web-arwaky login` validates a saved profile
   first; only an invalid session opens a headed browser for CAPTCHA.
 - [X]  **Atomic file routing**: `input` → `.processing` → `done` / `failed`
   with circuit breaker and rate limiter in the agent.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ python3 -m playwright install chromium
 Initialize standard XDG directory structures and local symlinks with one command:
 
 ```bash
-qwen-web-cli init
+qwen-web-arwaky init
 ```
 
 ### 3. One-Time Login Setup
@@ -82,7 +82,7 @@ qwen-web-cli init
 Authenticate your session once. Persistent session tokens are saved securely under `~/.local/share/qwen-web/qwen_session` with `0o700` restricted permissions:
 
 ```bash
-qwen-web-cli login
+qwen-web-arwaky login
 ```
 
 ---
@@ -91,10 +91,10 @@ qwen-web-cli login
 
 ### Interactive Terminal UI (TUI)
 
-Run `qwen-web-cli` without arguments to launch the Textual TUI dashboard:
+Run `qwen-web-arwaky` without arguments to launch the Textual TUI dashboard:
 
 ```bash
-qwen-web-cli
+qwen-web-arwaky
 ```
 
 ![Qwen Web TUI Dashboard](design/tui_dashboard.svg)
@@ -106,7 +106,7 @@ qwen-web-cli
 Send a quick prompt string directly from your terminal or shell script:
 
 ```bash
-qwen-web-cli prompt-direct -t "Explain quantum computing in 3 bullet points" -o output/result.md --headless
+qwen-web-arwaky prompt-direct -t "Explain quantum computing in 3 bullet points" -o output/result.md --headless
 ```
 
 ### Single Prompt File Processing
@@ -114,7 +114,7 @@ qwen-web-cli prompt-direct -t "Explain quantum computing in 3 bullet points" -o 
 Process a Markdown prompt file:
 
 ```bash
-qwen-web-cli prompt-only -i input/prompt.md -o output/audit_report.md --headless
+qwen-web-arwaky prompt-only -i input/prompt.md -o output/audit_report.md --headless
 ```
 
 ### Prompt File Processing with Document Attachment
@@ -122,7 +122,7 @@ qwen-web-cli prompt-only -i input/prompt.md -o output/audit_report.md --headless
 Send a prompt file along with a local PDF, Markdown, or text attachment:
 
 ```bash
-qwen-web-cli prompt-with-attachment -i input/review_prompt.md -a input/spec.pdf -o output/review_result.md --headless
+qwen-web-arwaky prompt-with-attachment -i input/review_prompt.md -a input/spec.pdf -o output/review_result.md --headless
 ```
 
 ---
@@ -188,7 +188,7 @@ Enforced automatically by `lint-arwaky-cli` with **0 architectural layer violati
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffffff', 'primaryTextColor': '#000000', 'primaryBorderColor': '#000000', 'lineColor': '#000000', 'secondaryColor': '#f4f4f4', 'tertiaryColor': '#ffffff', 'clusterBkg': '#ffffff', 'clusterBorder': '#000000', 'titleColor': '#000000', 'edgeLabelBackground': '#ffffff'}}}%%
 flowchart TD
     subgraph Client ["Client Interfaces"]
-        CLI["qwen-web-cli (TUI / Subcommands)"]
+        CLI["qwen-web-arwaky (TUI / Subcommands)"]
         MCP["qwen-web-mcp (Stdio Server)"]
     end
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -88,10 +88,10 @@ Instead of creating a Markdown prompt file manually, you can pass a built-in rol
 #### CLI Example
 ```bash
 # Code review with backend template and attachment
-qwen-web-cli prompt-with-attachment -i backend -a src/auth.py --headless --json
+qwen-web-arwaky prompt-with-attachment -i backend -a src/auth.py --headless --json
 
 # Architecture review
-qwen-web-cli prompt-with-attachment -i architect -a README.md --headless --json
+qwen-web-arwaky prompt-with-attachment -i architect -a README.md --headless --json
 ```
 
 ### Session Authentication (`setup_session`)

--- a/modules/cli/FRD.md
+++ b/modules/cli/FRD.md
@@ -14,13 +14,13 @@ The root parser reads `sys.argv` using a subcommand-based interface (`init`, `lo
 
 | Subcommand | Signal | Result | Validation |
 |---|---|---|---|
-| `doctor` | `qwen-web-cli doctor [--json]` | System health diagnostic | Checks Python, Playwright, workspace, session, permissions. |
-| `login` | `qwen-web-cli login [--headless]` | `mode="login"` | Forces headed browser for manual authentication unless overridden. |
-| `init` | `qwen-web-cli init [--dir]` | Workspace initialization | Creates XDG storage directories and root `.qwen-web` symlinks. |
-| `prompt-direct` | `qwen-web-cli prompt-direct -t "..." [--json]` | Inline text prompt | Direct text string is injected directly. |
-| `prompt-only` | `qwen-web-cli prompt-only -i FILE [--json]` | `mode="single"` | Prompt file must exist on disk. |
-| `prompt-with-attachment` | `qwen-web-cli prompt-with-attachment -i FILE -a FILE [--json]` | Attachment prompt | Prompt file and attachment file must exist. |
-| `mcp` | `qwen-web-cli mcp` | MCP Stdio Server | Hands off execution to MCP stdio server. |
+| `doctor` | `qwen-web-arwaky doctor [--json]` | System health diagnostic | Checks Python, Playwright, workspace, session, permissions. |
+| `login` | `qwen-web-arwaky login [--headless]` | `mode="login"` | Forces headed browser for manual authentication unless overridden. |
+| `init` | `qwen-web-arwaky init [--dir]` | Workspace initialization | Creates XDG storage directories and root `.qwen-web` symlinks. |
+| `prompt-direct` | `qwen-web-arwaky prompt-direct -t "..." [--json]` | Inline text prompt | Direct text string is injected directly. |
+| `prompt-only` | `qwen-web-arwaky prompt-only -i FILE [--json]` | `mode="single"` | Prompt file must exist on disk. |
+| `prompt-with-attachment` | `qwen-web-arwaky prompt-with-attachment -i FILE -a FILE [--json]` | Attachment prompt | Prompt file and attachment file must exist. |
+| `mcp` | `qwen-web-arwaky mcp` | MCP Stdio Server | Hands off execution to MCP stdio server. |
 
 An invalid run input is rejected with a non-success exit code and a clear, actionable diagnostic on `stderr`.
 
@@ -28,11 +28,11 @@ An invalid run input is rejected with a non-success exit code and a clear, actio
 
 The no-argument TTY fallback launches the **Obsidian Nebula Textual TUI App** (`surface_cli_tui_app.py`).
 
-1. **Dynamic Versioning**: Header displays package version dynamically via `importlib.metadata.version("qwen-web-cli")`.
+1. **Dynamic Versioning**: Header displays package version dynamically via `importlib.metadata.version("qwen-web-arwaky")`.
 2. **Safe Default Attachment**: If candidate attachment files do not exist on disk, attachment input defaults to an empty string `""` so optional fields never fail validation.
 3. **Output Folder Auto-Naming**: If an output path is a directory, a timestamped filename (e.g. `qwen_output_YYYYMMDD_HHMMSS.md`) is automatically resolved.
 4. **Destructive Action Safety**: Session reset actions present a modal confirmation screen (`ConfirmModal`) before wiping session tokens.
-5. **Non-TTY Rejection**: Running the interactive TUI in non-interactive environments (pipes/cron) prints a helpful, example-driven guidance message pointing to subcommands and `qwen-web-cli doctor`.
+5. **Non-TTY Rejection**: Running the interactive TUI in non-interactive environments (pipes/cron) prints a helpful, example-driven guidance message pointing to subcommands and `qwen-web-arwaky doctor`.
 
 ### FR-003: Manual Login & Session Setup
 

--- a/modules/cli/pyproject.toml
+++ b/modules/cli/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "qwen-web-cli"
+name = "qwen-web-arwaky"
 version = "4.0.0"
 description = "qwen-web CLI surface layer"
 requires-python = ">=3.10"

--- a/modules/cli/src/surface_cli_doctor_command.py
+++ b/modules/cli/src/surface_cli_doctor_command.py
@@ -84,7 +84,7 @@ def run_doctor(json_output: bool = False) -> int:
             "passed": ws_ok,
             "detail": f"Workspace found at {dot_qwen}"
             if ws_ok
-            else "Workspace not initialized (run: qwen-web-cli init)",
+            else "Workspace not initialized (run: qwen-web-arwaky init)",
         }
     )
 
@@ -98,7 +98,7 @@ def run_doctor(json_output: bool = False) -> int:
             "passed": sess_ok,
             "detail": f"Saved session found at {session_dir}"
             if sess_ok
-            else f"No active session found in {session_dir} (run: qwen-web-cli login)",
+            else f"No active session found in {session_dir} (run: qwen-web-arwaky login)",
         }
     )
 

--- a/modules/cli/src/surface_cli_interactive_controller.py
+++ b/modules/cli/src/surface_cli_interactive_controller.py
@@ -83,9 +83,8 @@ class InteractiveController:
             return success_response("Exited.")
 
         # C4: single shared dispatcher with the run subcommand.
+        # dispatch_run already returns the standard success/error envelope
+        # (result lives in `message`), so pass it through unchanged.
         from modules.cli.src.surface_cli_run_command import dispatch_run
 
-        envelope = dispatch_run(cfg, self._direct, self._file_only, self._attachment)
-        if not envelope.get("success", False):
-            return envelope
-        return success_response(envelope.get("result"))
+        return dispatch_run(cfg, self._direct, self._file_only, self._attachment)

--- a/modules/cli/src/surface_cli_interactive_controller.py
+++ b/modules/cli/src/surface_cli_interactive_controller.py
@@ -55,10 +55,10 @@ class InteractiveController:
                     "Interactive mode requires a TTY, but stdin is not interactive (pipe/cron detected).\n"
                     "Why: the Obsidian Nebula TUI needs a real terminal to render.\n"
                     "How to fix: use a non-interactive subcommand instead, e.g.:\n"
-                    '  qwen-web-cli prompt-direct -t "Summarize this" [--json]\n'
-                    "  qwen-web-cli prompt-only -i prompt.md [--json]\n"
-                    "  qwen-web-cli prompt-with-attachment -i prompt.md -a report.pdf [--json]\n"
-                    "Then verify your environment with: qwen-web-cli doctor"
+                    '  qwen-web-arwaky prompt-direct -t "Summarize this" [--json]\n'
+                    "  qwen-web-arwaky prompt-only -i prompt.md [--json]\n"
+                    "  qwen-web-arwaky prompt-with-attachment -i prompt.md -a report.pdf [--json]\n"
+                    "Then verify your environment with: qwen-web-arwaky doctor"
                 ),
                 "validation_error",
                 "cli-400",

--- a/modules/cli/src/surface_cli_tui_app.py
+++ b/modules/cli/src/surface_cli_tui_app.py
@@ -979,7 +979,7 @@ class QwenTuiApp(App[None]):
         self._session_check_timed_out = True
         with contextlib.suppress(Exception):
             badge = self.query_one("#session-badge", Label)
-            badge.update("SESSION: TIMEOUT — run 'qwen-web-cli doctor'")
+            badge.update("SESSION: TIMEOUT — run 'qwen-web-arwaky doctor'")
             badge.set_classes("invalid")
 
     @work(thread=True)

--- a/modules/cli/src/surface_cli_update_command.py
+++ b/modules/cli/src/surface_cli_update_command.py
@@ -56,7 +56,7 @@ def _format_check_result(res: UpdateCheckResult) -> str:
     if res.latest_version is None:
         lines.append("⚠️ Could not determine the latest published version. Check network access and retry.")
     elif res.update_available:
-        lines.append(f"⬆️ Run `qwen-web-cli update` to upgrade to {res.latest_version}.")
+        lines.append(f"⬆️ Run `qwen-web-arwaky update` to upgrade to {res.latest_version}.")
     else:
         lines.append("✅ You are already running the latest version.")
     lines.append("")

--- a/modules/core/FRD.md
+++ b/modules/core/FRD.md
@@ -366,7 +366,7 @@ End-to-end locks: `tests/test_qwen_client_behavior.py`, `tests/test_e2e_pipeline
 ## Test Scenarios / QA Checklist
 
 - [ ]  FR-001: expired cookies raise `AuthRequiredError` and point the user
-  at `qwen-web-cli login`.
+  at `qwen-web-arwaky login`.
 - [ ]  FR-002: attach card appears on fixture; oversized file never opens chooser.
 - [ ]  FR-003: killing the process during write leaves no half file (atomic).
 - [ ]  FR-004: 100k-char prompt injects via React setter on fixture.

--- a/modules/core/src/agent_setup_orchestrator.py
+++ b/modules/core/src/agent_setup_orchestrator.py
@@ -75,7 +75,7 @@ class SetupOrchestrator(ISetupAggregate):
             return ResponseText("Manual login completed successfully. The Qwen session is valid for headless tasks.")
 
         return ResponseText(
-            "Manual login did not produce a valid Qwen session. Please run 'qwen-web-cli --login' "
+            "Manual login did not produce a valid Qwen session. Please run 'qwen-web-arwaky --login' "
             "again and finish the login or CAPTCHA."
         )
 

--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -106,14 +106,14 @@ def _assert_on_chat_page(page: Page) -> None:
     if any(k in current_url for k in AUTH_KEYWORDS):
         raise AuthRequiredError(
             f"Not authenticated — browser is on login or guest page ({page.url}). "
-            "Please run 'qwen-web-cli --login' or click Login in TUI to authenticate first."
+            "Please run 'qwen-web-arwaky --login' or click Login in TUI to authenticate first."
         )
 
     combined_login = ", ".join(LOGIN_FORM_SELECTORS)
     if is_any_visible(page, combined_login):
         raise AuthRequiredError(
             f"Not authenticated — login form/button detected on page ({page.url}). "
-            "Please run 'qwen-web-cli --login' or click Login in TUI to authenticate first."
+            "Please run 'qwen-web-arwaky --login' or click Login in TUI to authenticate first."
         )
 
     if not page.query_selector(TEXTAREA_SELECTOR):

--- a/modules/core/src/capabilities_update_manager.py
+++ b/modules/core/src/capabilities_update_manager.py
@@ -38,11 +38,11 @@ from modules.shared.src.utility_core_version import get_package_version
 
 log = get_logger("capabilities_update_manager")
 
-DEFAULT_PACKAGE_NAME = "qwen-web-cli"
+DEFAULT_PACKAGE_NAME = "qwen-web-arwaky"
 DEFAULT_GITHUB_REPO = "rakaarwaky/qwen-web-arwaky"
 GITHUB_RELEASE_URL = "https://api.github.com/repos/{repo}/releases/latest"
 GITHUB_REPO_ENV = "QWEN_WEB_GITHUB_REPO"
-USER_AGENT = "qwen-web-cli-updater/1.0"
+USER_AGENT = "qwen-web-arwaky-updater/1.0"
 
 
 # ─── Module-level pure helpers ──────────────────────────────────────────────

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -64,7 +64,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     # ── update ────────────────────────────────────────────────────────────────
     p_update = sub.add_parser(
         "update",
-        help="Self-update qwen-web-cli and synchronize Playwright Chromium binaries",
+        help="Self-update qwen-web-arwaky and synchronize Playwright Chromium binaries",
         parents=[parent],
     )
     p_update.add_argument(
@@ -234,10 +234,10 @@ def _dispatch(
             print(
                 f"{_ERROR_PREFIX} Interactive TUI mode requires a terminal (TTY).\n\n"
                 "If you are running in a non-interactive environment, use a subcommand instead:\n"
-                "  qwen-web-cli doctor\n"
-                '  qwen-web-cli prompt-direct -t "Your prompt"\n'
-                "  qwen-web-cli prompt-only -i input/prompt.md\n\n"
-                "Run `qwen-web-cli --help` to see all available commands.",
+                "  qwen-web-arwaky doctor\n"
+                '  qwen-web-arwaky prompt-direct -t "Your prompt"\n'
+                "  qwen-web-arwaky prompt-only -i input/prompt.md\n\n"
+                "Run `qwen-web-arwaky --help` to see all available commands.",
                 file=sys.stderr,
             )
             return 1

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -118,7 +118,7 @@ All tools speak stdio MCP and return structured JSON envelopes:
 ### 2.2 Exact invocation payloads
 
 > **📁 Workspace rule: put ALL prompt/attachment/output files under `.qwen-web/`**
-> (`qwen-web-cli init` creates it in the cwd — already `.gitignore`d). Use
+> (`qwen-web-arwaky init` creates it in the cwd — already `.gitignore`d). Use
 > `.qwen-web/input/...` and `.qwen-web/output/...`; NEVER create a bare `input/`
 > or `output/` folder in the repo root. `output/` inside `.qwen-web/` is a symlink
 > to the XDG output dir, so results persist outside the repo.
@@ -156,7 +156,7 @@ Response completion is **event-driven**, not duration-driven. The historical `ti
 ### 2.4 CLI reference (equivalent surface for scripting & CI)
 
 ```bash
-# Primary command: qwa (or qwen-web-arwaky / qwc / qwen-web-cli)
+# Primary command: qwa (or qwen-web-arwaky)
 qwa doctor [--json]                        # environment health checks
 qwa init [--dir TARGET]                    # workspace provisioning (.qwen-web/ in cwd)
 qwa login                                  # headed manual login / CAPTCHA
@@ -164,7 +164,7 @@ qwa update [--check] [--force]             # self-update + Chromium sync
 qwa prompt-direct -t "..." [-o OUT] [--headless] [--json]
 qwa prompt-only   -i .qwen-web/input/PROMPT.md [-o OUT] [--headless] [--json]
 qwa prompt-with-attachment -i .qwen-web/input/PROMPT.md -a FILE [-o OUT] [--headless] [--json]
-qwen-web-cli mcp                                    # run MCP server over stdio
+qwen-web-arwaky mcp                                    # run MCP server over stdio
 ```
 
 Paths: always use `.qwen-web/input/...` for prompts/attachments and
@@ -341,18 +341,18 @@ Attached: the full diff (or consolidated changed files).
 
 | Exception / MCP code | Meaning | Agent action | Retryable? |
 | :--- | :--- | :--- | :--- |
-| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-cli login`), then retry the original task | ✅ after login |
+| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-arwaky login`), then retry the original task | ✅ after login |
 | `OutputValidationError` w/ "verify you are human" | CAPTCHA / bot challenge | `setup_session` headed; human solves CAPTCHA; retry | ✅ after human |
 | `OutputValidationError` (502/504/service unavailable) | Transient server error | Back off 10–30s, retry once | ✅ |
 | `NetworkTimeoutError` | Browser network timeout | Retry with `timeout_sec × 2`; if repeated → `doctor` | ✅ |
 | `ResponseDetectionTimeoutError` | Dispatch succeeded but no answer detected | Retry with larger timeout; simplify prompt; check logs for last lifecycle event | ✅ |
 | `CircuitBreakerOpenError` | ≥5 failures within 30s window | **Stop.** Back off ≥30s, diagnose root cause, then resume | ⏸ after backoff |
-| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-cli update`, retry | ⚠️ |
+| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-arwaky update`, retry | ⚠️ |
 | `FileValidationError` | Attachment missing / unreadable / >100 MB | Fix path/permissions/size; retry | ✅ after fix |
 | `UploadFailureError` | Attachment could not be verified as uploaded | Retry once; if repeated, convert attachment to `.md`/`.txt` | ✅ |
 | `SendDispatchError` | Send click + Enter fallback both failed | Check parse-toast state; retry; `doctor` if repeated | ✅ |
 | `ModelSwitchError` | Default model `Qwen3.8-Max` could not be verified | Retry once; check account model access | ⚠️ |
-| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-cli update` | ✅ after fix |
+| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-arwaky update` | ✅ after fix |
 | `FILE_NOT_FOUND` / `VALIDATION_ERROR` (MCP) | Bad tool arguments | Fix the flagged `field` from the error envelope; never blind-retry | ❌ fix first |
 
 Built-in guardrails you inherit automatically: client-side rate limiter (60 req/min),
@@ -376,7 +376,7 @@ Task returned an error / suspicious output
 │
 ├─ NetworkTimeoutError / 5xx challenge text?
 │  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
-│      → still failing? run `qwen-web-cli doctor`, verify connectivity
+│      → still failing? run `qwen-web-arwaky doctor`, verify connectivity
 │
 ├─ ResponseDetectionTimeoutError?
 │  └─► Check last lifecycle event in logs:
@@ -389,7 +389,7 @@ Task returned an error / suspicious output
 │      → RETRY once → if still failing, convert content to consolidated .md
 │
 ├─ BrowserLaunchError / PromptInjectionError / ModelSwitchError?
-│  └─► `qwen-web-cli doctor` → `qwen-web-cli update` (package + Chromium sync) → RETRY
+│  └─► `qwen-web-arwaky doctor` → `qwen-web-arwaky update` (package + Chromium sync) → RETRY
 │
 └─ MCP VALIDATION_ERROR / FILE_NOT_FOUND?
    └─► read `error.field` + `error.hint`; correct arguments; do NOT retry unchanged
@@ -433,7 +433,7 @@ MCP client registration (Claude Desktop / Cursor style):
 {
   "mcpServers": {
     "qwen-web": {
-      "command": "qwen-web-cli",
+      "command": "qwen-web-arwaky",
       "args": ["mcp"]
     }
   }
@@ -443,11 +443,11 @@ MCP client registration (Claude Desktop / Cursor style):
 ### 5.2 Combining CLI + MCP in one workflow
 
 1. **Bootstrap (once per machine, human-supervised):**
-   `qwen-web-cli doctor` → `qwen-web-cli login` → `qwen-web-cli init`
+   `qwen-web-arwaky doctor` → `qwen-web-arwaky login` → `qwen-web-arwaky init`
 2. **Autonomous steady state (agent via MCP):**
    `check_session` → `process_*` tools → verify `.meta.json` → chain next task.
 3. **Recovery (agent escalates to CLI/human):**
-   `setup_session` for CAPTCHA; `qwen-web-cli update` for UI drift; `doctor --json` for diagnostics.
+   `setup_session` for CAPTCHA; `qwen-web-arwaky update` for UI drift; `doctor --json` for diagnostics.
 
 ### 5.3 File attachment strategy
 
@@ -471,7 +471,7 @@ MCP client registration (Claude Desktop / Cursor style):
    to the user instead of looping.
 5. **Log forensics:** `app.jsonl` (JSONL events) + `status.json` (machine-readable run
    state) live in the OS state dir (`~/.local/state/qwen-web/log` on Linux).
-6. **Keep the engine current:** `qwen-web-cli update --check` regularly; run
+6. **Keep the engine current:** `qwen-web-arwaky update --check` regularly; run
 7. **Headless discipline:** keep `headless: true` for all production tasks; headed
    browsers are exclusively for `login` / `setup_session` / CAPTCHA resolution.
 

--- a/modules/shared/src/utility_core_version.py
+++ b/modules/shared/src/utility_core_version.py
@@ -11,7 +11,7 @@ import importlib.metadata
 import re
 from pathlib import Path
 
-PACKAGE_NAME = "qwen-web-cli"
+PACKAGE_NAME = "qwen-web-arwaky"
 _PYPROJECT_PATH = Path(__file__).resolve().parents[3] / "pyproject.toml"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=84.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "qwen-web-cli"
+name = "qwen-web-arwaky"
 version = "5.2.2"
 description = "Production-grade CLI automation and MCP server for chat.qwen.ai"
 readme = "README.md"
@@ -25,8 +25,6 @@ dependencies = [
 [project.scripts]
 qwen-web-arwaky = "modules.root_cli_main_entry:main"
 qwa = "modules.root_cli_main_entry:main"
-qwen-web-cli = "modules.root_cli_main_entry:main"
-qwc = "modules.root_cli_main_entry:main"
 qwen-web-mcp = "modules.root_mcp_main_entry:main"
 
 [tool.setuptools]

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/gates.sh — Local quality gates mirror CI for qwen-web-cli.
+# scripts/gates.sh — Local quality gates mirror CI for qwen-web-arwaky.
 # Usage: bash scripts/gates.sh
 #   Runs all 5 gates: Ruff (lint + format), Mypy, Bandit, AES self-lint, and Pytest.
 #   Mirrors .github/workflows/ci.yml (uv-based). Bandit is always enforced (not optional).

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-platform installation & environment setup script for qwen-web-cli & MCP server.
+"""Cross-platform installation & environment setup script for qwen-web-arwaky & MCP server.
 
 Supports Windows, macOS, and Linux without external shell dependencies.
 """
@@ -95,13 +95,13 @@ def setup_project_venv_symlink(venv_dir: Path) -> None:
 def uninstall_previous(python_bin: Path) -> None:
     log("🧹 [install] Removing any previous qwen-web installation...")
     subprocess.run(
-        [str(python_bin), "-m", "pip", "uninstall", "-y", "qwen-web", "qwen-web-cli"],
+        [str(python_bin), "-m", "pip", "uninstall", "-y", "qwen-web", "qwen-web-cli", "qwen-web-arwaky"],
         capture_output=True,
     )
 
     if sys.platform != "win32":
         local_bin = get_local_bin_dir()
-        for name in ("qwen-web-arwaky", "qwa", "qwen-web-cli", "qwc", "qwen-web-mcp"):
+        for name in ("qwen-web-arwaky", "qwa", "qwen-web-mcp"):
             target = local_bin / name
             if target.is_symlink() or target.exists():
                 with contextlib.suppress(OSError):
@@ -195,7 +195,7 @@ def setup_bin_links(python_bin: Path) -> None:
     local_bin.mkdir(parents=True, exist_ok=True)
 
     venv_bin_dir = python_bin.parent
-    for name in ("qwen-web-arwaky", "qwa", "qwen-web-cli", "qwc", "qwen-web-mcp"):
+    for name in ("qwen-web-arwaky", "qwa", "qwen-web-mcp"):
         src = venv_bin_dir / name
         dst = local_bin / name
         if src.exists():
@@ -212,11 +212,11 @@ def setup_bin_links(python_bin: Path) -> None:
         if str(local_bin) not in content:
             log(f"📝 [install] Adding {local_bin} to PATH in ~/.bashrc...")
             with bashrc.open("a", encoding="utf-8") as f:
-                f.write(f"\n# qwen-web-cli global CLI PATH\n{path_line}\n")
+                f.write(f"\n# qwen-web-arwaky global CLI PATH\n{path_line}\n")
 
 
 def main() -> None:
-    log("🚀 [install] Setting up qwen-web-cli environment (Cross-Platform)...")
+    log("🚀 [install] Setting up qwen-web-arwaky environment (Cross-Platform)...")
     os.chdir(PROJECT_ROOT)
 
     python_bin = ensure_venv()
@@ -231,11 +231,11 @@ def main() -> None:
     if sys.platform == "win32":
         venv_scripts = get_venv_dir() / "Scripts"
         log(f"👉 To run CLI on Windows, activate venv: {venv_scripts}\\Activate.ps1")
-        log("👉 Then run: qwc --login  atau  qwc --mcp")
+        log("👉 Then run: qwa --login  atau  qwa --mcp")
     else:
-        log("👉 You can now run 'qwc' or 'qwen-web-cli' from anywhere in your terminal!")
-        log("👉 To perform initial session login: qwc --login")
-        log("👉 To start MCP server: qwc --mcp")
+        log("👉 You can now run 'qwa' or 'qwen-web-arwaky' from anywhere in your terminal!")
+        log("👉 To perform initial session login: qwa --login")
+        log("👉 To start MCP server: qwa --mcp")
 
 
 if __name__ == "__main__":

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Installation & environment setup script for qwen-web-cli & MCP server.
+# Installation & environment setup script for qwen-web-arwaky & MCP server.
 
 set -euo pipefail
 

--- a/scripts/real_tests.py
+++ b/scripts/real_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Standalone real-world pipeline execution test runner for qwen-web-arwaky v5.0.0.
 
-Invokes the real CLI binary/entry point (`modules/root_cli_main_entry.py` or `qwen-web-cli`)
+Invokes the real CLI binary/entry point (`modules/root_cli_main_entry.py` or `qwen-web-arwaky`)
 to execute 3 end-to-end pipelines using v5.0.0 release fixtures from `tests/fixtures/`:
 
 1. Pipeline 1: prompt-direct (direct inline string prompt)

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -13,7 +13,7 @@ PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 echo "=== Uninstalling qwen-web-arwaky ==="
 
 # Remove bin launchers
-COMMANDS=("qwen-web-arwaky" "qwa" "qwen-web-cli" "qwc" "qwen-web-mcp")
+COMMANDS=("qwen-web-arwaky" "qwa" "qwen-web-mcp")
 for cmd in "${COMMANDS[@]}"; do
     if [ -L "$BIN_DIR/$cmd" ] || [ -f "$BIN_DIR/$cmd" ]; then
         rm -f "$BIN_DIR/$cmd"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test suite for qwen-web-cli."""
+"""Test suite for qwen-web-arwaky."""

--- a/tests/integration_surface_init_cmd.py
+++ b/tests/integration_surface_init_cmd.py
@@ -1,4 +1,4 @@
-"""Unit tests for qwc init command and workspace initialization logic."""
+"""Unit tests for qwa init command and workspace initialization logic."""
 
 import tempfile
 import unittest
@@ -8,8 +8,8 @@ from modules.core.src.root_core_container import SharedContainer
 from modules.shared.src import DEFAULT_LOG, DEFAULT_OUTPUT
 
 
-class TestQwcInit(unittest.TestCase):
-    """Test suite for qwc init functionality."""
+class TestQwaInit(unittest.TestCase):
+    """Test suite for qwa init functionality."""
 
     def test_run_init_creates_structure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/unit_surface_cli_update_command.py
+++ b/tests/unit_surface_cli_update_command.py
@@ -46,7 +46,7 @@ class TestSurfaceCliUpdateCommand(unittest.TestCase):
         args.force = False
 
         self.updater.check_update.return_value = UpdateCheckResult(
-            package_name="qwen-web-cli",
+            package_name="qwen-web-arwaky",
             current_version="4.5.1",
             latest_version="4.5.1",
             update_available=False,
@@ -63,7 +63,7 @@ class TestSurfaceCliUpdateCommand(unittest.TestCase):
         args.force = False
 
         self.updater.check_update.return_value = UpdateCheckResult(
-            package_name="qwen-web-cli",
+            package_name="qwen-web-arwaky",
             current_version="4.5.1",
             latest_version="4.5.2",
             update_available=True,
@@ -72,7 +72,7 @@ class TestSurfaceCliUpdateCommand(unittest.TestCase):
 
         res = surface_cli_update_command.handle(args, self.updater)
         self.assertTrue(res.get("success"))
-        self.assertIn("qwen-web-cli update", str(res.get("message")))
+        self.assertIn("qwen-web-arwaky update", str(res.get("message")))
 
     def test_handle_perform_update_success(self) -> None:
         args = MagicMock()
@@ -80,7 +80,7 @@ class TestSurfaceCliUpdateCommand(unittest.TestCase):
         args.force = False
 
         self.updater.perform_update.return_value = UpdateReport(
-            package_name="qwen-web-cli",
+            package_name="qwen-web-arwaky",
             previous_version="4.5.1",
             latest_version="4.5.2",
             source="github",
@@ -94,7 +94,7 @@ class TestSurfaceCliUpdateCommand(unittest.TestCase):
             health_checks=(UpdateStepResult("health:python_runtime", True, True, "Python 3.10+"),),
             post_update_version="4.5.2",
             healthy=True,
-            message="Successfully updated qwen-web-cli 4.5.1 -> 4.5.2",
+            message="Successfully updated qwen-web-arwaky 4.5.1 -> 4.5.2",
         )
 
         res = surface_cli_update_command.handle(args, self.updater)
@@ -158,7 +158,7 @@ class TestUpdateManagerRealFlow(unittest.TestCase):
                 self.manager,
                 "check_update",
                 return_value=UpdateCheckResult(
-                    package_name="qwen-web-cli",
+                    package_name="qwen-web-arwaky",
                     current_version="5.0.0",
                     latest_version="5.2.0",
                     update_available=True,
@@ -225,7 +225,7 @@ class TestUpdateManagerRealFlow(unittest.TestCase):
     ) -> None:
         mock_curr_ver.side_effect = [VersionString("4.5.1"), VersionString("4.5.2")]
         mock_check_update.return_value = UpdateCheckResult(
-            package_name="qwen-web-cli",
+            package_name="qwen-web-arwaky",
             current_version="4.5.1",
             latest_version="4.5.2",
             update_available=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1065,7 +1065,7 @@ wheels = [
 ]
 
 [[package]]
-name = "qwen-web-cli"
+name = "qwen-web-arwaky"
 version = "5.2.2"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Ringkasan
PR dari branch `uiux` berisi 2 commit hasil review UI/UX ganda (dual AI review) + standardisasi perintah CLI.

## Perubahan

### 1. `fix(cli): UI/UX hardening from dual AI review (P0-P3)` — `8c52eb7`
Perbaikan kualitas UI/UX pada TUI (Obsidian Nebula) berdasarkan review:
- **P0**
  - Modal konfirmasi penghapusan sesi tidak lagi bisa dilewati (event `Button.Pressed` tidak lagi ditangani ganda di level app).
  - Data race `_slot_stats` diperbaiki dengan finalizer khusus di UI thread.
  - Quit dengan job aktif kini memunculkan konfirmasi, bukan langsung keluar.
- **P1**
  - Filter namespace pada `QwenTuiLogHandler` → noise log pihak ketiga (urllib3/PIL/playwright) dibuang.
  - Escape markup rich pada pesan log runtime.
  - Guard re-entrancy login (`Ctrl+L` ganda).
  - Timeout session check (badge tidak menggantung di `CHECKING...`).
  - Batas baris `RichLog` (`max_lines`).
  - Design token warna terpusat (`_THEME`) + CSS token Obsidian Nebula.
- **P2/P3**
  - Cache ref widget untuk mengurangi DOM query.
  - Empty-state hint per slot, status icon ASCII-safe, dll.

### 2. `refactor(cli): remove legacy qwen-web-cli/qwc command, standardize on qwen-web-arwaky/qwa` — `10450a9`
- Perintah lama `qwen-web-cli`/`qwc` dihapus, distandarkan ke `qwen-web-arwaky`/`qwa`.
- Dokumen (README, PRD, SKILL, FRD) dan skrip pendukung disesuaikan.

## Pengujian
- `tests/unit_surface_cli_tui_app.py`
- `tests/unit_surface_cli_controller.py`
- `tests/integration_surface_login.py`

Semua **21 test lolos** ✅

## Catatan
- Branch `uiux` sudah sinkron dengan `origin/uiux`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the CLI command on `qwen-web-arwaky` (alias `qwa`) by removing the legacy `qwen-web-cli` and `qwc` entry points, and fixes the interactive controller so successful headless runs no longer return empty results.

- `dispatch_run` now passes its standard envelope through unchanged; previously `success_response(envelope.get("result"))` wrapped `None` and discarded every successful headless execution.
- Package name, version lookups, user agent, and update/install/uninstall scripts now reference `qwen-web-arwaky`.
- Docs (README, AGENTS, SKILL, PRD, FRDs) and tests updated to the new command name.

**Migration**
- Existing users must switch from `qwen-web-cli` / `qwc` to `qwen-web-arwaky` / `qwa`; the old entry points are removed from `[project.scripts]`.

<sup>Written for commit e213b50c6278745047a4e84a336d99c6460f23e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

