### PR TITLE
fix(cli): UI/UX v6.0.1 — 11 findings from Obsidian Nebula review

### DIFF
--- a/modules/cli/src/surface_cli_tui_app.py
+++ b/modules/cli/src/surface_cli_tui_app.py
@@ -117,6 +117,8 @@ class QwenTuiApp(
         self._session_check_timed_out: bool = False
         # P4: debounce metrics refresh — at most 4 updates/sec.
         self._metrics_pending: bool = False
+        # A4: timestamp of last Escape press for double-escape quit guard.
+        self._last_esc_time: float = 0.0
 
 
 __all__ = [

--- a/modules/cli/src/surface_cli_tui_compose.py
+++ b/modules/cli/src/surface_cli_tui_compose.py
@@ -67,7 +67,7 @@ class _TuiComposeMixin:
                     yield Label(f"SLOTS: {self._NUM_SLOTS}", id="metric-slots", classes="metric-item")
                     yield Label("ACTIVE: 0", id="metric-active", classes="metric-item")
                     yield Label("DONE: 0", id="metric-done", classes="metric-item")
-                    yield Label("SESSION: CHECKING...", id="session-badge", classes="metric-item")
+                    yield Label("SESSION: CHECKING…", id="session-badge", classes="metric-item")
 
                 yield Label("Active Job Slots (1 Browser per Job)", classes="field-label")
                 yield DataTable(id="slots-table")
@@ -157,6 +157,14 @@ class _TuiComposeMixin:
         # P3: cache metric widget refs once; no per-call DOM lookups.
         self._metric_active = self.query_one("#metric-active", Label)
         self._metric_done = self.query_one("#metric-done", Label)
+
+        # P1: cache RichLog widget refs at mount time — hot render path.
+        self._log_views: dict[int, RichLog] = {}
+        with contextlib.suppress(NoMatches):
+            self._log_views[0] = self.query_one("#log-view-overview", RichLog)
+        for s in range(1, self._NUM_SLOTS + 1):
+            with contextlib.suppress(NoMatches):
+                self._log_views[s] = self.query_one(f"#log-view-{s}", RichLog)
 
         # P5: defer RichLog writes until after first paint to avoid overlay glitch.
         self.set_timer(0.4, self._deferred_startup)

--- a/modules/cli/src/surface_cli_tui_css.py
+++ b/modules/cli/src/surface_cli_tui_css.py
@@ -92,7 +92,7 @@ Tab.-active {
     width: 100%;
     padding: 1 2;
     background: $bg-base;
-    overflow: hidden;
+    overflow-y: auto;   /* L3: was hidden — now scrolls on short terminals */
 }
 
 #log-view-overview {
@@ -143,7 +143,7 @@ Tab.-active {
 
 .left-pane {
     width: 48%;
-    min-width: 40;
+    min-width: 30;      /* L1: 40+40 overflowed < 85 cols; now 30+30 fits */
     height: 100%;
     background: $bg-surface;
     border-right: solid $border;
@@ -152,14 +152,13 @@ Tab.-active {
 
 .right-pane {
     width: 52%;
-    min-width: 40;
+    min-width: 30;
     height: 100%;
     background: $bg-overlay;
     padding: 1 2;
 }
 
-/* L1: min-width guards keep panes usable on narrow terminals
-   (Textual 8 has no @media support; min-width is the reflow guard). */
+/* L1: reduced min-width allows reflow on narrow terminals (< 85 cols). */
 
 .pane-title {
     background: $bg-base;
@@ -252,9 +251,9 @@ Switch.-on {
 .btn-slot-cancel {
     width: 100%;
     height: 3;
-    background: $status-err;
+    background: #991B1B;          /* A1: white on #991B1B ≈ 8.3:1 (AA+AAA) */
     color: #ffffff;
-    border: solid $status-err;
+    border: solid $status-err;    /* keep the bright red as outline, not fill */
     text-style: bold;
     margin-top: 1;
 }
@@ -346,7 +345,7 @@ FilePickerModal {
 }
 
 #btn-cancel-modal:hover {
-    background: $status-err;
+    background: #991B1B;          /* A1: was $status-err @ ≈ 3.8:1 */
     color: #ffffff;
 }
 
@@ -372,12 +371,6 @@ SelectOverlay {
 SelectOverlay > OptionList > .option-list--option-highlighted {
     background: $bg-active;
     color: $fg-accent;
-}
-
-.template-row {
-    layout: horizontal;
-    height: auto;
-    margin-bottom: 1;
 }
 
 /* ─── Help Screen (A4) ──────────────────────────────────────────────────────────── */

--- a/modules/cli/src/surface_cli_tui_handlers.py
+++ b/modules/cli/src/surface_cli_tui_handlers.py
@@ -162,8 +162,17 @@ class _TuiHandlersMixin:
             self._log_msg(f"[bold {THEME['err']}]INIT ERROR:[/] {escape(str(exc))}")
 
     def action_request_quit(self) -> None:
+        import time
+
         active = [s for s, w in self._slot_workers.items() if w is not None]
         if not active:
+            # A4: double-escape guard — require two Esc presses within 1s.
+            now = time.monotonic()
+            last = getattr(self, "_last_esc_time", 0.0)
+            if now - last > 1.0:
+                self._last_esc_time = now
+                self._log_msg(f"[{THEME['muted']}]Press Escape again within 1s to quit.[/]")
+                return
             self.exit()
             return
 

--- a/modules/cli/src/surface_cli_tui_utils.py
+++ b/modules/cli/src/surface_cli_tui_utils.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from rich.text import Text
 from textual.content import Content
@@ -23,18 +23,27 @@ from modules.cli.src.surface_cli_tui_components import QwenTuiLogHandler
 if TYPE_CHECKING:
     pass
 
+# C1/V1: single source of truth for slot status — one value, one formatter.
+SlotStatus = Literal["IDLE", "RUNNING", "SUCCESS", "FAILED", "CANCELLED"]
+
+_STATUS_BADGE: dict[str, str] = {
+    "IDLE": "● READY",
+    "RUNNING": "▶ RUNNING",
+    "SUCCESS": "✓ SUCCESS",
+    "FAILED": "✕ FAILED",
+    "CANCELLED": "■ CANCELLED",
+}
+_STATUS_TABLE: dict[str, str] = {
+    "IDLE": "IDLE 💤",
+    "RUNNING": "RUNNING ⏳",
+    "SUCCESS": "DONE ✅",
+    "FAILED": "FAILED ❌",
+    "CANCELLED": "CANCELLED ✕",
+}
+
 
 class _TuiUtilsMixin:
     """Mixin for UI utility helpers: table, metrics, status badges, logging."""
-
-    # A1: status text+glyph so meaning never relies on color alone (WCAG 1.4.1).
-    _STATUS_ICONS: dict[str, str] = {
-        "STATUS: READY": "● READY",
-        "STATUS: RUNNING": "▶ RUNNING",
-        "STATUS: SUCCESS": "✓ SUCCESS",
-        "STATUS: FAILED": "✕ FAILED",
-        "STATUS: CANCELLED": "■ CANCELLED",
-    }
 
     # Class-level annotations for attributes set by QwenTuiApp.__init__.
     _NUM_SLOTS: int
@@ -43,6 +52,7 @@ class _TuiUtilsMixin:
     _metric_active: Any
     _metric_done: Any
     _log_handler: logging.Handler
+    _log_views: dict[int, RichLog]
 
     # Stubs for methods/attrs provided by other mixins / App at runtime.
     query_one: Any
@@ -56,7 +66,7 @@ class _TuiUtilsMixin:
             table = self.query_one("#slots-table", DataTable)
             table.add_columns("Slot", "Status", "Prompt File", "Duration")
             for s in range(1, self._NUM_SLOTS + 1):
-                table.add_row(f"Slot {s}", "IDLE 💤", "-", "0.0s", key=f"row-slot-{s}")
+                table.add_row(f"Slot {s}", self._format_status("IDLE", "table"), "-", "0.0s", key=f"row-slot-{s}")
 
     def _update_table_row(self, slot_id: int, status: str, filename: str, duration: str) -> None:
         with contextlib.suppress(NoMatches, CellDoesNotExist):
@@ -85,6 +95,11 @@ class _TuiUtilsMixin:
 
     # ── Slot status / tab title ──────────────────────────────────────────
 
+    def _format_status(self, status: SlotStatus, target: str) -> str:
+        """C1/V1: one status value, one formatter — badge/table never diverge."""
+        table = _STATUS_BADGE if target == "badge" else _STATUS_TABLE
+        return table.get(status, status)
+
     def _set_slot_tab_title(self, slot_id: int, title: str) -> None:
         with contextlib.suppress(LookupError, NoMatches):
             tabs = self.query_one(TabbedContent)
@@ -94,7 +109,7 @@ class _TuiUtilsMixin:
     def _update_slot_status(self, slot_id: int, status_text: str) -> None:
         with contextlib.suppress(NoMatches):
             badge = self.query_one(f"#status-badge-{slot_id}", Label)
-            badge.update(self._STATUS_ICONS.get(status_text, status_text))
+            badge.update(status_text)
 
     @staticmethod
     def _truncate_name(name: str, limit: int = 12) -> str:
@@ -111,17 +126,19 @@ class _TuiUtilsMixin:
     def _log_msg(self, msg: str | Text, slot_id: int | None = None) -> None:
         # Truncate plain strings to prevent RichLog horizontal overflow.
         if isinstance(msg, str) and len(msg) > 200:
-            msg = msg[:197] + "..."
-        with contextlib.suppress(NoMatches):
-            if slot_id is not None:
-                log_view = self.query_one(f"#log-view-{slot_id}", RichLog)
-                log_view.write(msg)
-            else:
-                with contextlib.suppress(NoMatches):
-                    self.query_one("#log-view-overview", RichLog).write(msg)
-                with contextlib.suppress(NoMatches):
-                    active_slot = self._get_active_slot_id()
-                    self.query_one(f"#log-view-{active_slot}", RichLog).write(msg)
+            msg = msg[:197] + "…"
+        views = getattr(self, "_log_views", {})
+        if slot_id is not None:
+            view = views.get(slot_id)
+            if view is not None:
+                view.write(msg)
+            return
+        overview = views.get(0)
+        if overview is not None:
+            overview.write(msg)
+        active = views.get(self._get_active_slot_id())
+        if active is not None and active is not overview:
+            active.write(msg)
 
 
 __all__ = ["_TuiUtilsMixin"]

--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -120,8 +120,8 @@ class _TuiWorkersMixin:
         self._slot_workers[slot_id] = None
         self._slot_stats[slot_id] = {"status": status, "file": filename, "duration": duration}
         self._set_slot_tab_title(slot_id, f"Slot {slot_id}: {self._truncate_name(filename)} {icon}")
-        self._update_slot_status(slot_id, self._format_status(status, "badge"))  # type: ignore[arg-type]
-        self._update_table_row(slot_id, self._format_status(status, "table"), filename, f"{duration}s")  # type: ignore[arg-type]
+        self._update_slot_status(slot_id, self._format_status(status, "badge"))
+        self._update_table_row(slot_id, self._format_status(status, "table"), filename, f"{duration}s")
         self._refresh_metrics()
         with contextlib.suppress(NoMatches):
             self.query_one(f"#loading-{slot_id}", LoadingIndicator).display = False
@@ -229,8 +229,7 @@ class _TuiWorkersMixin:
             badge.update("SESSION: TIMEOUT")
             badge.set_classes("invalid")
         self._log_msg(
-            f"[bold {THEME['warn']}]WARNING:[/] Session check timed out — "
-            "run 'qwen-web-arwaky doctor' for diagnostics."
+            f"[bold {THEME['warn']}]WARNING:[/] Session check timed out — run 'qwen-web-arwaky doctor' for diagnostics."
         )
 
     @work(thread=True)

--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -46,6 +46,7 @@ class _TuiWorkersMixin:
     _update_slot_status: Any
     _update_table_row: Any
     _refresh_metrics: Any
+    _format_status: Any
     call_from_thread: Any
     set_timer: Any
     _ensure_log_handler: Any
@@ -62,7 +63,12 @@ class _TuiWorkersMixin:
             file_val = self.query_one(f"#input-file-{slot_id}", Input).value
             out_val = self.query_one(f"#input-output-{slot_id}", Input).value
             headless_val = self.query_one(f"#switch-headless-{slot_id}", Switch).value
-        except Exception:
+        except Exception as exc:
+            # U1: a user-initiated action must never fail silently.
+            msg = f"Could not read Slot {slot_id} inputs: {exc}"
+            self._log_msg(f"[bold {THEME['err']}]ERROR:[/] {escape(msg)}", slot_id)
+            with contextlib.suppress(Exception):
+                self.notify(msg, severity="error", title=f"Slot {slot_id}")
             return
 
         plan = self._slot_config.resolve_slot_run_plan(prompt_val, file_val, out_val, headless_val)
@@ -78,9 +84,9 @@ class _TuiWorkersMixin:
         p_name = plan.prompt_path.name
 
         self._set_slot_tab_title(slot_id, f"Slot {slot_id}: {self._truncate_name(p_name)} ⏳")
-        self._update_slot_status(slot_id, "STATUS: RUNNING")
+        self._update_slot_status(slot_id, self._format_status("RUNNING", "badge"))
         self._slot_stats[slot_id] = {"status": "RUNNING", "file": p_name, "duration": 0.0}
-        self._update_table_row(slot_id, "RUNNING ⏳", p_name, "running...")
+        self._update_table_row(slot_id, self._format_status("RUNNING", "table"), p_name, "running…")
         self._refresh_metrics()
         with contextlib.suppress(NoMatches):
             self.query_one(f"#loading-{slot_id}", LoadingIndicator).display = True
@@ -95,10 +101,11 @@ class _TuiWorkersMixin:
         worker.cancel()
         self._slot_workers[slot_id] = None
         self._log_msg(f"[bold {THEME['warn']}]CANCELLED:[/] Slot {slot_id} stopped by user.", slot_id)
-        self._update_slot_status(slot_id, "STATUS: CANCELLED")
+        self._update_slot_status(slot_id, self._format_status("CANCELLED", "badge"))
         self._set_slot_tab_title(slot_id, f"Slot {slot_id} 💤")
         self._slot_stats[slot_id]["status"] = "CANCELLED"
-        self._update_table_row(slot_id, "CANCELLED ✕", self._slot_stats[slot_id]["file"], "stopped")
+        file_name = self._slot_stats[slot_id]["file"]
+        self._update_table_row(slot_id, self._format_status("CANCELLED", "table"), file_name, "stopped")
         self._refresh_metrics()
         with contextlib.suppress(NoMatches):
             self.query_one(f"#loading-{slot_id}", LoadingIndicator).display = False
@@ -113,8 +120,8 @@ class _TuiWorkersMixin:
         self._slot_workers[slot_id] = None
         self._slot_stats[slot_id] = {"status": status, "file": filename, "duration": duration}
         self._set_slot_tab_title(slot_id, f"Slot {slot_id}: {self._truncate_name(filename)} {icon}")
-        self._update_slot_status(slot_id, f"STATUS: {status}")
-        self._update_table_row(slot_id, f"{'DONE' if ok else 'FAILED'} {icon}", filename, f"{duration}s")
+        self._update_slot_status(slot_id, self._format_status(status, "badge"))  # type: ignore[arg-type]
+        self._update_table_row(slot_id, self._format_status(status, "table"), filename, f"{duration}s")  # type: ignore[arg-type]
         self._refresh_metrics()
         with contextlib.suppress(NoMatches):
             self.query_one(f"#loading-{slot_id}", LoadingIndicator).display = False
@@ -207,7 +214,7 @@ class _TuiWorkersMixin:
         if self._session is None:
             badge.update("SESSION: N/A")
             return
-        badge.update("SESSION: CHECKING...")
+        badge.update("SESSION: CHECKING…")
         self._session_check_timed_out = False
         self.set_timer(15.0, self._session_check_timeout)
         self._session_check_worker()
@@ -218,8 +225,13 @@ class _TuiWorkersMixin:
         self._session_check_timed_out = True
         with contextlib.suppress(NoMatches):
             badge = self.query_one("#session-badge", Label)
-            badge.update("SESSION: TIMEOUT — run 'qwen-web-arwaky doctor'")
+            # L2: keep the badge ≤ 20 chars; remediation goes to the overview log.
+            badge.update("SESSION: TIMEOUT")
             badge.set_classes("invalid")
+        self._log_msg(
+            f"[bold {THEME['warn']}]WARNING:[/] Session check timed out — "
+            "run 'qwen-web-arwaky doctor' for diagnostics."
+        )
 
     @work(thread=True)
     def _session_check_worker(self) -> None:

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -84,8 +84,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p_direct.add_argument("-o", "--output-path", default=None, help="Output file path")
     p_direct.add_argument(
         "--headless",
-        action=argparse.BooleanOptionalAction,   # U3: accepts --headless / --no-headless
-        default=True,                            # matches TUI Switch and MCP default
+        action=argparse.BooleanOptionalAction,  # U3: accepts --headless / --no-headless
+        default=True,  # matches TUI Switch and MCP default
         help="Run browser headlessly (default: true; use --no-headless to watch)",
     )
     p_direct.add_argument("--json", action="store_true", help="Format output as JSON")

--- a/modules/root_cli_main_entry.py
+++ b/modules/root_cli_main_entry.py
@@ -82,7 +82,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p_direct = sub.add_parser("prompt-direct", help="Send an inline text prompt to Qwen", parents=[parent])
     p_direct.add_argument("-t", "--text", required=True, help="Prompt text to send directly")
     p_direct.add_argument("-o", "--output-path", default=None, help="Output file path")
-    p_direct.add_argument("--headless", action="store_true", help="Run browser headlessly")
+    p_direct.add_argument(
+        "--headless",
+        action=argparse.BooleanOptionalAction,   # U3: accepts --headless / --no-headless
+        default=True,                            # matches TUI Switch and MCP default
+        help="Run browser headlessly (default: true; use --no-headless to watch)",
+    )
     p_direct.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── prompt-only ───────────────────────────────────────────────────────────
@@ -95,7 +100,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Path to prompt file OR built-in role template (architect|backend|frontend|analyst)",
     )
     p_only.add_argument("-o", "--output-path", default=None, help="Output file path")
-    p_only.add_argument("--headless", action="store_true", help="Run browser headlessly")
+    p_only.add_argument(
+        "--headless",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run browser headlessly (default: true; use --no-headless to watch)",
+    )
     p_only.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── prompt-with-attachment ────────────────────────────────────────────────
@@ -111,7 +121,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p_attach.add_argument("-a", "--attachment-path", required=True, help="Path to file to attach")
     p_attach.add_argument("-o", "--output-path", default=None, help="Output file path")
-    p_attach.add_argument("--headless", action="store_true", help="Run browser headlessly")
+    p_attach.add_argument(
+        "--headless",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run browser headlessly (default: true; use --no-headless to watch)",
+    )
     p_attach.add_argument("--json", action="store_true", help="Format output as JSON")
 
     # ── mcp ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes 11 findings from the comprehensive Obsidian Nebula TUI & CLI UI/UX review. All changes in  and .

## Changes

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| U1 | CRITICAL | Silent run failure —  swallows widget-read exceptions | Log + notify on failure path |
| A1 | WARNING | Cancel button contrast ≈ 3.8:1 (WCAG AA needs 4.5:1) | Darken fill to `#991B1B` (8.3:1) |
| A4 | INFO | Single Escape kills TUI with no confirmation | Double-escape guard (1s window) |
| C1/V1 | WARNING | Status in 3 dialects + dual icon sets | Unified `SlotStatus` literal + `_format_status()` |
| L1 | WARNING | Pane `min-width: 40` overflows < 85 cols | Reduced to 30 |
| L2 | WARNING | Session-timeout badge too long, pushes metrics off-screen | Shortened to ≤20 chars, remediation to log |
| L3 | WARNING | Overview `overflow: hidden` clips log on short terminals | Changed to `overflow-y: auto` |
| P1 | WARNING | `_log_msg` does DOM query per message (hot path) | Cache `RichLog` refs at mount time |
| U3 | WARNING | Headless default differs: CLI visible, TUI/MCP hidden | `BooleanOptionalAction` with `default=True` |
| V2 | INFO | Ellipsis inconsistent (`...` vs `…`) | Standardized to `…` |
| V4 | INFO | `.template-row` defined twice in CSS | Removed duplicate |

## Verification

- **Ruff**: All checks passed
- **Tests**: 316/316 passed (13s)
- **py_compile**: All 7 files compile clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 11 UI/UX findings from the Obsidian Nebula review, improving accessibility, reliability, and consistency in the TUI and CLI.

**Behavior changes**
- CLI `--headless` now defaults to true; use `--no-headless` to watch the browser.
- Single Escape no longer quits the TUI; press Escape twice within 1s to exit when idle.
- Widget-read failures in `_run_slot` now log an error and show a notification instead of failing silently.
- Session-timeout badge is shortened to ≤20 characters; remediation moves to the log.

**Polish and consistency**
- Cancel button contrast raised from 3.8:1 to 8.3:1 for WCAG AA compliance.
- Unified slot status formatting and icon set across badges, tabs, and tables.
- Standardized ellipsis to `…` and removed duplicate CSS rule.
- Reduced pane min-width to allow reflow on narrow terminals; log now scrolls instead of clipping.
- Cached RichLog widget refs at mount time to avoid per-message DOM queries.

<sup>Written for commit 039350c9f8654274c2306572a6877c9d8f558366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

