### PR TITLE
fix(tui): address slots-table columns by stable keys, not labels

### DIFF
--- a/modules/cli/src/surface_cli_tui_utils.py
+++ b/modules/cli/src/surface_cli_tui_utils.py
@@ -61,19 +61,33 @@ class _TuiUtilsMixin:
 
     # ── Overview table ───────────────────────────────────────────────────
 
+    # T1: columns are addressed by stable KEYS, never by labels. Textual's
+    # add_columns("Status") auto-generates a ColumnKey, so update_cell(row,
+    # "Status") raises CellDoesNotExist and every write is a silent no-op.
+    COL_SLOT = "slot"
+    COL_STATUS = "status"
+    COL_FILE = "file"
+    COL_DURATION = "duration"
+
     def _init_table(self) -> None:
         with contextlib.suppress(NoMatches):
             table = self.query_one("#slots-table", DataTable)
-            table.add_columns("Slot", "Status", "Prompt File", "Duration")
+            table.add_columns(
+                ("Slot", self.COL_SLOT),
+                ("Status", self.COL_STATUS),
+                ("Prompt File", self.COL_FILE),
+                ("Duration", self.COL_DURATION),
+            )
             for s in range(1, self._NUM_SLOTS + 1):
                 table.add_row(f"Slot {s}", self._format_status("IDLE", "table"), "-", "0.0s", key=f"row-slot-{s}")
 
     def _update_table_row(self, slot_id: int, status: str, filename: str, duration: str) -> None:
         with contextlib.suppress(NoMatches, CellDoesNotExist):
             table = self.query_one("#slots-table", DataTable)
-            table.update_cell(f"row-slot-{slot_id}", "Status", status)
-            table.update_cell(f"row-slot-{slot_id}", "Prompt File", filename)
-            table.update_cell(f"row-slot-{slot_id}", "Duration", duration)
+            row_key = f"row-slot-{slot_id}"
+            table.update_cell(row_key, self.COL_STATUS, status)
+            table.update_cell(row_key, self.COL_FILE, filename)
+            table.update_cell(row_key, self.COL_DURATION, duration)
 
     # ── Metrics bar ──────────────────────────────────────────────────────
 

--- a/tests/unit_surface_cli_tui_app.py
+++ b/tests/unit_surface_cli_tui_app.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import MagicMock
 
+import pytest
 from textual.widgets import DataTable, Label, RichLog, TabbedContent
+from textual.widgets._data_table import CellDoesNotExist
 
 from modules.cli.src.surface_cli_tui_app import NUM_SLOTS, QwenTuiApp
 from modules.cli.src.surface_cli_tui_components import QwenTuiLogHandler
