### PR TITLE
chore(release): v6.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,16 @@ Naming: `{layer}_{concern}_{role}.{ext}`.
 
 ```
 modules/shared/src/   taxonomy_*, contract_*, utility_*
-modules/core/src/     agent_core_orchestrator, capabilities_* (10)
+modules/core/src/     agent_* orchestrators (7), capabilities_* (13)
 modules/cli/src/      surface_cli_*, root_cli_container
 modules/mcp/src/      surface_mcp_*, root_mcp_container
 root_cli_main_entry.py, root_mcp_main_entry.py
 tests/                unit/integration/e2e, fixtures/, conftest.py, smoke_qwen_auto.py
 lint_arwaky.config.yaml, pyproject.toml, requirements.txt
+Containerfile         containerized execution (scripts/podman.sh)
 ```
+
+Key v6.0.0 capabilities: `capabilities_folder_compiler` (import-aware multi-language folder → Markdown), `capabilities_folder_to_attachment`, `capabilities_job_manager` + `agent_job_orchestrator` (async MCP jobs), `capabilities_tui_slot_config` + `surface_cli_tui_components` (TUI observability), `utility_core_session_cloner` (parallel sessions).
 
 ## Build & Run
 
@@ -69,9 +72,10 @@ pytest tests/ -m slow -v
 
 ## Migration State
 
-- **Branch**: `aes-migration`.
-- **Goal**: Complete AES layer migration + compliance-driven auth middleware (legal: session token storage).
-- **Merge freeze**: since 2026-03-05 (mobile release cut).
+- **Status**: AES 7-layer architecture complete and enforced in CI (`lint-arwaky-cli`, **0 violations**).
+- **Current release**: **v6.0.0** (2026-09-09). Breaking change: legacy `qwen-web-cli` / `qwc` removed — CLI is exclusively `qwen-web-arwaky` / `qwa`.
+- **Branches**: `main` is the release line and is protected (PR + 1 approval + status checks). Releases flow via `release/vX.Y.Z` PRs; tags trigger the auto-build/`action-gh-release` pipeline.
+- **No merge freeze** currently active.
 
 ## Agent Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,42 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [6.0.0] - 2026-09-09
+
+### Added
+
+- feat(cli): add `qwen-web-arwaky` and `qwa` as the canonical CLI entry point aliases
+- feat(folder): implement **import-aware multi-language folder compilation** — compile an entire folder of prompt files into a single Markdown document (`utility_folder_compiler`, `capabilities_folder_compiler`)
+- feat(folder): resolve TypeScript/JavaScript **tsconfig path aliases** during folder compilation
+- feat(folder): resolve Rust **`crate::` imports** from the true crate root during folder compilation
+- feat(core): add folder-to-attachment capability (`capabilities_folder_to_attachment`) so compiled folder output can be attached to prompts
+- feat(mcp): add **async job dispatch and status tracking** (`agent_job_orchestrator`, `capabilities_job_manager`) using `QwenEventType` — background runs avoid MCP timeouts
+- feat(mcp): add `get_job_status` and `list_jobs` tools; `process_*` tools gain an `async_run` option returning a `job_id`
+- feat(obs): add **per-job JSONL logging** and TUI observability for parallel/long-running jobs
+- feat(core): add session cloner (`utility_core_session_cloner`) for parallel session handling
+- feat(taxonomy): standardize prompt templates across all roles (analyst, architect, backend, devops, frontend) in dedicated constant modules plus `utility_core_prompt_template`
+- feat(tui): add dedicated TUI components module (`surface_cli_tui_components`) and slot config; major TUI observability upgrade (run-in-progress guard, job status, quit confirmation)
+- feat(install): add XDG-compliant `scripts/uninstall.sh` that removes the venv and all launchers; clean all launchers on reinstall
+- feat(container): add `Containerfile`, `.containerignore`/`.dockerignore` and `scripts/podman.sh` for containerized execution
+- feat(docs): add root `SKILL.md`; remove obsolete role-specific skill files (5× role SKILL.md and `LEAN-CTX.md`)
+
+### Fixed
+
+- fix(cli): UI/UX hardening from dual AI review (P0–P3) across `doctor`, interactive controller, run command, session setup and TUI app
+- fix(mcp): replace `assert` with `cast` for mypy narrowing (Codacy B101)
+- fix(review): address CodeRabbit feedback on PR #166 (observability setup, MCP tool command, folder compiler, skill constants)
+- fix(install): enforce XDG base directory for venv, root symlinks and bin paths
+- fix(install): migrate venv location to standard XDG data directory
 
 ### Changed
 
