### PR TITLE
fix(tui): survive teardown race in session-badge writers

### DIFF
--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 
 from rich.markup import escape
 from textual import work
+from textual.app import ScreenStackError
 from textual.css.query import NoMatches
 from textual.widgets import Input, Label, LoadingIndicator, Switch
 
@@ -21,6 +22,19 @@ from modules.cli.src.surface_cli_tui_css import THEME
 from modules.core.src.capabilities_tui_slot_config import SlotInputError
 from modules.shared.src.taxonomy_core_vo import AppConfig, HeadlessFlag
 from modules.shared.src.utility_core_response import detect_processing_failure
+
+# A badge write can land while the app is tearing down: the worker thread's
+# ``call_from_thread`` is queued on the event loop and keeps running after the
+# screen is popped (``ScreenStackError``) or the badge is unmounted
+# (``NoMatches``). Neither is a subclass of ``LookupError``/``AttributeError``,
+# so catching only those let the exception escape as an app crash. There is
+# nothing left to display in that window — return quietly instead.
+_BADGE_UNAVAILABLE: tuple[type[BaseException], ...] = (
+    NoMatches,
+    ScreenStackError,
+    LookupError,
+    AttributeError,
+)
 
 
 class _TuiWorkersMixin:
@@ -267,7 +281,7 @@ class _TuiWorkersMixin:
         try:
             badge = self.query_one("#session-badge", Label)
             badge.update("SESSION: LOGGING IN…")
-        except (LookupError, AttributeError):
+        except _BADGE_UNAVAILABLE:
             pass
         try:
             if self._setup is None:
@@ -291,7 +305,7 @@ class _TuiWorkersMixin:
     def _refresh_session_badge(self) -> None:
         try:
             badge = self.query_one("#session-badge", Label)
-        except (LookupError, AttributeError):
+        except _BADGE_UNAVAILABLE:
             return
         if self._session is None:
             badge.update("SESSION: N/A")
@@ -308,9 +322,9 @@ class _TuiWorkersMixin:
         if self._session_check_timed_out:
             return
         self._session_check_timed_out = True
-        with contextlib.suppress(NoMatches):
+        with contextlib.suppress(*_BADGE_UNAVAILABLE):
             badge = self.query_one("#session-badge", Label)
-            badge_text = str(badge.renderable) if badge.renderable else ""
+            badge_text = str(badge.render() or "")
             # Only show TIMEOUT if the badge is still in CHECKING state.
             # If the worker already completed and set VALID/EXPIRED, do not overwrite.
             if "CHECKING" not in badge_text:
@@ -336,7 +350,7 @@ class _TuiWorkersMixin:
     def _apply_session_badge(self, valid: bool) -> None:
         try:
             badge = self.query_one("#session-badge", Label)
-        except (LookupError, AttributeError):
+        except _BADGE_UNAVAILABLE:
             return
         badge.update("SESSION: VALID" if valid else "SESSION: EXPIRED")
         badge.set_classes("invalid" if not valid else "")

--- a/tests/unit_surface_cli_tui_app.py
+++ b/tests/unit_surface_cli_tui_app.py
@@ -257,3 +257,45 @@ def test_active_tab_label_renders_on_screen() -> None:
             assert underline.styles.color == accent
 
     asyncio.run(_run())
+
+
+# ── Regression: session-badge writes during teardown must not crash the app ───
+#
+# The login/session workers call call_from_thread(self._refresh_session_badge)
+# (and _apply_session_badge) from background threads. When that callback lands
+# while the app is tearing down — badge already unmounted, or screen stack
+# popped — query_one raises NoMatches / ScreenStackError. Those are NOT
+# subclasses of (LookupError, AttributeError), so the old handlers let them
+# escape and run_test re-raised them as an app crash (~1 in 6-8 flaky runs of
+# this file). With the badge removed we can reproduce the teardown state
+# deterministically.
+
+
+def test_session_badge_survives_teardown_state() -> None:
+    """Badge writers no-op when #session-badge is gone instead of raising NoMatches."""
+    from textual.widgets import Label as _Label
+
+    app = _make_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            # Sanity: on the normal path the badge IS updated (the widened
+            # except-clause must not swallow real work).
+            app._session = None
+            app._refresh_session_badge()
+            assert str(app.query_one("#session-badge", _Label).render()) == "SESSION: N/A"
+            app._apply_session_badge(True)
+            assert str(app.query_one("#session-badge", _Label).render()) == "SESSION: VALID"
+
+            # Teardown state: badge unmounted while a queued callback still
+            # targets it. Before the fix each of these raised NoMatches.
+            app.query_one("#session-badge", _Label).remove()
+            for _ in range(3):
+                await pilot.pause()
+
+            app._session = MagicMock()  # non-None → refresh takes the CHECKING path
+            app._refresh_session_badge()  # must not raise
+            app._apply_session_badge(True)  # must not raise
+            app._session_check_timeout()  # must not raise (also covers the render() read)
+
+    asyncio.run(_run())


### PR DESCRIPTION
Lands Linus's verified fix (commit `eb455a5`) from kanban task `t_c89d1930`.

The worker's badge writes are queued via `call_from_thread` and can land while the app is tearing down. The old handlers caught only `(LookupError, AttributeError)`, so:

- `NoMatches` (badge already unmounted) escaped as `WorkerFailure → App._handle_exception → crash`
- `ScreenStackError` (screen popped) likewise escaped

Fix: a shared `_BADGE_UNAVAILABLE` tuple (`NoMatches`, `ScreenStackError`, `LookupError`, `AttributeError`) applied at all four badge-write sites.

Also fixes a latent bug on the session-timeout path: `badge.renderable` does not exist in Textual 8.2.8, so `_session_check_timeout` raised `AttributeError` and never displayed the TIMEOUT status. Verified by direct reproduction on `origin/main` (`AttributeError: 'Label' object has no attribute 'renderable'`, escaping Textual's callback dispatcher). Replaced with `badge.render()`.

Regression test `test_session_badge_survives_teardown_state` removes the badge to force the `NoMatches` window, then asserts the normal path still updates the badge — so the widened suppression cannot mask a real regression.

Gates verified on `fe5ffde` + this commit: 323 passed, mypy 81 files clean, ruff check + format clean, `uv lock --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a teardown race in the TUI session-badge writers so queued badge updates no longer crash the app when they land after the badge is unmounted or the screen is popped.

- Widens the exception guard to catch `NoMatches`, `ScreenStackError`, `LookupError`, and `AttributeError` at all four badge-write sites.
- Fixes a latent `AttributeError` on the session-timeout path by using `badge.render()` instead of `badge.renderable`, which does not exist in Textual 8.2.8.
- Adds a regression test that removes the badge to force the teardown state and verifies the normal path still updates the badge.

<sup>Written for commit eb455a52050e6e890814ed5f5aa878c23b77f49b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session and login badge handling during screen teardown.
  - Prevented timeout and badge updates from raising errors when the badge is unavailable or has been unmounted.
- **Tests**
  - Added coverage confirming badges continue to update normally and safely no-op during teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->