+from modules.cli.src.surface_cli_tui_utils import _TuiUtilsMixin
 
 
-def test_tui_app_mounts_and_populates_tabs() -> None:
-    app = QwenTuiApp(
+def _make_app() -> QwenTuiApp:
+    return QwenTuiApp(
         workspace=MagicMock(),
         direct=MagicMock(),
         file_only=MagicMock(),
@@ -21,6 +25,10 @@ def test_tui_app_mounts_and_populates_tabs() -> None:
         session=MagicMock(),
         jobs=MagicMock(),
     )
+
+
+def test_tui_app_mounts_and_populates_tabs() -> None:
+    app = _make_app()
 
     async def _run() -> None:
         async with app.run_test():
@@ -78,3 +86,121 @@ def test_log_handler_routes_thread_to_slot() -> None:
     # args[0] is _log_msg, args[1] is formatted string, args[2] is slot_id
     assert "Worker message" in args[1]
     assert args[2] == 2
+
+
+# ── Regression: #slots-table columns must be addressed by KEY, not label ──────
+#
+# Textual's add_columns("Status") treats the string as a LABEL and auto-generates
+# a ColumnKey, so update_cell(row, "Status") raises CellDoesNotExist — which the
+# contextlib.suppress in _update_table_row swallows. Result: the dashboard table
+# froze at "IDLE / - / 0.0s" forever, and only row_count was ever asserted, so
+# the old test passed green. These tests read actual cells.
+
+
+def test_slots_table_uses_stable_column_keys() -> None:
+    """The table's column keys must be the declared ones, not auto-generated."""
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test():
+            table = app.query_one("#slots-table", DataTable)
+            assert list(table.columns.keys()) == [
+                _TuiUtilsMixin.COL_SLOT,
+                _TuiUtilsMixin.COL_STATUS,
+                _TuiUtilsMixin.COL_FILE,
+                _TuiUtilsMixin.COL_DURATION,
+            ]
+            # Labels are still what the user sees (Textual stores them as Rich Text).
+            assert [str(c.label) for c in table.columns.values()] == ["Slot", "Status", "Prompt File", "Duration"]
+            # Cells must be readable BY KEY — this raises CellDoesNotExist if
+            # _init_table goes back to label-only add_columns().
+            assert table.get_cell("row-slot-1", "status") == "IDLE 💤"
+
+    asyncio.run(_run())
+
+
+def test_slots_table_update_table_row_actually_writes_cells() -> None:
+    """_update_table_row must move cells off their IDLE/-/0.0s initial values."""
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test():
+            table = app.query_one("#slots-table", DataTable)
+            before = (
+                table.get_cell("row-slot-1", "status"),
+                table.get_cell("row-slot-1", "file"),
+                table.get_cell("row-slot-1", "duration"),
+            )
+            assert before == ("IDLE 💤", "-", "0.0s")
+
+            app._update_table_row(1, "SUCCESS", "task.md", "12.3s")
+
+            after = (
+                table.get_cell("row-slot-1", "status"),
+                table.get_cell("row-slot-1", "file"),
+                table.get_cell("row-slot-1", "duration"),
+            )
+            assert after == ("SUCCESS", "task.md", "12.3s")
+            assert after != before, "_update_table_row was a silent no-op (CellDoesNotExist suppressed?)"
+            # The Slot column is untouched.
+            assert table.get_cell("row-slot-1", "slot") == "Slot 1"
+
+            # Other rows must not be affected.
+            assert table.get_cell("row-slot-2", "status") == "IDLE 💤"
+
+    asyncio.run(_run())
+
+
+def test_slots_table_update_table_row_multi_digit_slot() -> None:
+    """row-slot-10 (multi-digit id) resolves too — not just single digits."""
+    if NUM_SLOTS < 10:
+        pytest.skip(f"app configured with only {NUM_SLOTS} slots")
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test():
+            table = app.query_one("#slots-table", DataTable)
+            app._update_table_row(10, "FAILED", "long-job.md", "1m 4s")
+            assert table.get_cell("row-slot-10", "status") == "FAILED"
+            assert table.get_cell("row-slot-10", "file") == "long-job.md"
+            assert table.get_cell("row-slot-10", "duration") == "1m 4s"
+
+    asyncio.run(_run())
+
+
+def test_slots_table_tick_elapsed_updates_duration_live() -> None:
+    """The live path: a RUNNING slot's Duration cell advances from 'running…'."""
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test():
+            table = app.query_one("#slots-table", DataTable)
+            app._slot_stats[1] = {
+                "status": "RUNNING",
+                "file": "task.md",
+                "duration": 0.0,
+                "_start_perf": time.perf_counter() - 42,
+            }
+            app._update_table_row(1, "RUNNING ⏳", "task.md", "running…")
+            assert table.get_cell("row-slot-1", "duration") == "running…"
+
+            app._tick_elapsed(1)
+
+            assert table.get_cell("row-slot-1", "duration") == "42s"
+            assert table.get_cell("row-slot-1", "status") == "RUNNING ⏳"
+
+    asyncio.run(_run())
+
+
+def test_slots_table_update_missing_row_stays_quiet() -> None:
+    """Narrow suppression must survive: unknown slot no-ops instead of raising."""
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test():
+            app._update_table_row(999, "SUCCESS", "x.md", "1.0s")  # no raise
+            table = app.query_one("#slots-table", DataTable)
+            with pytest.raises(CellDoesNotExist):
+                table.get_cell("row-slot-999", "status")
+
+    asyncio.run(_run())


### PR DESCRIPTION
fix(tui): address slots-table columns by stable keys, not labels

## Symptom

The Overview dashboard job table (`#slots-table`) was frozen — it kept showing `IDLE 💤 / - / 0.0s` no matter what a slot did. Duration never ticked, status never changed, cancel rows never appeared.

## Root cause

Textual's `DataTable.add_columns("Slot", "Status", ...)` treats bare strings as **labels** and auto-generates a `ColumnKey` object for each column. The label is *not* the key.

`_update_table_row` then called `table.update_cell("row-slot-1", "Status", ...)` — looking up a column by the KEY `"Status"`, which does not exist. Every call raised `CellDoesNotExist`, and the surrounding `contextlib.suppress(NoMatches, CellDoesNotExist)` swallowed it. Every write was a silent no-op.

This also broke every caller that funnels through `_update_table_row`: `_tick_elapsed` (live duration), `_finalize_slot` (final status/duration) and `_do_cancel_slot` (CANCELLED row).

## Fix

- `_init_table` declares explicit stable keys via `(label, key)` tuples: `("Status", "status")`, etc., using `COL_*` class constants as the single source of truth.
- `_update_table_row` addresses cells by those **keys**.
- `add_row(..., key=f"row-slot-{s}")` unchanged; the narrow `contextlib.suppress(NoMatches, CellDoesNotExist)` is kept (no broad `except Exception`) so genuinely-missing rows stay quiet — covered by a dedicated test.

## Test blind spot (why this shipped green)

`tests/unit_surface_cli_tui_app.py` asserted only `table.row_count >= 2`. It never read a cell, so it proved nothing about updates. This PR adds regression tests that read actual cell values:

- `test_slots_table_uses_stable_column_keys` — column keys are the declared ones; labels still render correctly.
- `test_slots_table_update_table_row_actually_writes_cells` — cells move off their `IDLE 💤 / - / 0.0s` initial values; other rows unaffected.
- `test_slots_table_update_table_row_multi_digit_slot` — `row-slot-10` resolves too.
- `test_slots_table_tick_elapsed_updates_duration_live` — the live path: `_tick_elapsed` advances the Duration cell from `"running…"` to real elapsed time.
- `test_slots_table_update_missing_row_stays_quiet` — the narrow suppression behaviour is pinned.

**Guard verified by revert:** reverting `_update_table_row` to label addressing fails 3 of the new tests; reverting `_init_table` to label-only `add_columns` fails 4. Neither half of the fix can silently regress.

## Evidence

- `uv run pytest -q`: 321 passed (full suite, incl. 5 new tests)
- `uv run ruff check modules/ tests/`: All checks passed
- `uv run ruff format --check modules/ tests/`: 126 files already formatted
- `uv lock --check`: exit 0, no lockfile change in this PR
- Headless live-path probe (`run_test`): Duration goes `running…` → `7s` → `2m 5s`, then `_finalize_slot` yields `['Slot 1', 'DONE ✅', 'proof.md', '125.0s']`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI Overview dashboard `#slots-table` freezing at "IDLE 💤 / - / 0.0s" — duration never ticked, status never updated, and cancel rows never appeared. Textual's `add_columns("Status")` treats the string as a label and auto-generates a separate column key, so `update_cell` with the label string raised `CellDoesNotExist` and the narrow `contextlib.suppress` swallowed it, making every write a silent no-op. Columns are now declared with explicit stable keys and cells are addressed by those keys.

**Test coverage**
- Adds regression tests that read actual cell values; the old test only checked `row_count`, so it passed on the frozen table.
- Covers live duration updates via `_tick_elapsed`, multi-digit slot ids, and the narrow suppression behavior.

<sup>Written for commit 16805299648eeda673e132c8d2529e9f42302bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table updates so slot statuses, filenames, and durations remain correctly aligned.
  * Fixed updates for multi-digit slot IDs.
  * Preserved live duration updates while avoiding errors when a row is unavailable.

* **Tests**
  * Added regression coverage for table columns, cell updates, slot identifiers, duration ticking, and missing-row handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->