-- Rename primary CLI command from `qwen-web-cli` (alias `qwc`) to `qwen-web-arwaky` (alias `qwa`); legacy `qwen-web-cli` / `qwc` entry points and references removed.
+- **BREAKING**: refactor(cli): remove legacy `qwen-web-cli` / `qwc` command — the CLI is now exclusively `qwen-web-arwaky` / `qwa`
+- refactor(taxonomy): standardize prompt templates across all roles
+- refactor: generalize frontend template to surface-agnostic UI/UX
+- refactor: standardize `uninstall.sh` to XDG Base Directory spec
+- chore(deps): bump `mcp` from 2.0.0 to 2.1.1
+- chore(deps): bump `sentry-sdk` from 2.68.0 to 2.68.1
+- chore(deps-ci): bump `softprops/action-gh-release` from 3.0.2 to 3.0.3
 
 ## [5.2.2] - 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@
 
 ---
 
+## What's New in v6.0.0
+
+- **Import-aware folder compilation** — compile an entire folder of prompt files into a single Markdown document, with tsconfig path alias (TS/JS) and `crate::` (Rust) resolution.
+- **Async MCP job dispatch** — background prompt jobs (`async_run` → `job_id`) with `get_job_status` / `list_jobs` tools; no more MCP stdio timeouts on long runs.
+- **Per-job JSONL logging + TUI observability** — track parallel and long-running jobs with run-in-progress guards and live status.
+- **Standardized role prompt templates** — consistent analyst / architect / backend / devops / frontend templates.
+- **Container support** — official `Containerfile` + `scripts/podman.sh` for containerized execution.
+- **XDG-compliant uninstall** — `scripts/uninstall.sh` removes the venv and all launchers cleanly.
+- ⚠️ **Breaking**: legacy `qwen-web-cli` / `qwc` commands removed — use `qwen-web-arwaky` / `qwa` only.
+
+---
+
 ## Quick Start in 60 Seconds
 
 ### 1. Installation (Cross-Platform)
@@ -156,6 +168,9 @@ qwen-web-mcp
 - `process_prompt_file_only`: Process input Markdown prompt files and output results locally.
 - `process_prompt_with_attachment`: Send prompt files together with document attachments.
 - `setup_session`: Trigger an interactive browser session for manual re-authentication if session tokens expire.
+- `get_job_status` / `list_jobs`: Poll and list asynchronous background jobs (v6.0.0+).
+
+> **Async mode (v6.0.0+)**: all `process_*` tools accept `async_run: true` and return a `job_id` immediately; poll with `get_job_status` — ideal for long generations that would otherwise exceed MCP stdio timeouts.
 
 ---
 

--- a/modules/cli/pyproject.toml
+++ b/modules/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-arwaky"
-version = "4.0.0"
+version = "6.0.0"
 description = "qwen-web CLI surface layer"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/core/pyproject.toml
+++ b/modules/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-core"
-version = "5.2.0"
+version = "6.0.0"
 description = "qwen-web core feature: capabilities, orchestrators, and DI container"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/mcp/pyproject.toml
+++ b/modules/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-mcp"
-version = "5.2.0"
+version = "6.0.0"
 description = "qwen-web MCP surface layer (tools)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/modules/shared/pyproject.toml
+++ b/modules/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwen-web-shared"
-version = "5.2.0"
+version = "6.0.0"
 description = "qwen-web shared taxonomy, contracts, and utilities (domain layer)"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qwen-web-arwaky"
-version = "5.2.2"
+version = "6.0.0"
 description = "Production-grade CLI automation and MCP server for chat.qwen.ai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "qwen-web-arwaky"
-version = "5.2.2"
+version = "6.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Automated release PR for **v6.0.0** (bumped from v5.2.2).

## Summary

- **Version bump**: 5.2.2 → 6.0.0 across root + module manifests and uv.lock
- **Complete CHANGELOG.md** entry for v6.0.0 (89 files changed, +5283/−1352 since v5.2.2)
- **README.md** updated: v6.0.0 highlights, new MCP tools (`get_job_status`, `list_jobs`, `async_run`)
- **AGENTS.md** updated: current workspace inventory (13 capabilities, 7 orchestrators), up-to-date migration state

## ⚠️ Breaking Change

Legacy `qwen-web-cli` / `qwc` commands removed — CLI is now exclusively `qwen-web-arwaky` / `qwa`. This justifies the **major** version bump.

## Highlights

- Import-aware multi-language folder compilation (tsconfig aliases, Rust `crate::`)
- Async MCP job dispatch + status tracking (`get_job_status` / `list_jobs`)
- Per-job JSONL logging + TUI observability
- Standardized role prompt templates
- Container support (Containerfile + podman.sh)
- XDG-compliant uninstall

See the [v6.0.0 entry](CHANGELOG.md) for the full changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v6.0.0, bumping all package manifests and `uv.lock` from 5.2.2 to 6.0.0 and updating the release documentation. This is a major release because the legacy `qwen-web-cli` / `qwc` commands are removed.

**Breaking Change**
- Users must migrate to `qwen-web-arwaky` / `qwa` for all CLI usage.

**Docs**
- README.md and AGENTS.md now reflect the v6.0.0 feature set: import-aware folder compilation, async MCP job dispatch and status tools, TUI observability, container support, and XDG-compliant uninstall.

<sup>Written for commit 120694fc8c7bf80c4839720ac36124d801d4a2b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

