### PR TITLE
fix(tui): stop border-bottom from clipping active tab label to zero rows

### DIFF
--- a/modules/cli/src/surface_cli_tui_css.py
+++ b/modules/cli/src/surface_cli_tui_css.py
@@ -101,7 +101,10 @@ Tab.-active {
     color: $fg_primary;
     text-style: bold;
     background: $bg_active;
-    border-bottom: solid $accent;
+}
+
+Underline {
+    color: $accent;
 }
 
 /* --- Overview Tab ------------------------------------------------------- */

--- a/tests/unit_surface_cli_tui_app.py
+++ b/tests/unit_surface_cli_tui_app.py
@@ -204,3 +204,56 @@ def test_slots_table_update_missing_row_stays_quiet() -> None:
                 table.get_cell("row-slot-999", "status")
 
     asyncio.run(_run())
+
+
+# ── Regression: the ACTIVE tab's label must actually render ────────────────────
+#
+# `Tab.-active { border-bottom: solid $accent }` on a Tab (Textual default
+# height:1) consumes the tab's only row — the active tab measured
+# content_region.height == 0 and its label vanished behind the highlight.
+# The old test asserted `str(tab.label)`, which passes even when nothing is
+# drawn. This asserts on composited screen text instead, and pins the
+# replacement accent indicator (Textual's Underline, styled via the bare
+# type selector — `Tabs > Underline` is a measured no-op on 8.2.8).
+
+
+def test_active_tab_label_renders_on_screen() -> None:
+    """The active tab's relabelled text must reach the rendered screen."""
+    from textual.color import Color
+    from textual.widgets import Tab
+    from textual.widgets._tabs import Underline
+
+    accent = Color.parse("#8083ff")  # _COLORS["accent"] in surface_cli_tui_css
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            tabs = app.query_one(TabbedContent)
+            tabs.active = "tab-slot-1"
+            await pilot.pause()
+            app._set_slot_tab_title(1, "Slot 1: deep-review ⏳")
+            await pilot.pause()
+
+            strips = list(app.screen._compositor.render_strips())
+            rendered = "".join(s.text for s in strips)
+            # Load-bearing: the label is drawn somewhere on screen.
+            assert "deep-review" in rendered
+
+            # …and specifically on the tab row (the strip holding "Overview").
+            tab_row = next(s.text for s in strips if "Overview" in s.text)
+            assert "deep-review" in tab_row
+
+            # Geometry: the active Tab keeps a full text row; inactive ones are
+            # unchanged.
+            active_tab = app.query_one("#--content-tab-tab-slot-1", Tab)
+            assert active_tab.content_region.height > 0
+            for w in app.query(Tab):
+                if w.id != "--content-tab-tab-slot-1":
+                    assert w.content_region.height == 1, w.id
+
+            # The accent active-indicator survives on Textual's Underline.
+            underline = tabs.query_one(Underline)
+            assert underline.styles.color == accent
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Symptom (user-reported)
Selecting a tab showed only the highlight block — the tab name disappeared, so there was no way to see which tab was active.

## Root cause
`Tab` has Textual's default `height: 1`. The app's active rule added `border-bottom: solid $accent`, which consumes that one row, leaving **zero rows for text**. Measured headless: active tab `content_region.height == 0` vs `1` for every inactive tab, and the active label string was absent from the composited screen text entirely.

## Fix — `modules/cli/src/surface_cli_tui_css.py`
1. Removed `border-bottom: solid $accent;` from `Tab.-active` (kept `color`, `text-style: bold`, `background: $bg_active`).
2. Preserved the accent active-indicator by styling Textual's own `Underline` widget, which already tracks the active tab:
   ```css
   Underline {
       color: ;
   }
   ```
   The **bare type selector is load-bearing**: measured on Textual 8.2.8, `Tabs > Underline` is a no-op (resolves to default white) because `Underline` is not a direct child of `Tabs` — it sits inside `#tabs-scroll` -> `#tabs-list-bar`. The unrelated `border-bottom` on `Tabs` (strip separator) is untouched.

## Regression test — `tests/unit_surface_cli_tui_app.py`
`test_active_tab_label_renders_on_screen` asserts on **rendered output**, not the label model (the old `assert "test.md" in str(tab1.label)` passes even when nothing is drawn — that blind spot is why this shipped broken). It activates `tab-slot-1`, relabels via `_set_slot_tab_title`, then asserts:
- `"deep-review"` appears in `app.screen._compositor.render_strips()` text, **and** specifically on the tab row;
- the active Tab widget's `content_region.height > 0` while all inactive tabs stay at 1;
- `Underline.styles.color == Color(128, 131, 255)` (the accent).

### Fail/pass evidence (criterion 2)
With the CSS fix reverted (`border-bottom` restored, `Underline` rule removed):
```
>           assert "deep-review" in rendered
E           AssertionError: assert 'deep-review' in ' ⭘                  QWEN-CLI 6.1.0  — chat.qwen.ai parallel automation engine ...'
FAILED tests/unit_surface_cli_tui_app.py::test_active_tab_label_renders_on_screen
```
With the fix applied: `.  [100]` — exit 0.

Reverting only half 2 (keeping the border removed, dropping the `Underline` rule) fails the indicator assertion (`r: 255 != 128`), so both halves are independently guarded.

### Rendered tab row, before vs after
```
before: '  Overview 📊                              Slot 2 💤    Slot 3 💤    Slot 4 💤 ...'   <- Slot 1 gone
after : '  Overview 📊    Slot 1: deep-review ⏳    Slot 2 💤    Slot 3 💤    Slot 4 💤 ...'
```

## Verification
- `uv run pytest -q` — **322 passed**, exit 0 (321 on `origin/main` + this new test).
- `ruff check` All checks passed; `ruff format --check` 126 files already formatted.
- `mypy modules/ --ignore-missing-imports` — Success: no issues found in 81 source files.
- `lint-arwaky-cli scan .` — Total: 0 violations.
- `uv lock --check` exit 0; **no uv.lock change** in this diff (only the 2 files above touched).

## Notes / follow-up
- Local bandit reports 3 issues, all pre-existing and in `modules/core/src/capabilities_update_manager.py` (untouched here) — identical on `origin/main`.
- Unrelated pre-existing flake observed on clean `origin/main` (~1 in 6-8 runs of `unit_surface_cli_tui_app.py`): a login-thread `call_from_thread(_refresh_session_badge)` racing screen teardown raises `NoMatches`, which `_refresh_session_badge` doesn't catch (it catches only `LookupError, AttributeError`). Not caused by, and not fixable within, this CSS change — filed as a separate card.

Base is current `origin/main` (113079f, incl. the slots-table column-key merge); rebase confirmed a no-op and all 5 `test_slots_table_*` tests from that merge are intact alongside this new test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI active tab label being clipped to zero rows by moving the accent indicator from the active Tab's border-bottom to Textual's `Underline` widget. The active tab now keeps a full content row, so its label renders instead of disappearing behind the highlight block. Adds a regression test that asserts the label appears in the rendered output.

<sup>Written for commit efecb217f9909a3d68c408767a5415d94adebd2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

