### PR TITLE
fix(tui): schedule elapsed timer via call_from_thread

### DIFF
--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -201,8 +201,14 @@ class _TuiWorkersMixin:
         start_t = time.perf_counter()
         # U7: capture the generation at worker start for finalize guard
         gen = self._slot_generation.get(slot_id, 0)
-        # U4: start periodic elapsed-time updater for the Overview table
-        elapsed_timer = self.set_timer(5.0, lambda: self._tick_elapsed(slot_id), repeat=True)
+        # U4: start periodic elapsed-time updater via call_from_thread
+        # (set_timer must be called from the main event loop thread)
+        timer_holder: list[Any] = []
+
+        def _create_timer() -> None:
+            timer_holder.append(self.set_timer(5.0, lambda: self._tick_elapsed(slot_id), repeat=True))
+
+        self.call_from_thread(_create_timer)
         try:
             if cfg.file_path:
                 res = self._attachment.process_prompt_with_attachment(
@@ -248,7 +254,8 @@ class _TuiWorkersMixin:
             )
             self.call_from_thread(self._finalize_slot, slot_id, "FAILED", prompt_name, dur, False, gen)
         finally:
-            elapsed_timer.stop()
+            if timer_holder:
+                timer_holder[0].stop()
 
     # ── Login worker ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Bug

`_execute_slot_worker` runs in `@work(thread=True)` background thread but calls `self.set_timer()` directly — this must be called from the main event loop thread.

## Fix

Use `call_from_thread()` to create the timer from the main thread. Timer reference stored in a list for safe access in the `finally` block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI elapsed timer by creating it on the main event loop instead of calling `set_timer()` from the background `_execute_slot_worker` thread. The timer reference is retained so the worker can still stop it when execution finishes.

<sup>Written for commit 56d066b9eae418838eff002c7372d6e0f33ef1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

