### PR TITLE
fix(tui): use set_interval instead of set_timer(repeat)

### DIFF
--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -50,6 +50,7 @@ class _TuiWorkersMixin:
     _format_status: Any
     call_from_thread: Any
     set_timer: Any
+    set_interval: Any
     _ensure_log_handler: Any
     push_screen: Any
     _session_check_timer: Any

--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -206,7 +206,7 @@ class _TuiWorkersMixin:
         timer_holder: list[Any] = []
 
         def _create_timer() -> None:
-            timer_holder.append(self.set_timer(5.0, lambda: self._tick_elapsed(slot_id), repeat=True))
+            timer_holder.append(self.set_interval(5.0, lambda: self._tick_elapsed(slot_id)))
 
         self.call_from_thread(_create_timer)
         try:
@@ -255,7 +255,7 @@ class _TuiWorkersMixin:
             self.call_from_thread(self._finalize_slot, slot_id, "FAILED", prompt_name, dur, False, gen)
         finally:
             if timer_holder:
-                timer_holder[0].stop()
+                self.call_from_thread(timer_holder[0].stop)
 
     # ── Login worker ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Bug

Textual's `set_timer()` does not support a `repeat` parameter, causing:
`TypeError: MessagePump.set_timer() got an unexpected keyword argument 'repeat'`

## Fix

- Use `set_interval()` which is the correct API for periodic timers
- Schedule `timer.stop()` via `call_from_thread()` for thread safety

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TUI worker timers by replacing unsupported `set_timer(..., repeat=True)` with `set_interval`, restoring periodic elapsed-time updates and adding the corresponding mypy stub. Timer cleanup now runs through `call_from_thread` for thread safety.

<sup>Written for commit 998f31260267a929ecd372e77ce86047db7daa24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

