### PR TITLE
fix(release): fail loudly when git push or tag push is rejected

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -54,6 +54,11 @@ uv lock
 git add pyproject.toml uv.lock
 git commit -m "release: v$NEW"
 git tag "v$NEW"
-git push && git push --tags
+# Push each ref explicitly and check the result. Under `set -e`, a failing
+# command on the LEFT of `&&` is exempt from the exit, so the old
+# `git push && git push --tags` printed "Released" even when the push was
+# rejected. Push branch + tag by name (no upstream assumption).
+git push origin "v$NEW" HEAD || { echo "Error: git push failed" >&2; exit 1; }
+git push --tags || { echo "Error: tag push failed" >&2; exit 1; }
 
 echo "Released v$NEW"


### PR DESCRIPTION
## Summary
- `scripts/release.sh` ended with `git push && git push --tags`. Under `set -e`, a failing command on the LEFT of `&&` does not abort the script, so a rejected push still printed `Released v...` and exited 0 — a release could silently never reach origin.
- Replaced with explicit per-push checks that push branch + tag by name (no upstream assumption):
  - `git push origin "v$NEW" HEAD || { echo "Error: git push failed" >&2; exit 1; }`
  - `git push --tags || { echo "Error: tag push failed" >&2; exit 1; }`
- Success line now prints only after both pushes succeed; committing `pyproject.toml` + `uv.lock` before pushing is unchanged (PR #198 behavior preserved).

## Test plan (executed, sandbox repo w/ local bare remotes)
- [x] Happy path: exit 0, `Released v9.9.9` printed, branch `main` + tag `v9.9.9` on remote, release commit contains exactly `pyproject.toml,uv.lock`.
- [x] Rejected branch push (unreachable remote): exit 1, no `Released v...`, `Error: git push failed` on stderr.
- [x] Rejected tag push (conflicting tag on remote blocks `git push --tags` after branch push succeeded): exit 1, no `Released v...`, `Error: tag push failed`.
- [x] Negative control: pre-fix script passes happy path but FAILS the two failure scenarios (exit 0 + false "Released") — the checks genuinely bite. 11/11 pass post-fix.

Board: t_747396ee (validation child t_8a2ddc8b, root t_4caee620).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release script so a rejected git push or tag push fails loudly instead of silently printing a success message. Previously, `git push && git push --tags` under `set -e` ignored a failure on the left of `&&`, so the script exited 0 and printed `Released v...` even when the push never reached origin. Now each push is checked explicitly, and the success line prints only after both pushes succeed.

<sup>Written for commit b10a163518b7dfd0bd0a02426d677beaff91a14e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release publishing now stops immediately when a push fails.
  - Clear error messages are shown, and the release process no longer reports success after a rejected push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->