### PR TITLE
fix(repo): refresh stale uv.lock and add CI lock-drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           version: "latest"
 
+      - name: Lockfile drift check
+        run: uv lock --check
+
       - name: Install project
         run: uv sync --no-dev
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,7 +48,10 @@ sed -i "s/^version = \"$CURRENT\"/version = \"$NEW\"/" "$PYPROJECT"
 
 # Commit and tag
 cd "$PROJECT_ROOT"
-git add pyproject.toml
+# The root [project] version in pyproject.toml is the single source of truth and
+# uv.lock must move with it — a stale lock breaks --locked/--frozen usage.
+uv lock
+git add pyproject.toml uv.lock
 git commit -m "release: v$NEW"
 git tag "v$NEW"
 git push && git push --tags

--- a/uv.lock
+++ b/uv.lock
@@ -1066,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "qwen-web-arwaky"
-version = "6.0.0"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Problem

The committed `uv.lock` is stale: release commit `1bac5a2` (v6.0.0 → v6.1.0) bumped `version` in `pyproject.toml` but staged only `pyproject.toml`, so the lock still records the root package at **6.0.0** while the manifest says **6.1.0**.

CI is green today only because every job runs `uv sync --no-dev`, which **silently rewrites the lock in place**. Any `--locked` / `--frozen` usage fails:

```
$ uv lock --check   # on origin/main, uv 0.12.9
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

## Changes

1. **Refresh the lock** — `uv lock` produces exactly one diff line: root package `qwen-web-arwaky` `6.0.0` → `6.1.0`. No dependency churn.
2. **`scripts/release.sh` refreshes the lock on every release** — after the `sed` version bump it now runs `uv lock` and stages `pyproject.toml uv.lock` together, with a comment noting the root `[project]` version is the single source of truth and the lock must move with it.
3. **CI drift guard** — the existing *Lint (ruff check + mypy)* job gains a `Lockfile drift check` step running `uv lock --check`, placed **before** `Install project`.

## Why sync-before-check ordering is mandatory

`uv sync` rewrites `uv.lock` in place. A `uv lock --check` placed after it would always pass and be worthless. The step therefore sits between `Install uv` and `Install project`.

## Why the Lint job instead of a new job

The branch-protection ruleset (`ruleset_id 20809701`) pins required contexts to the 6 existing job names. A brand-new top-level job would not be a required context and would block nothing; reusing the Lint job makes the guard enforcement-effective with zero ruleset changes.

## Verification

- `git diff origin/main --stat` → only `uv.lock`, `scripts/release.sh`, `.github/workflows/ci.yml`
- `uv lock` diff: exactly the root-package version line (`6.0.0` → `6.1.0`)
- `uv lock --check` on this branch: exit 0 (`Resolved 65 packages`, no error)
- `uv run mypy modules/` → `Success: no issues found in 81 source files`
- `ruff check modules/ tests/` → `All checks passed!`; `ruff format --check` → `126 files already formatted`
- `pytest -q` → 316 passed (exit 0)
- `bash -n scripts/release.sh` clean, and end-to-end rehearsal of the new release flow in a throwaway clone: `release.sh patch` committed **both** `pyproject.toml` and `uv.lock` (6.1.0 → 6.1.1 in lock, matching manifest) and `uv lock --check` exits 0 immediately after the release commit.
- ci.yml diff is 3 lines (step + blank), indentation matches sibling steps (6 spaces), step ordering programmatically verified: `Lockfile drift check` precedes `Install project` with `run: uv lock --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the stale `uv.lock` after the 6.1.0 release (root package 6.0.0 → 6.1.0, no dependency changes) and adds a CI lock-drift guard. Previously the lock drifted from `pyproject.toml` and CI stayed green only because `uv sync --no-dev` silently rewrote it; now `--locked`/`--frozen` usage works and drift is caught in CI.

**Changes**
- `scripts/release.sh` now runs `uv lock` and commits `uv.lock` together with `pyproject.toml` so releases can't diverge.
- Adds a `Lockfile drift check` (`uv lock --check`) to the Lint job before `Install project`, since a check after `uv sync` would always pass.
- Reuses the Lint job because it's already a required branch-protection context, so the guard blocks PRs without new required checks.

<sup>Written for commit 53c69b2f8f29259c1e962608fc9e21af4adb8190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated verification that the dependency lockfile is up to date during continuous integration.
  * Updated the release process to regenerate and include the dependency lockfile when preparing a release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->