### PR TITLE
fix(cli): session badge VALID overwritten by stale timeout timer

### DIFF
--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -302,12 +302,15 @@ class _TuiWorkersMixin:
         self._session_check_timed_out = True
         with contextlib.suppress(NoMatches):
             badge = self.query_one("#session-badge", Label)
-            # L2: keep the badge ≤ 20 chars; remediation goes to the overview log.
+            badge_text = str(badge.renderable) if badge.renderable else ""
+            # Only show TIMEOUT if the badge is still in CHECKING state.
+            # If the worker already completed and set VALID/EXPIRED, do not overwrite.
+            if "CHECKING" not in badge_text:
+                return
             badge.update("⚠ SESSION: TIMEOUT")
             badge.set_classes("invalid")
         msg = "Session check timed out — run 'qwen-web-arwaky doctor' for diagnostics."
         self._log_msg(f"[bold {THEME['warn']}]WARNING:[/] {msg}")
-        # U3: add toast for discoverability regardless of active tab
         with contextlib.suppress(Exception):
             self.notify(msg, severity="warning", title="Session")
 
@@ -329,6 +332,12 @@ class _TuiWorkersMixin:
             return
         badge.update("SESSION: VALID" if valid else "SESSION: EXPIRED")
         badge.set_classes("invalid" if not valid else "")
+        # BUG FIX: cancel the timeout timer when the worker completes.
+        # Without this, a 15s timer can fire AFTER the badge is already
+        # set to VALID, overwriting it with "TIMEOUT".
+        if hasattr(self, "_session_check_timer") and self._session_check_timer is not None:
+            self._session_check_timer.stop()
+            self._session_check_timer = None
 
 
 __all__ = ["_TuiWorkersMixin"]


### PR DESCRIPTION
## Bug

After TUI launch, session badge shows **SESSION: VALID** momentarily, then changes to **⚠ SESSION: TIMEOUT** — even though the session is actually valid.

## Root Cause

Race condition in `_refresh_session_badge`:

1. Badge set to `CHECKING…`, 15s timeout timer starts, validation worker starts
2. Worker completes in \~2s → `_apply_session_badge(True)` → badge = `VALID`
3. Timer fires at 15s → `_session_check_timeout()` → badge = `⚠ TIMEOUT` (overwrites VALID)

The timer was never cancelled when the worker completed successfully.

## Fix

- `_apply_session_badge` now cancels the timeout timer on completion
- `_session_check_timeout` checks if badge text still contains `CHECKING` before overwriting — skips if the worker already set VALID/EXPIRED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CLI session badge from changing from `SESSION: VALID` to `⚠ SESSION: TIMEOUT` when validation completes before the 15-second timeout. Completed checks now retain `VALID` or `EXPIRED`, and timeout handling applies only while the badge is still `CHECKING`.

- Cancels the pending timeout timer when validation finishes.
- Skips the timeout update and warning notification if validation already produced a result.

<sup>Written for commit f7b856806d047bc88461179e7ff90dd8992281ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed session status badges being incorrectly changed to “TIMEOUT” after validation or expiration.
  - Session-check timers now stop when validation completes, preventing delayed updates from overwriting the final status.
  - Timeout notifications continue to appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->