### PR TITLE
docs(skill): simplify SKILL.md to use cases and add output timestamps

### DIFF
--- a/.agents/skills/qwen-web/SKILL.md
+++ b/.agents/skills/qwen-web/SKILL.md
@@ -2,13 +2,9 @@
 name: qwen-web
 description: >
   Automate Qwen AI Web (chat.qwen.ai) with the Qwen3.8-Max intelligence model —
-  zero API keys, zero paid quota, persistent browser sessions.
-  USE THIS SKILL when an AI agent must: send prompts to Qwen and capture the full
-  un-truncated answer; audit, review, refactor, or generate production code;
-  analyze documents (PDF/MD/TXT attachments); run long deep-reasoning software
-  engineering tasks (up to 15 minutes); or manage Qwen login sessions — via the
-  qwen-web-arwaky CLI or MCP tools.
-version: 5.2.0
+  zero API keys, persistent browser sessions. Use when an AI agent needs to send
+  prompts, review code, or analyze document attachments via CLI or MCP tools.
+version: 6.0.0
 trigger_keywords:
   - qwen
   - chat.qwen.ai
@@ -21,488 +17,162 @@ trigger_keywords:
 entry_points: [qwen-web-arwaky, qwa, qwen-web-mcp]
 ---
 
-# Qwen Web Automation — Master-Class Agent Harness
+# Qwen Web Automation Skill Guide
 
-> **Purpose.** This skill turns `qwen-web-arwaky` into a deterministic, production-grade
-> LLM backend for autonomous AI agents. It covers every MCP tool, every CLI subcommand,
-> prompt-engineering contracts for complete un-truncated output, multi-role engineering
-> workflows, and a full resilience decision tree.
->
-> **Prime directive for agents:** treat Qwen3.8-Max as your deep-reasoning engine.
-> Structure every request with an explicit *Output Contract*, pick the correct timeout
-> band, and always verify the output envelope before consuming results.
+Use this skill when an AI agent needs to send prompts or document files to **Qwen AI (`chat.qwen.ai`)** and receive complete responses via MCP tools or CLI commands.
 
 ---
 
-## 1. Core Capabilities & Architecture Summary
+## 1. Quick Reference: MCP Tools & CLI Commands
 
-### 1.1 What makes this engine different
-
-| Capability | Implementation detail |
-| :--- | :--- |
-| **Qwen3.8-Max by default** | The pipeline **forces and verifies** the hardcoded default model (`Qwen3.8-Max`) on every session before dispatch. The agent never picks a model manually; a `ModelSwitchError` aborts the run if the model cannot be confirmed active. |
-| **Zero API key** | Authentication is a real Chromium browser session (persistent cookies in `qwen_session/`). No tokens, no billing, no quota. |
-| **Zero-truncation extraction (Tier-1 React Fiber)** | Response capture walks the React Fiber tree (`__reactFiber` → `memoizedProps.content`, up to 30 levels) to recover **100% of raw Markdown**, including code blocks that Monaco Editor virtualization would clip in the visible DOM. |
-| **Tier-2 DOM Tree Walker fallback** | A block-aware tree walker (preserves `PRE`/code formatting, strips UI chrome, buttons, copy widgets) guarantees extraction even when Fiber props are absent. |
-| **30s cloud reload sync** | While waiting for a terminal event, the page is reloaded every 30 seconds to re-sync Qwen Cloud streaming state — long generations survive network drops and tab throttling. |
-| **Event-driven long-run monitor** | The stream monitor has no elapsed-time response cutoff. It waits for terminal generation state and keeps recovery polling alive for long-running jobs. |
-| **Terminal-event completion** | A response is accepted only after stable text and an explicit generation-complete signal; stability alone can never terminate an unfinished response. |
-| **Self-healing browser sessions** | Automatic stale `SingletonLock` cleanup, session directory permission repair (`0700`), 3-attempt launch retry with backoff. |
-| **Multi-strategy input injection** | Playwright `fill` → React native value-setter (with `_valueTracker` reset) → `type()` keystroke fallback. |
-| **Parse-gated dispatch** | The send button is held until document parsing is positively verified (network `files/parse` 200 + DOM spinner/toast clearance). Prompts are never dispatched onto half-parsed attachments. |
-| **Atomic, traceable output** | Outputs are written atomically with a METADATA TRACEABILITY header and a `.meta.json` sidecar (`run_id`, `duration_sec`, `input_chars`, `output_chars`). |
-| **Full observability** | Structured JSONL logs (`app.jsonl`), `status.json` for monitoring, optional Sentry + OpenTelemetry tracing, lifecycle event stream with strict predecessor gating. |
-
-### 1.2 Layered architecture
-
-```
-┌─ SURFACE (thin, zero business logic) ─────────────────────────────────┐
-│  CLI surfaces: init / login / doctor / update / run / TUI controller  │
-│  MCP surface : surface_mcp_tool_command (stdio JSON-RPC tools)        │
-├─ CORE AGENTS (5 orchestrators) ───────────────────────────────────────┤
-│  DirectPromptOrchestrator · PromptFileOrchestrator ·                  │
-│  AttachmentPromptOrchestrator · SessionOrchestrator · SetupOrchestrator│
-├─ CAPABILITIES ────────────────────────────────────────────────────────┤
-│  BrowserAdapter · PromptInjector · SendDispatcher · StreamMonitor ·   │
-│  FileUploader · Saver · ObservabilitySetup · UpdateManager · Workspace│
-├─ SHARED (taxonomy / contract / utility) ──────────────────────────────┤
-│  Constants · VOs · Entities (CircuitBreaker, RateLimiter, Lifecycle) ·│
-│  Events · Errors · Protocols (DI contracts) · Pure utilities          │
-└───────────────────────────────────────────────────────────────────────┘
-```
-
-### 1.3 Lifecycle event sequence (observability contract)
-
-Every run emits this strictly-ordered event chain (enforced by `LifecycleGate` —
-out-of-order events are rejected with an auditable reason in the logs):
-
-```
-EVENT_WEB_LOADED → EVENT_LOGIN_VERIFIED → EVENT_MODEL_VERIFIED
-  → [EVENT_FILE_UPLOADED → EVENT_DOCUMENT_PARSED]   (attachment pipeline only)
-  → EVENT_PROMPT_INJECTED → EVENT_SEND_CLICKED → EVENT_DISPATCH_ACKNOWLEDGED
-  → EVENT_THINKING_STARTED → EVENT_STREAMING_GENERATION → EVENT_GENERATION_FINISHED
-  → EVENT_OUTPUT_COPIED
-```
-
-**Agent debugging rule:** when a run fails, find the *last successfully emitted event*
-in `app.jsonl` — the failure always lives in the capability owning the *next* event.
-
----
-
-## 2. Complete MCP Tool Reference
-
-All tools speak stdio MCP and return structured JSON envelopes:
-
-- **Success:** `{"success": true, "status": "SUCCESS", "result": "...", "output_path": "...", "run_id": "..."}`
-- **Failure:** `{"success": false, "error": {"code", "message", "hint", "retryable", "field"}}`
-
-### 2.1 Tool matrix
-
-| MCP Tool | Purpose | Required params | Optional params (defaults) |
-| :--- | :--- | :--- | :--- |
-| `process_direct_prompt` | One-shot inline text prompt → AI answer | `prompt` (str) | `timeout_sec` (int, **120**), `headless` (bool, **true**) |
-| `process_prompt_file_only` | Prompt from a `.md` file on disk, no attachment | `input_file` (str) | `output_file` (str, **null** → auto), `headless` (bool, **true**) |
-| `process_prompt_with_attachment` | Prompt file + document attachment (PDF/MD/TXT) | `prompt_file` (str), `attachment_file` (str) | `output_file` (str, **null** → auto), `headless` (bool, **true**) |
-| `check_session` | Validate saved session cookies | — | — |
-| `setup_session` | Open visible browser for manual login / CAPTCHA | — | — |
-| `delete_session` | Wipe saved session profile | — | `confirm` (bool, **false** — MUST be `true`) |
-| `init_workspace` | Create `.qwen-web/`, skill guide, samples, `.gitignore` | — | `target_dir` (str, **"."**) |
-
-### 2.2 Exact invocation payloads
-
-> **📁 Workspace rule: put ALL prompt/attachment/output files under `.qwen-web/`**
-> (`qwen-web-arwaky init` creates it in the cwd — already `.gitignore`d). Use
-> `.qwen-web/input/...` and `.qwen-web/output/...`; NEVER create a bare `input/`
-> or `output/` folder in the repo root. `output/` inside `.qwen-web/` is a symlink
-> to the XDG output dir, so results persist outside the repo.
-
-```json
-// Fast factual query (completion is event-driven; duration is not a cutoff)
-{ "prompt": "List the 5 SOLID principles in one line each.",
-  "timeout_sec": 60, "headless": true }
-
-// Standard engineering task (timeout_sec remains an optional compatibility hint)
-{ "input_file": ".qwen-web/input/role-fullstack-developer/todo/task_042.md",
-  "output_file": ".qwen-web/output/role-fullstack-developer/task_042.md",
-  "headless": true }
-
-// Deep reasoning with document context (no response-duration cutoff)
-{ "prompt_file": ".qwen-web/input/role-architect/todo/review_spec.md",
-  "attachment_file": ".qwen-web/input/role-architect/docs/system_spec.pdf",
-  "output_file": ".qwen-web/output/role-architect/review_spec.md",
-  "headless": true }
-```
-
-### 2.3 Event-Driven Long-Running Lifecycle
-
-Response completion is **event-driven**, not duration-driven. The historical `timeout_sec` input remains an observability hint for API compatibility, but it is not used to cut off a Qwen response.
-
-- **Terminal event as source of truth**: The monitor waits for stable response text plus an explicit generation-complete state.
-- **Long-running recovery**: Every 30 seconds the browser can reload to resynchronize cloud state. Browser operation timeouts trigger recovery and continue waiting instead of reporting success or truncating the response.
-- **Output-written success gate**: The pipeline emits `EVENT_OUTPUT_COPIED` only after the saver returns and the target output file is verified as readable and non-empty. CLI success/exit code `0` is downstream of that event.
-- **24-hour operation target**: A persistent host can keep the process alive for 24 hours or longer. Normal completion remains event-driven; a separate **4-hour safety circuit breaker** only stops a run that has produced no terminal event at all, preventing infinite hangs and resource exhaustion.
-- **Parse-Gated Dispatch**: Document parsing is held automatically until backend `/files/parse` 200 OK is confirmed before sending.
-- **Maximum Attachment Size**: **100 MB** (pre-flight validated).
-
-> **⚠️ NEVER wrap runs in an external timeout** (`timeout N`, shell alarm, CI job timeout, agent-loop kill). The engine owns its own timing: killing a run from outside with `timeout`/`pkill` leaves the Chromium process and page orphaned, corrupts the shared browser profile, and causes the NEXT run to fail with `TargetClosedError` or silent hang. If a run looks stuck, verify it is actually still generating (see §5.6) before considering any intervention — and the only safe interventions are letting it finish or cleanly cancelling via the TUI **Cancel Run** button.
-
-### 2.4 CLI reference (equivalent surface for scripting & CI)
-
-```bash
-# Primary command: qwa (or qwen-web-arwaky)
-qwa doctor [--json]                        # environment health checks
-qwa init [--dir TARGET]                    # workspace provisioning (.qwen-web/ in cwd)
-qwa login                                  # headed manual login / CAPTCHA
-qwa update [--check] [--force]             # self-update + Chromium sync
-qwa prompt-direct -t "..." [-o OUT] [--headless] [--json]
-qwa prompt-only   -i .qwen-web/input/PROMPT.md [-o OUT] [--headless] [--json]
-qwa prompt-with-attachment -i .qwen-web/input/PROMPT.md -a FILE [-o OUT] [--headless] [--json]
-qwen-web-arwaky mcp                                    # run MCP server over stdio
-```
-
-Paths: always use `.qwen-web/input/...` for prompts/attachments and
-`.qwen-web/output/...` for results — never bare `input/`/`output/` in the repo root.
-
-Exit codes: `0` success · `1` generic error · `2` `AuthRequiredError` · `130` interrupted.
-Use `--json` in pipelines for machine-readable envelopes.
-
----
-
-## 3. Prompt Engineering & Output Quality Harness
-
-### 3.1 The five laws of complete, un-truncated output
-
-1. **State an explicit Output Contract.** List exact section headings, required code
-   fences, and formatting rules. Qwen3.8-Max follows structural contracts with high
-   fidelity — vague asks produce vague output.
-2. **Ban truncation in writing.** Always include: *"Output every file COMPLETE and
-   VERBATIM inside fenced code blocks. Never use ellipses (`...`), placeholder
-   comments (`// rest unchanged`), or references to omitted code."*
-3. **Reason first, produce second.** Ask for a compact analysis section *before* the
-   deliverable. This spends the model's deep-reasoning budget on understanding; the
-   event-driven monitor waits for the full response (no fixed watchdog cutoff).
-4. **Move bulk into attachments.** Prompt files should carry *instructions*; large
-   code, specs, and diffs belong in attachments (PDF/MD/TXT ≤ 100 MB). Use one
-   consolidated attachment per run (exactly one attachment is supported per execution).
-5. **Demand a self-verification checklist.** End every prompt with: *"Before finishing,
-   verify: (a) every requested section exists, (b) all code blocks are complete and
-   syntactically valid, (c) no placeholders remain. If any check fails, fix before
-   answering."*
-
-### 3.2 Canonical prompt-file skeleton
-
-```markdown
-# ROLE
-You are a principal <ROLE> working on <SYSTEM>.
-
-# CONTEXT
-<2–6 sentences: what the system is, constraints, tech stack.
- Reference the attachment explicitly: "The attached file contains ...">
-
-# TASK
-<Numbered, single-responsibility task list. One deliverable per item.>
-
-# OUTPUT CONTRACT
-Respond in Markdown with EXACTLY these sections:
-## 1. <Analysis>
-## 2. <Deliverable>
-## 3. <Risks & Trade-offs>
-## 4. <Verification Checklist>
-Rules:
-- Output every file COMPLETE and VERBATIM in fenced code blocks with language tags.
-- No ellipses, no "rest unchanged", no placeholders.
-- Cite file paths and line ranges when discussing existing code.
-
-# SELF-VERIFICATION
-Before finishing, confirm all contract rules are satisfied; fix violations first.
-```
-
-### 3.3 Battle-tested prompt templates
-
-#### Template A — Code Audit (`prompt-with-attachment`, `timeout_sec: 600–900`)
-
-```markdown
-# ROLE
-You are a principal software auditor performing a production-readiness audit.
-
-# CONTEXT
-The attached file is a consolidated export of the target codebase.
-
-# TASK
-1. Identify correctness bugs, security issues, concurrency hazards, and error-handling gaps.
-2. Rate each finding: CRITICAL / HIGH / MEDIUM / LOW with file path + line reference.
-3. Provide a concrete fix (complete code) for every CRITICAL and HIGH finding.
-
-# OUTPUT CONTRACT
-## 1. Executive Summary (max 10 bullets)
-## 2. Findings Table (severity | location | category | description)
-## 3. Detailed Fixes (one subsection per CRITICAL/HIGH finding; complete patched code)
-## 4. Verification Checklist
-No truncation. Every fix must compile/run as-is.
-```
-
-#### Template B — Architecture Review (`prompt-with-attachment`, `timeout_sec: 900`)
-
-```markdown
-# ROLE
-You are a systems architect reviewing the attached design document.
-
-# TASK
-1. Reconstruct the implied architecture diagram in Mermaid.
-2. Evaluate: scalability, failure domains, data consistency, observability, security.
-3. Produce ADR-style recommendations (Context / Decision / Consequences) for each weakness.
-
-# OUTPUT CONTRACT
-## 1. Architecture Reconstruction (Mermaid)
-## 2. Strengths
-## 3. Weaknesses & Risks (ranked)
-## 4. ADR Recommendations (numbered)
-## 5. Verification Checklist
-```
-
-#### Template C — Multi-File Refactoring (`prompt-with-attachment`, `timeout_sec: 600–900`)
-
-```markdown
-# ROLE
-You are a senior engineer executing a surgical refactor.
-
-# CONTEXT
-Attached: consolidated export of all files in scope.
-Refactor goal: <state invariant-preserving goal, e.g. "extract I/O behind a protocol">.
-
-# TASK
-1. List every file that must change and why.
-2. Preserve public behavior; change only what the goal requires.
-3. Output the COMPLETE new content of every changed file.
-
-# OUTPUT CONTRACT
-## 1. Change Manifest (file | change | reason)
-## 2. Invariants Preserved
-## 3. Full File Contents (one fenced block per file, path as header comment)
-## 4. Migration & Test Plan
-## 5. Verification Checklist
-NEVER output partial files. Unchanged files must be listed, not re-emitted.
-```
-
-#### Template D — Bug Fix (`prompt-direct` or `prompt-only`, `timeout_sec: 300`)
-
-```markdown
-# ROLE
-You are a debugging specialist.
-
-# SYMPTOM
-<observed behavior + exact error message / stack trace>
-
-# EXPECTED
-<correct behavior>
-
-# REPRODUCTION
-<minimal steps or input>
-
-# CODE
-<paste the smallest relevant code section, or reference the attachment>
-
-# OUTPUT CONTRACT
-## 1. Root Cause Analysis (chain of causality, not guesses)
-## 2. Fix (complete corrected code, language-tagged fence)
-## 3. Regression Test (a test that fails before the fix, passes after)
-## 4. Verification Checklist
-```
-
-#### Template E — PR Summary (`prompt-with-attachment`, `timeout_sec: 300`)
-
-```markdown
-# ROLE
-You are a tech lead writing a review-ready PR description.
-
-# CONTEXT
-Attached: the full diff (or consolidated changed files).
-
-# OUTPUT CONTRACT
-## 1. What & Why (3–5 sentences)
-## 2. Change Breakdown (per-file: intent + notable hunks)
-## 3. Risk Assessment (behavior changes, migrations, feature flags)
-## 4. Test Plan (how this was / should be verified)
-## 5. Reviewer Focus Areas (max 5 bullets)
-```
-
----
-
-## 4. Resilience, Error Handling & Session Recovery
-
-### 4.1 Error → agent action matrix
-
-| Exception / MCP code | Meaning | Agent action | Retryable? |
-| :--- | :--- | :--- | :--- |
-| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-arwaky login`), then retry the original task | ✅ after login |
-| `OutputValidationError` w/ "verify you are human" | CAPTCHA / bot challenge | `setup_session` headed; human solves CAPTCHA; retry | ✅ after human |
-| `OutputValidationError` (502/504/service unavailable) | Transient server error | Back off 10–30s, retry once | ✅ |
-| `NetworkTimeoutError` | Browser network timeout | Retry with `timeout_sec × 2`; if repeated → `doctor` | ✅ |
-| `ResponseDetectionTimeoutError` | Dispatch succeeded but no answer detected | Retry with larger timeout; simplify prompt; check logs for last lifecycle event | ✅ |
-| `CircuitBreakerOpenError` | ≥5 failures within 30s window | **Stop.** Back off ≥30s, diagnose root cause, then resume | ⏸ after backoff |
-| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-arwaky update`, retry | ⚠️ |
-| `FileValidationError` | Attachment missing / unreadable / >100 MB | Fix path/permissions/size; retry | ✅ after fix |
-| `UploadFailureError` | Attachment could not be verified as uploaded | Retry once; if repeated, convert attachment to `.md`/`.txt` | ✅ |
-| `SendDispatchError` | Send click + Enter fallback both failed | Check parse-toast state; retry; `doctor` if repeated | ✅ |
-| `ModelSwitchError` | Default model `Qwen3.8-Max` could not be verified | Retry once; check account model access | ⚠️ |
-| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-arwaky update` | ✅ after fix |
-| `FILE_NOT_FOUND` / `VALIDATION_ERROR` (MCP) | Bad tool arguments | Fix the flagged `field` from the error envelope; never blind-retry | ❌ fix first |
-
-Built-in guardrails you inherit automatically: client-side rate limiter (60 req/min),
-circuit breaker (5 failures / 30s), upload retry with backoff (3 attempts), browser
-launch retry (3 attempts), stale-lock cleanup, and permission self-repair.
-
-### 4.2 Failure decision tree
-
-```
-Task returned an error / suspicious output
-│
-├─ Message contains "AUTH_REQUIRED", "login", "Not authenticated"?
-│  └─► setup_session → check_session → RETRY original task
-│
-├─ Message contains "CAPTCHA", "verify you are human", "Attention Required"?
-│  └─► setup_session (headed; human solves challenge) → check_session → RETRY
-│
-├─ CircuitBreakerOpenError?
-│  └─► STOP ≥ 30s → inspect app.jsonl for the repeated root cause
-│      → fix cause → resume slowly (1 task, verify, continue)
-│
-├─ NetworkTimeoutError / 5xx challenge text?
-│  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
-│      → still failing? run `qwen-web-arwaky doctor`, verify connectivity
-│
-├─ ResponseDetectionTimeoutError?
-│  └─► Check last lifecycle event in logs:
-│      • stopped before SEND_CLICKED → injection/send problem → retry, then `update`
-│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → keep waiting;
-│        only the 4-hour no-terminal-event circuit breaker stops the run
-│
-├─ Upload/File errors?
-│  └─► verify: exists · regular file · readable · ≤ 100 MB · .pdf/.md/.txt
-│      → RETRY once → if still failing, convert content to consolidated .md
-│
-├─ BrowserLaunchError / PromptInjectionError / ModelSwitchError?
-│  └─► `qwen-web-arwaky doctor` → `qwen-web-arwaky update` (package + Chromium sync) → RETRY
-│
-└─ MCP VALIDATION_ERROR / FILE_NOT_FOUND?
-   └─► read `error.field` + `error.hint`; correct arguments; do NOT retry unchanged
-```
-
-### 4.3 Session recovery procedure (canonical order)
-
-```
-1. check_session                          # cheap, headless validation
-2. valid?  ── yes ──► proceed
-        └── no ──► setup_session          # headed browser; user logs in;
-                                          # closing the browser triggers validation
-3. repeated CAPTCHA or corrupt profile?
-   ──► delete_session(confirm: true)      # wipes qwen_session/ (path-safety checked)
-   ──► setup_session                      # fresh profile
-4. check_session                          # MUST pass before resuming batch work
-```
-
-Session facts for agents:
-- Session lives in the OS data dir (`~/.local/share/qwen-web/qwen_session` on Linux,
-  `~/Library/Application Support/qwen-web` on macOS, `%LOCALAPPDATA%\qwen-web` on Windows).
-- `setup_session` reuses an already-valid session without opening a browser.
-- Directory permissions (`0700`) and Chromium lock files self-heal on every launch.
-- `delete_session` refuses unsafe paths and requires explicit `confirm: true`.
-
----
-
-## 5. Best Practices for Power Users & Autonomous Agents
-
-### 5.1 Choosing the right surface
-
-| Surface | Use when | Notes |
+| Action | MCP Tool | CLI Command (`qwa` / `qwen-web-arwaky`) |
 | :--- | :--- | :--- |
-| **MCP tools** | Agent-loop integration (Claude Desktop, Cursor, Antigravity, Gemini CLI) | Structured JSON envelopes, `retryable` hints, per-field validation errors |
-| **CLI subcommands** | CI/CD, shell scripts, cron, chained pipelines | `--json` for parsing; deterministic exit codes |
-| **Interactive TUI** | Human-supervised debugging | Live log streaming, file picker, one-keystroke run/login/init/reset |
+| Direct text prompt | `process_direct_prompt` | `qwa prompt-direct -t "<prompt>" [-o <out>]` |
+| Prompt file only | `process_prompt_file_only` | `qwa prompt-only -i <prompt.md> [-o <out>]` |
+| Prompt with attachment | `process_prompt_with_attachment` | `qwa prompt-with-attachment -i <prompt.md> -a <file> [-o <out>]` |
+| Check session health | `check_session` | `qwa doctor` |
+| Manual login / CAPTCHA | `setup_session` | `qwa login` |
+| Reset session | `delete_session` | — |
+| Initialize workspace | `init_workspace` | `qwa init` |
 
-MCP client registration (Claude Desktop / Cursor style):
+> **File conventions:** Place inputs under `.qwen-web/input/` and outputs under `.qwen-web/output/`. Always append a timestamp to output filenames (e.g., `arch_review_$(date +%Y%m%d_%H%M%S).md` in CLI or `YYYYMMDD_HHMMSS` in MCP) to prevent overwriting results from previous runs.
 
+---
+
+## 2. Usage by Use Case
+
+### Use Case 1: Quick Inline Prompt / Question
+Use for fast queries, factual explanations, or one-off code generation where no external files are needed.
+
+**MCP:**
 ```json
 {
-  "mcpServers": {
-    "qwen-web": {
-      "command": "qwen-web-arwaky",
-      "args": ["mcp"]
-    }
-  }
+  "prompt": "Explain the difference between optimistic and pessimistic locking in 3 concise bullet points with a brief Python example.",
+  "headless": true
 }
 ```
 
-### 5.2 Combining CLI + MCP in one workflow
-
-1. **Bootstrap (once per machine, human-supervised):**
-   `qwen-web-arwaky doctor` → `qwen-web-arwaky login` → `qwen-web-arwaky init`
-2. **Autonomous steady state (agent via MCP):**
-   `check_session` → `process_*` tools → verify `.meta.json` → chain next task.
-3. **Recovery (agent escalates to CLI/human):**
-   `setup_session` for CAPTCHA; `qwen-web-arwaky update` for UI drift; `doctor --json` for diagnostics.
-
-### 5.3 File attachment strategy
-
-- **Consolidated code exports (`.md`)** are the highest-value attachment: one file,
-  exact filenames preserved, parsed fast. Prefer exporting the whole module into one
-  Markdown bundle over many small files (one attachment per run).
-- **PDF** for specs/PRDs/contracts; **TXT/MD** for logs, diffs, and data.
-- Keep attachments **≤ 100 MB**; split or summarize beyond that.
-- Upload verification matches the **exact filename** in the Qwen DOM — avoid exotic
-  characters in filenames; whitespace-normalized exact names parse most reliably.
-- Parsing may take up to 120s for large documents — the send gate waits automatically;
-  never "fix" a slow start by killing the run before 120s.
-
-### 5.4 Operational hygiene for autonomous loops
-
-1. **Pre-flight:** `check_session` once per agent session start, not per task.
-2. **Serialize** all executions (single persistent browser profile per machine).
-3. **Verify outputs:** success string or `success: true` envelope **and**
-   `output_chars > 0` in `.meta.json`; treat `ERROR [...]` result strings as failures.
-4. **Respect backoff:** on any `retryable: false` error, stop and surface the `hint`
-   to the user instead of looping.
-5. **Log forensics:** `app.jsonl` (JSONL events) + `status.json` (machine-readable run
-   state) live in the OS state dir (`~/.local/state/qwen-web/log` on Linux).
-6. **Keep the engine current:** `qwen-web-arwaky update --check` regularly; run
-7. **Headless discipline:** keep `headless: true` for all production tasks; headed
-   browsers are exclusively for `login` / `setup_session` / CAPTCHA resolution.
-
-### 5.5 Orphan processes & safe cleanup (read before killing anything)
-
-- **Never `pkill -9`/`kill -9` a qwen run as a first resort.** Hard-killing the CLI
-  does **not** close the Playwright Chromium it spawned — the browser keeps running
-  as an orphan, holds the shared `qwen_session` profile lock, and breaks every
-  subsequent run (`TargetClosedError`, hung dispatch, silent no-op). This is the
-  single most common cause of "it worked before, now it hangs".
-- **Symptoms of an orphan:** a new run starts but the page never acts; `EVENT_*`
-  stops right after `DISPATCH_ACKNOWLEDGED`; a second Chromium process lingers after
-  the CLI already exited; `TargetClosedError: Page.wait_for_timeout`.
-- **Safe cleanup order:**
-  1. Prefer letting the run finish — completion is event-driven; the only
-     automatic stop is the 4-hour no-terminal-event safety circuit breaker.
-  2. Prefer in-app cancellation (TUI **Cancel Run**; MCP has no cancel — wait).
-  3. Only as a last resort, kill the **exact PID** of the CLI process
-     (`kill <pid>`, not `pkill -9 -f`), then verify with
-     `ps aux | grep -E "chrome.*qwen_session"` that no orphan Chromium remains;
-     kill remaining orphan Chromium PIDs individually.
-  4. After any hard kill, **wait 2–3s** and confirm zero lingering
-     `chrome.*qwen_session` processes before starting the next run.
-- **Always run one pipeline at a time** on the shared profile; concurrent launches
-  collide and look identical to orphan-related hangs.
-
-### 5.6 Quick troubleshooting table
-
-| Symptom | Likely cause | Fix |
-| :--- | :--- | :--- |
-| Run dies at `EVENT_LOGIN_VERIFIED` gate | Expired cookies | `setup_session` |
-| Long run returns partial/short text | Challenge page captured | Read output; apply §5.2 tree |
-| "Default model not active" | Model picker drift | Retry; `update`; verify account access to `Qwen3.8-Max` |
-| Attachment never sends | Backend parse slow / toast | Wait ≥120s; retry; shrink file |
-| Nothing happens, no logs | Chromium missing | `doctor`; `python3 -m playwright install chromium` |
-| Two runs collide | Concurrent launches | Serialize — one pipeline at a time |
+**CLI:**
+```bash
+qwa prompt-direct -t "Explain optimistic vs pessimistic locking" -o .qwen-web/output/locking_$(date +%Y%m%d_%H%M%S).md --headless
+```
 
 ---
 
-*End of skill guide. Emit complete requests, verify every envelope, and let the
-terminal lifecycle event—not elapsed time—decide when output is complete.*
+### Use Case 2: Complex Task from a Prompt File
+Use for multi-step instructions, complex refactor specs, or long prompts authored in a Markdown file.
+
+**MCP:**
+```json
+{
+  "input_file": ".qwen-web/input/refactor_task.md",
+  "output_file": ".qwen-web/output/refactor_result_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-only -i .qwen-web/input/refactor_task.md -o .qwen-web/output/refactor_result_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 3: Code Audit or Document Analysis with Attachment
+Use when the prompt requires analyzing a codebase export, technical document, log file, or PDF spec (supported: `.pdf`, `.md`, `.txt` up to 100 MB).
+
+**MCP:**
+```json
+{
+  "prompt_file": ".qwen-web/input/audit_spec.md",
+  "attachment_file": ".qwen-web/input/codebase_export.md",
+  "output_file": ".qwen-web/output/audit_findings_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-with-attachment -i .qwen-web/input/audit_spec.md -a .qwen-web/input/codebase_export.md -o .qwen-web/output/audit_findings_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 4: Standard Reviews Using Built-in Role Templates
+Instead of writing a custom prompt file, you can pass a built-in role template name directly as the prompt input:
+- `backend`: Security, performance, error handling, code quality, and maintainability.
+- `architect`: Layer boundaries, architecture violations, scalability, and data flow.
+- `frontend`: Usability, responsive layout, component quality, and design tokens.
+- `analyst`: Requirements clarity, business logic flow, and testability.
+
+**MCP:**
+```json
+{
+  "prompt_file": "backend",
+  "attachment_file": "src/api/auth.py",
+  "output_file": ".qwen-web/output/auth_review_20260911_133000.md"
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-with-attachment -i backend -a src/api/auth.py -o .qwen-web/output/auth_review_$(date +%Y%m%d_%H%M%S).md --headless
+qwa prompt-with-attachment -i architect -a README.md -o .qwen-web/output/arch_review_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 5: Session Setup & Authentication
+Use to verify login status or authenticate a new browser session when cookies expire.
+
+1. **Check session health:**
+   - MCP: call `check_session`
+   - CLI: `qwa doctor`
+2. **Login / Re-authenticate (opens visible browser for login / CAPTCHA):**
+   - MCP: call `setup_session`
+   - CLI: `qwa login`
+3. **Reset session profile (if corrupted):**
+   - MCP: `delete_session` with `{"confirm": true}`
+
+---
+
+### Use Case 6: Workspace Initialization
+Use when provisioning `.qwen-web/` workspace directories and sample configuration in a new project.
+
+**MCP:**
+```json
+{
+  "target_dir": "."
+}
+```
+
+**CLI:**
+```bash
+qwa init
+```
+
+---
+
+## 3. Prompt Engineering for Complete, Un-Truncated Output
+
+To ensure Qwen produces complete code without placeholders or omitted sections:
+
+1. **Specify an explicit Output Contract:** Define exact required section titles and expected markdown formatting.
+2. **Forbid truncation explicitly:** Include this clause in your prompt:
+   > *"Output every file COMPLETE and VERBATIM inside fenced code blocks with language tags. Never use ellipses (`...`), placeholder comments (`// rest unchanged`), or omit code."*
+3. **Reason first, code second:** Request an analysis or plan before the implementation code so the model thinks before writing.
+4. **Put large context into attachments:** Keep the prompt file focused on instructions; provide code, logs, and schemas as attachments.
+5. **Add a self-verification step:** Instruct the model to verify that no placeholders exist and all requested items are satisfied before completing.
+
+---
+
+## 4. Error Handling & Recovery
+
+| Error / Condition | Cause | Action |
+| :--- | :--- | :--- |
+| `AuthRequiredError` / `AUTH_REQUIRED` | Session expired or login needed | Call `setup_session` (MCP) or run `qwa login` (CLI) to re-authenticate. |
+| `OutputValidationError` (CAPTCHA) | Bot verification challenge | Run `setup_session` or `qwa login` to solve challenge manually. |
+| `NetworkTimeoutError` | Temporary network latency | Retry the request; if persistent, verify internet connection via `qwa doctor`. |
+| `FileValidationError` / `FILE_NOT_FOUND` | Missing, unreadable, or file > 100 MB | Verify file path, permissions, and ensure file size is under 100 MB. |
+| `CircuitBreakerOpenError` | Repeated consecutive failures | Wait 30 seconds before sending next request. |
+| `VALIDATION_ERROR` (MCP) | Invalid tool parameter | Check error `field` in response and correct the argument payload. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,120 +1,178 @@
 ---
 name: qwen-web
-description: Automate Qwen AI Web (chat.qwen.ai) prompt processing via CLI or MCP tools without requiring official API keys.
----
-# Qwen Web Automation & MCP Server Skill Guide
-
-Use this skill when an AI agent needs to send prompts or document files to **Qwen AI (`chat.qwen.ai`)** and receive generated AI responses via MCP tools or CLI execution.
-
----
-
-## Available MCP Tools
-
-| MCP Tool Name               | Description                                      | Key Parameters                                                                                  |
-| :-------------------------- | :----------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `process_direct_prompt`     | Process a direct text prompt string              | `prompt` (str), `timeout_sec` (int, default 120), `headless` (bool, default true)               |
-| `process_prompt_file_only`  | Process a single Markdown prompt file            | `input_file` (str), `output_file` (optional str), `headless` (bool)                             |
-| `process_prompt_with_attachment` | Process a prompt file with a document attachment | `prompt_file` (str), `attachment_file` (str), `output_file` (optional str), `headless` (bool) |
-| `setup_session`             | Launch visible browser for manual login          | None                                                                                            |
-
+description: >
+  Automate Qwen AI Web (chat.qwen.ai) with the Qwen3.8-Max intelligence model —
+  zero API keys, persistent browser sessions. Use when an AI agent needs to send
+  prompts, review code, or analyze document attachments via CLI or MCP tools.
+version: 6.0.0
+triggers:
+  - qwen
+  - chat.qwen.ai
+  - prompt automation
+  - code audit
+  - architecture review
+  - deep reasoning
+  - document analysis
+  - no api key
+entry_points: [qwen-web-arwaky, qwa, qwen-web-mcp]
 ---
 
-## Usage Guidelines for AI Agents
+# Qwen Web Automation Skill Guide
 
-### Direct Text Queries (`process_direct_prompt`)
+Use this skill when an AI agent needs to send prompts or document files to **Qwen AI (`chat.qwen.ai`)** and receive complete responses via MCP tools or CLI commands.
 
-Use for one-shot prompts where text is provided directly. Supports long deep-thinking prompts up to 900s (15 min) with proactive 30s cloud reload sync for network resilience.
+---
 
+## 1. Quick Reference: MCP Tools & CLI Commands
+
+| Action | MCP Tool | CLI Command (`qwa` / `qwen-web-arwaky`) |
+| :--- | :--- | :--- |
+| Direct text prompt | `process_direct_prompt` | `qwa prompt-direct -t "<prompt>" [-o <out>]` |
+| Prompt file only | `process_prompt_file_only` | `qwa prompt-only -i <prompt.md> [-o <out>]` |
+| Prompt with attachment | `process_prompt_with_attachment` | `qwa prompt-with-attachment -i <prompt.md> -a <file> [-o <out>]` |
+| Check session health | `check_session` | `qwa doctor` |
+| Manual login / CAPTCHA | `setup_session` | `qwa login` |
+| Reset session | `delete_session` | — |
+| Initialize workspace | `init_workspace` | `qwa init` |
+
+> **File conventions:** Place inputs under `.qwen-web/input/` and outputs under `.qwen-web/output/`. Always append a timestamp to output filenames (e.g., `arch_review_$(date +%Y%m%d_%H%M%S).md` in CLI or `YYYYMMDD_HHMMSS` in MCP) to prevent overwriting results from previous runs.
+
+---
+
+## 2. Usage by Use Case
+
+### Use Case 1: Quick Inline Prompt / Question
+Use for fast queries, factual explanations, or one-off code generation where no external files are needed.
+
+**MCP:**
 ```json
 {
-  "prompt": "Analyze the following system architecture and summarize key bottlenecks...",
-  "timeout_sec": 120,
+  "prompt": "Explain the difference between optimistic and pessimistic locking in 3 concise bullet points with a brief Python example.",
   "headless": true
 }
 ```
 
-### File Processing (`process_prompt_file_only`)
-
-Use when processing an existing Markdown prompt file stored on disk.
-
-```json
-{
-  "input_file": "input/role-architect/task_001.md",
-  "output_file": "output/role-architect/task_001.md"
-}
-```
-
-### File Processing With Attachment (`process_prompt_with_attachment`)
-
-Use when the prompt file must be sent together with a document attachment.
-
-```json
-{
-  "prompt_file": "input/role-architect/task_001.md",
-  "attachment_file": "input/role-architect/docs/spec.pdf",
-  "output_file": "output/role-architect/task_001.md"
-}
-```
-
-### Parallel Job Execution
-
-Multiple prompt jobs can run concurrently against one authenticated browser session. Each worker job launches its own dedicated Chromium browser instance using an isolated ephemeral clone of the master login session profile, enabling N jobs to run in parallel without tab collisions or SingletonLock conflicts.
-
-- **Concurrency limit**: controlled by `QWEN_WEB_MAX_WORKERS` (default 2). Set higher to increase throughput; all workers share the same authenticated login session.
-- **Isolated processes**: 1 browser process per job with clean ephemeral state; temporary profile clones are automatically purged on completion.
-- **Login mode**: `setup_session` operates directly on the master session profile so authenticated credentials persist across runs.
-
+**CLI:**
 ```bash
-# Run 4 prompt files concurrently (2 at a time by default):
-QWEN_WEB_MAX_WORKERS=4 qwa process input/task_001.md input/task_002.md input/task_003.md input/task_004.md
+qwa prompt-direct -t "Explain optimistic vs pessimistic locking" -o .qwen-web/output/locking_$(date +%Y%m%d_%H%M%S).md --headless
 ```
 
-### Built-in Role Prompt Templates
+---
 
-Instead of creating a Markdown prompt file manually, you can pass a built-in role template name wherever a prompt file path is accepted (`input_file`, `prompt_file`, or CLI `-i` / `--prompt-path`):
-- `architect`: Layer Boundaries, Naming, Orphan, Scalability, Data Flow
-- `backend`: Security, Performance, Error Handling, SOLID, Code Quality, Maintainability
-- `frontend`: Accessibility & Usability, Layout & Responsiveness, UX Patterns & User Flow, Component / Module Quality, Visual Consistency & Design Tokens, Performance
-- `analyst`: Requirements Clarity, Business Flow, Logic Implementation, Testability, Traceability
+### Use Case 2: Complex Task from a Prompt File
+Use for multi-step instructions, complex refactor specs, or long prompts authored in a Markdown file.
 
-#### MCP Example (Attachment Review with Role Template)
+**MCP:**
+```json
+{
+  "input_file": ".qwen-web/input/refactor_task.md",
+  "output_file": ".qwen-web/output/refactor_result_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-only -i .qwen-web/input/refactor_task.md -o .qwen-web/output/refactor_result_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 3: Code Audit or Document Analysis with Attachment
+Use when the prompt requires analyzing a codebase export, technical document, log file, or PDF spec (supported: `.pdf`, `.md`, `.txt` up to 100 MB).
+
+**MCP:**
+```json
+{
+  "prompt_file": ".qwen-web/input/audit_spec.md",
+  "attachment_file": ".qwen-web/input/codebase_export.md",
+  "output_file": ".qwen-web/output/audit_findings_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-with-attachment -i .qwen-web/input/audit_spec.md -a .qwen-web/input/codebase_export.md -o .qwen-web/output/audit_findings_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 4: Standard Reviews Using Built-in Role Templates
+Instead of writing a custom prompt file, you can pass a built-in role template name directly as the prompt input:
+- `backend`: Security, performance, error handling, code quality, and maintainability.
+- `architect`: Layer boundaries, architecture violations, scalability, and data flow.
+- `frontend`: Usability, responsive layout, component quality, and design tokens.
+- `analyst`: Requirements clarity, business logic flow, and testability.
+
+**MCP:**
 ```json
 {
   "prompt_file": "backend",
-  "attachment_file": "src/api/auth.py"
+  "attachment_file": "src/api/auth.py",
+  "output_file": ".qwen-web/output/auth_review_20260911_133000.md"
 }
 ```
 
-#### CLI Example
+**CLI:**
 ```bash
-# Code review with backend template and attachment
-qwen-web-arwaky prompt-with-attachment -i backend -a src/auth.py --headless --json
-
-# Architecture review
-qwen-web-arwaky prompt-with-attachment -i architect -a README.md --headless --json
+qwa prompt-with-attachment -i backend -a src/api/auth.py -o .qwen-web/output/auth_review_$(date +%Y%m%d_%H%M%S).md --headless
+qwa prompt-with-attachment -i architect -a README.md -o .qwen-web/output/arch_review_$(date +%Y%m%d_%H%M%S).md --headless
 ```
 
-### Session Authentication (`setup_session`)
+---
 
-If session cookies expire or CAPTCHA is detected, invoke `setup_session` to launch a visible browser window for manual user login.
+### Use Case 5: Session Setup & Authentication
+Use to verify login status or authenticate a new browser session when cookies expire.
+
+1. **Check session health:**
+   - MCP: call `check_session`
+   - CLI: `qwa doctor`
+2. **Login / Re-authenticate (opens visible browser for login / CAPTCHA):**
+   - MCP: call `setup_session`
+   - CLI: `qwa login`
+3. **Reset session profile (if corrupted):**
+   - MCP: `delete_session` with `{"confirm": true}`
 
 ---
 
-## Error Handling for Agents
+### Use Case 6: Workspace Initialization
+Use when provisioning `.qwen-web/` workspace directories and sample configuration in a new project.
 
-| Exception | Meaning | Agent Action |
+**MCP:**
+```json
+{
+  "target_dir": "."
+}
+```
+
+**CLI:**
+```bash
+qwa init
+```
+
+---
+
+## 3. Prompt Engineering for Complete, Un-Truncated Output
+
+To ensure Qwen produces complete code without placeholders or omitted sections:
+
+1. **Specify an explicit Output Contract:** Define exact required section titles and expected markdown formatting.
+2. **Forbid truncation explicitly:** Include this clause in your prompt:
+   > *"Output every file COMPLETE and VERBATIM inside fenced code blocks with language tags. Never use ellipses (`...`), placeholder comments (`// rest unchanged`), or omit code."*
+3. **Reason first, code second:** Request an analysis or plan before the implementation code so the model thinks before writing.
+4. **Put large context into attachments:** Keep the prompt file focused on instructions; provide code, logs, and schemas as attachments.
+5. **Add a self-verification step:** Instruct the model to verify that no placeholders exist and all requested items are satisfied before completing.
+
+---
+
+## 4. Error Handling & Recovery
+
+| Error / Condition | Cause | Action |
 | :--- | :--- | :--- |
-| `AuthRequiredError` | Session expired or CAPTCHA detected | Call `setup_session` for re-authentication |
-| `NetworkTimeoutError` | Browser network timeout | Retry with increased `timeout_sec` |
-| `OutputValidationError` | Response contains error page or CAPTCHA | Retry or check input quality |
-| `CircuitBreakerOpenError` | Too many consecutive failures | Wait and retry later |
-| `PromptInjectionError` | Text injection failed | Check if Qwen UI has changed |
-
----
-
-## Session Management
-
-- Session cookies stored in `qwen_session/` (persistent across runs).
-- First run requires `--login` or interactive mode for manual authentication.
-- Subsequent runs can use `--headless` mode.
-- Session health checked automatically before each file processing.
+| `AuthRequiredError` / `AUTH_REQUIRED` | Session expired or login needed | Call `setup_session` (MCP) or run `qwa login` (CLI) to re-authenticate. |
+| `OutputValidationError` (CAPTCHA) | Bot verification challenge | Run `setup_session` or `qwa login` to solve challenge manually. |
+| `NetworkTimeoutError` | Temporary network latency | Retry the request; if persistent, verify internet connection via `qwa doctor`. |
+| `FileValidationError` / `FILE_NOT_FOUND` | Missing, unreadable, or file > 100 MB | Verify file path, permissions, and ensure file size is under 100 MB. |
+| `CircuitBreakerOpenError` | Repeated consecutive failures | Wait 30 seconds before sending next request. |
+| `VALIDATION_ERROR` (MCP) | Invalid tool parameter | Check error `field` in response and correct the argument payload. |

--- a/modules/shared/src/taxonomy_skill_constant.py
+++ b/modules/shared/src/taxonomy_skill_constant.py
@@ -9,14 +9,10 @@ EMBEDDED_SKILL_MD: str = r"""---
 name: qwen-web
 description: >
   Automate Qwen AI Web (chat.qwen.ai) with the Qwen3.8-Max intelligence model —
-  zero API keys, zero paid quota, persistent browser sessions.
-  USE THIS SKILL when an AI agent must: send prompts to Qwen and capture the full
-  un-truncated answer; audit, review, refactor, or generate production code;
-  analyze documents (PDF/MD/TXT attachments); run long deep-reasoning software
-  engineering tasks (up to 15 minutes); or manage Qwen login sessions — via the
-  qwen-web-arwaky CLI or MCP tools.
-version: 5.2.0
-trigger_keywords:
+  zero API keys, persistent browser sessions. Use when an AI agent needs to send
+  prompts, review code, or analyze document attachments via CLI or MCP tools.
+version: 6.0.0
+triggers:
   - qwen
   - chat.qwen.ai
   - prompt automation
@@ -28,489 +24,163 @@ trigger_keywords:
 entry_points: [qwen-web-arwaky, qwa, qwen-web-mcp]
 ---
 
-# Qwen Web Automation — Master-Class Agent Harness
+# Qwen Web Automation Skill Guide
 
-> **Purpose.** This skill turns `qwen-web-arwaky` into a deterministic, production-grade
-> LLM backend for autonomous AI agents. It covers every MCP tool, every CLI subcommand,
-> prompt-engineering contracts for complete un-truncated output, multi-role engineering
-> workflows, and a full resilience decision tree.
->
-> **Prime directive for agents:** treat Qwen3.8-Max as your deep-reasoning engine.
-> Structure every request with an explicit *Output Contract*, pick the correct timeout
-> band, and always verify the output envelope before consuming results.
+Use this skill when an AI agent needs to send prompts or document files to **Qwen AI (`chat.qwen.ai`)** and receive complete responses via MCP tools or CLI commands.
 
 ---
 
-## 1. Core Capabilities & Architecture Summary
+## 1. Quick Reference: MCP Tools & CLI Commands
 
-### 1.1 What makes this engine different
-
-| Capability | Implementation detail |
-| :--- | :--- |
-| **Qwen3.8-Max by default** | The pipeline **forces and verifies** the hardcoded default model (`Qwen3.8-Max`) on every session before dispatch. The agent never picks a model manually; a `ModelSwitchError` aborts the run if the model cannot be confirmed active. |
-| **Zero API key** | Authentication is a real Chromium browser session (persistent cookies in `qwen_session/`). No tokens, no billing, no quota. |
-| **Zero-truncation extraction (Tier-1 React Fiber)** | Response capture walks the React Fiber tree (`__reactFiber` → `memoizedProps.content`, up to 30 levels) to recover **100% of raw Markdown**, including code blocks that Monaco Editor virtualization would clip in the visible DOM. |
-| **Tier-2 DOM Tree Walker fallback** | A block-aware tree walker (preserves `PRE`/code formatting, strips UI chrome, buttons, copy widgets) guarantees extraction even when Fiber props are absent. |
-| **30s cloud reload sync** | While waiting for a terminal event, the page is reloaded every 30 seconds to re-sync Qwen Cloud streaming state — long generations survive network drops and tab throttling. |
-| **Event-driven long-run monitor** | The stream monitor has no elapsed-time response cutoff. It waits for terminal generation state and keeps recovery polling alive for long-running jobs. |
-| **Terminal-event completion** | A response is accepted only after stable text and an explicit generation-complete signal; stability alone can never terminate an unfinished response. |
-| **Self-healing browser sessions** | Automatic stale `SingletonLock` cleanup, session directory permission repair (`0700`), 3-attempt launch retry with backoff. |
-| **Multi-strategy input injection** | Playwright `fill` → React native value-setter (with `_valueTracker` reset) → `type()` keystroke fallback. |
-| **Parse-gated dispatch** | The send button is held until document parsing is positively verified (network `files/parse` 200 + DOM spinner/toast clearance). Prompts are never dispatched onto half-parsed attachments. |
-| **Atomic, traceable output** | Outputs are written atomically with a METADATA TRACEABILITY header and a `.meta.json` sidecar (`run_id`, `duration_sec`, `input_chars`, `output_chars`). |
-| **Full observability** | Structured JSONL logs (`app.jsonl`), `status.json` for monitoring, optional Sentry + OpenTelemetry tracing, lifecycle event stream with strict predecessor gating. |
-
-### 1.2 Layered architecture
-
-```
-┌─ SURFACE (thin, zero business logic) ─────────────────────────────────┐
-│  CLI surfaces: init / login / doctor / update / run / TUI controller  │
-│  MCP surface : surface_mcp_tool_command (stdio JSON-RPC tools)        │
-├─ CORE AGENTS (5 orchestrators) ───────────────────────────────────────┤
-│  DirectPromptOrchestrator · PromptFileOrchestrator ·                  │
-│  AttachmentPromptOrchestrator · SessionOrchestrator · SetupOrchestrator│
-├─ CAPABILITIES ────────────────────────────────────────────────────────┤
-│  BrowserAdapter · PromptInjector · SendDispatcher · StreamMonitor ·   │
-│  FileUploader · Saver · ObservabilitySetup · UpdateManager · Workspace│
-├─ SHARED (taxonomy / contract / utility) ──────────────────────────────┤
-│  Constants · VOs · Entities (CircuitBreaker, RateLimiter, Lifecycle) ·│
-│  Events · Errors · Protocols (DI contracts) · Pure utilities          │
-└───────────────────────────────────────────────────────────────────────┘
-```
-
-### 1.3 Lifecycle event sequence (observability contract)
-
-Every run emits this strictly-ordered event chain (enforced by `LifecycleGate` —
-out-of-order events are rejected with an auditable reason in the logs):
-
-```
-EVENT_WEB_LOADED → EVENT_LOGIN_VERIFIED → EVENT_MODEL_VERIFIED
-  → [EVENT_FILE_UPLOADED → EVENT_DOCUMENT_PARSED]   (attachment pipeline only)
-  → EVENT_PROMPT_INJECTED → EVENT_SEND_CLICKED → EVENT_DISPATCH_ACKNOWLEDGED
-  → EVENT_THINKING_STARTED → EVENT_STREAMING_GENERATION → EVENT_GENERATION_FINISHED
-  → EVENT_OUTPUT_COPIED
-```
-
-**Agent debugging rule:** when a run fails, find the *last successfully emitted event*
-in `app.jsonl` — the failure always lives in the capability owning the *next* event.
-
----
-
-## 2. Complete MCP Tool Reference
-
-All tools speak stdio MCP and return structured JSON envelopes:
-
-- **Success:** `{"success": true, "status": "SUCCESS", "result": "...", "output_path": "...", "run_id": "..."}`
-- **Failure:** `{"success": false, "error": {"code", "message", "hint", "retryable", "field"}}`
-
-### 2.1 Tool matrix
-
-| MCP Tool | Purpose | Required params | Optional params (defaults) |
-| :--- | :--- | :--- | :--- |
-| `process_direct_prompt` | One-shot inline text prompt → AI answer | `prompt` (str) | `timeout_sec` (int, **120**), `headless` (bool, **true**) |
-| `process_prompt_file_only` | Prompt from a `.md` file on disk, no attachment | `input_file` (str) | `output_file` (str, **null** → auto), `headless` (bool, **true**) |
-| `process_prompt_with_attachment` | Prompt file + document attachment (PDF/MD/TXT) | `prompt_file` (str), `attachment_file` (str) | `output_file` (str, **null** → auto), `headless` (bool, **true**) |
-| `check_session` | Validate saved session cookies | — | — |
-| `setup_session` | Open visible browser for manual login / CAPTCHA | — | — |
-| `delete_session` | Wipe saved session profile | — | `confirm` (bool, **false** — MUST be `true`) |
-| `init_workspace` | Create `.qwen-web/`, skill guide, samples, `.gitignore` | — | `target_dir` (str, **"."**) |
-
-### 2.2 Exact invocation payloads
-
-> **📁 Workspace rule: put ALL prompt/attachment/output files under `.qwen-web/`**
-> (`qwen-web-arwaky init` creates it in the cwd — already `.gitignore`d). Use
-> `.qwen-web/input/...` and `.qwen-web/output/...`; NEVER create a bare `input/`
-> or `output/` folder in the repo root. `output/` inside `.qwen-web/` is a symlink
-> to the XDG output dir, so results persist outside the repo.
-
-```json
-// Fast factual query (completion is event-driven; duration is not a cutoff)
-{ "prompt": "List the 5 SOLID principles in one line each.",
-  "timeout_sec": 60, "headless": true }
-
-// Standard engineering task (timeout_sec remains an optional compatibility hint)
-{ "input_file": ".qwen-web/input/role-fullstack-developer/todo/task_042.md",
-  "output_file": ".qwen-web/output/role-fullstack-developer/task_042.md",
-  "headless": true }
-
-// Deep reasoning with document context (no response-duration cutoff)
-{ "prompt_file": ".qwen-web/input/role-architect/todo/review_spec.md",
-  "attachment_file": ".qwen-web/input/role-architect/docs/system_spec.pdf",
-  "output_file": ".qwen-web/output/role-architect/review_spec.md",
-  "headless": true }
-```
-
-### 2.3 Event-Driven Long-Running Lifecycle
-
-Response completion is **event-driven**, not duration-driven. The historical `timeout_sec` input remains an observability hint for API compatibility, but it is not used to cut off a Qwen response.
-
-- **Terminal event as source of truth**: The monitor waits for stable response text plus an explicit generation-complete state.
-- **Long-running recovery**: Every 30 seconds the browser can reload to resynchronize cloud state. Browser operation timeouts trigger recovery and continue waiting instead of reporting success or truncating the response.
-- **Output-written success gate**: The pipeline emits `EVENT_OUTPUT_COPIED` only after the saver returns and the target output file is verified as readable and non-empty. CLI success/exit code `0` is downstream of that event.
-- **24-hour operation target**: A persistent host can keep the process alive for 24 hours or longer. Normal completion remains event-driven; a separate **4-hour safety circuit breaker** only stops a run that has produced no terminal event at all, preventing infinite hangs and resource exhaustion.
-- **Parse-Gated Dispatch**: Document parsing is held automatically until backend `/files/parse` 200 OK is confirmed before sending.
-- **Maximum Attachment Size**: **100 MB** (pre-flight validated).
-
-> **⚠️ NEVER wrap runs in an external timeout** (`timeout N`, shell alarm, CI job timeout, agent-loop kill). The engine owns its own timing: killing a run from outside with `timeout`/`pkill` leaves the Chromium process and page orphaned, corrupts the shared browser profile, and causes the NEXT run to fail with `TargetClosedError` or silent hang. If a run looks stuck, verify it is actually still generating (see §5.6) before considering any intervention — and the only safe interventions are letting it finish or cleanly cancelling via the TUI **Cancel Run** button.
-
-### 2.4 CLI reference (equivalent surface for scripting & CI)
-
-```bash
-# Primary command: qwa (or qwen-web-arwaky)
-qwa doctor [--json]                        # environment health checks
-qwa init [--dir TARGET]                    # workspace provisioning (.qwen-web/ in cwd)
-qwa login                                  # headed manual login / CAPTCHA
-qwa update [--check] [--force]             # self-update + Chromium sync
-qwa prompt-direct -t "..." [-o OUT] [--headless] [--json]
-qwa prompt-only   -i .qwen-web/input/PROMPT.md [-o OUT] [--headless] [--json]
-qwa prompt-with-attachment -i .qwen-web/input/PROMPT.md -a FILE [-o OUT] [--headless] [--json]
-qwen-web-arwaky mcp                                    # run MCP server over stdio
-```
-
-Paths: always use `.qwen-web/input/...` for prompts/attachments and
-`.qwen-web/output/...` for results — never bare `input/`/`output/` in the repo root.
-
-Exit codes: `0` success · `1` generic error · `2` `AuthRequiredError` · `130` interrupted.
-Use `--json` in pipelines for machine-readable envelopes.
-
----
-
-## 3. Prompt Engineering & Output Quality Harness
-
-### 3.1 The five laws of complete, un-truncated output
-
-1. **State an explicit Output Contract.** List exact section headings, required code
-   fences, and formatting rules. Qwen3.8-Max follows structural contracts with high
-   fidelity — vague asks produce vague output.
-2. **Ban truncation in writing.** Always include: *"Output every file COMPLETE and
-   VERBATIM inside fenced code blocks. Never use ellipses (`...`), placeholder
-   comments (`// rest unchanged`), or references to omitted code."*
-3. **Reason first, produce second.** Ask for a compact analysis section *before* the
-   deliverable. This spends the model's deep-reasoning budget on understanding; the
-   event-driven monitor waits for the full response (no fixed watchdog cutoff).
-4. **Move bulk into attachments.** Prompt files should carry *instructions*; large
-   code, specs, and diffs belong in attachments (PDF/MD/TXT ≤ 100 MB). Use one
-   consolidated attachment per run (exactly one attachment is supported per execution).
-5. **Demand a self-verification checklist.** End every prompt with: *"Before finishing,
-   verify: (a) every requested section exists, (b) all code blocks are complete and
-   syntactically valid, (c) no placeholders remain. If any check fails, fix before
-   answering."*
-
-### 3.2 Canonical prompt-file skeleton
-
-```markdown
-# ROLE
-You are a principal <ROLE> working on <SYSTEM>.
-
-# CONTEXT
-<2–6 sentences: what the system is, constraints, tech stack.
- Reference the attachment explicitly: "The attached file contains ...">
-
-# TASK
-<Numbered, single-responsibility task list. One deliverable per item.>
-
-# OUTPUT CONTRACT
-Respond in Markdown with EXACTLY these sections:
-## 1. <Analysis>
-## 2. <Deliverable>
-## 3. <Risks & Trade-offs>
-## 4. <Verification Checklist>
-Rules:
-- Output every file COMPLETE and VERBATIM in fenced code blocks with language tags.
-- No ellipses, no "rest unchanged", no placeholders.
-- Cite file paths and line ranges when discussing existing code.
-
-# SELF-VERIFICATION
-Before finishing, confirm all contract rules are satisfied; fix violations first.
-```
-
-### 3.3 Battle-tested prompt templates
-
-#### Template A — Code Audit (`prompt-with-attachment`, `timeout_sec: 600–900`)
-
-```markdown
-# ROLE
-You are a principal software auditor performing a production-readiness audit.
-
-# CONTEXT
-The attached file is a consolidated export of the target codebase.
-
-# TASK
-1. Identify correctness bugs, security issues, concurrency hazards, and error-handling gaps.
-2. Rate each finding: CRITICAL / HIGH / MEDIUM / LOW with file path + line reference.
-3. Provide a concrete fix (complete code) for every CRITICAL and HIGH finding.
-
-# OUTPUT CONTRACT
-## 1. Executive Summary (max 10 bullets)
-## 2. Findings Table (severity | location | category | description)
-## 3. Detailed Fixes (one subsection per CRITICAL/HIGH finding; complete patched code)
-## 4. Verification Checklist
-No truncation. Every fix must compile/run as-is.
-```
-
-#### Template B — Architecture Review (`prompt-with-attachment`, `timeout_sec: 900`)
-
-```markdown
-# ROLE
-You are a systems architect reviewing the attached design document.
-
-# TASK
-1. Reconstruct the implied architecture diagram in Mermaid.
-2. Evaluate: scalability, failure domains, data consistency, observability, security.
-3. Produce ADR-style recommendations (Context / Decision / Consequences) for each weakness.
-
-# OUTPUT CONTRACT
-## 1. Architecture Reconstruction (Mermaid)
-## 2. Strengths
-## 3. Weaknesses & Risks (ranked)
-## 4. ADR Recommendations (numbered)
-## 5. Verification Checklist
-```
-
-#### Template C — Multi-File Refactoring (`prompt-with-attachment`, `timeout_sec: 600–900`)
-
-```markdown
-# ROLE
-You are a senior engineer executing a surgical refactor.
-
-# CONTEXT
-Attached: consolidated export of all files in scope.
-Refactor goal: <state invariant-preserving goal, e.g. "extract I/O behind a protocol">.
-
-# TASK
-1. List every file that must change and why.
-2. Preserve public behavior; change only what the goal requires.
-3. Output the COMPLETE new content of every changed file.
-
-# OUTPUT CONTRACT
-## 1. Change Manifest (file | change | reason)
-## 2. Invariants Preserved
-## 3. Full File Contents (one fenced block per file, path as header comment)
-## 4. Migration & Test Plan
-## 5. Verification Checklist
-NEVER output partial files. Unchanged files must be listed, not re-emitted.
-```
-
-#### Template D — Bug Fix (`prompt-direct` or `prompt-only`, `timeout_sec: 300`)
-
-```markdown
-# ROLE
-You are a debugging specialist.
-
-# SYMPTOM
-<observed behavior + exact error message / stack trace>
-
-# EXPECTED
-<correct behavior>
-
-# REPRODUCTION
-<minimal steps or input>
-
-# CODE
-<paste the smallest relevant code section, or reference the attachment>
-
-# OUTPUT CONTRACT
-## 1. Root Cause Analysis (chain of causality, not guesses)
-## 2. Fix (complete corrected code, language-tagged fence)
-## 3. Regression Test (a test that fails before the fix, passes after)
-## 4. Verification Checklist
-```
-
-#### Template E — PR Summary (`prompt-with-attachment`, `timeout_sec: 300`)
-
-```markdown
-# ROLE
-You are a tech lead writing a review-ready PR description.
-
-# CONTEXT
-Attached: the full diff (or consolidated changed files).
-
-# OUTPUT CONTRACT
-## 1. What & Why (3–5 sentences)
-## 2. Change Breakdown (per-file: intent + notable hunks)
-## 3. Risk Assessment (behavior changes, migrations, feature flags)
-## 4. Test Plan (how this was / should be verified)
-## 5. Reviewer Focus Areas (max 5 bullets)
-```
-
----
-
-## 4. Resilience, Error Handling & Session Recovery
-
-### 4.1 Error → agent action matrix
-
-| Exception / MCP code | Meaning | Agent action | Retryable? |
-| :--- | :--- | :--- | :--- |
-| `AuthRequiredError` (exit 2, `AUTH_REQUIRED`) | Session expired / login page detected | Call `setup_session` (or `qwen-web-arwaky login`), then retry the original task | ✅ after login |
-| `OutputValidationError` w/ "verify you are human" | CAPTCHA / bot challenge | `setup_session` headed; human solves CAPTCHA; retry | ✅ after human |
-| `OutputValidationError` (502/504/service unavailable) | Transient server error | Back off 10–30s, retry once | ✅ |
-| `NetworkTimeoutError` | Browser network timeout | Retry with `timeout_sec × 2`; if repeated → `doctor` | ✅ |
-| `ResponseDetectionTimeoutError` | Dispatch succeeded but no answer detected | Retry with larger timeout; simplify prompt; check logs for last lifecycle event | ✅ |
-| `CircuitBreakerOpenError` | ≥5 failures within 30s window | **Stop.** Back off ≥30s, diagnose root cause, then resume | ⏸ after backoff |
-| `PromptInjectionError` | All 3 injection strategies failed | Qwen UI likely changed → run `qwen-web-arwaky update`, retry | ⚠️ |
-| `FileValidationError` | Attachment missing / unreadable / >100 MB | Fix path/permissions/size; retry | ✅ after fix |
-| `UploadFailureError` | Attachment could not be verified as uploaded | Retry once; if repeated, convert attachment to `.md`/`.txt` | ✅ |
-| `SendDispatchError` | Send click + Enter fallback both failed | Check parse-toast state; retry; `doctor` if repeated | ✅ |
-| `ModelSwitchError` | Default model `Qwen3.8-Max` could not be verified | Retry once; check account model access | ⚠️ |
-| `BrowserLaunchError` | Chromium cannot start | `python3 -m playwright install chromium` or `qwen-web-arwaky update` | ✅ after fix |
-| `FILE_NOT_FOUND` / `VALIDATION_ERROR` (MCP) | Bad tool arguments | Fix the flagged `field` from the error envelope; never blind-retry | ❌ fix first |
-
-Built-in guardrails you inherit automatically: client-side rate limiter (60 req/min),
-circuit breaker (5 failures / 30s), upload retry with backoff (3 attempts), browser
-launch retry (3 attempts), stale-lock cleanup, and permission self-repair.
-
-### 4.2 Failure decision tree
-
-```
-Task returned an error / suspicious output
-│
-├─ Message contains "AUTH_REQUIRED", "login", "Not authenticated"?
-│  └─► setup_session → check_session → RETRY original task
-│
-├─ Message contains "CAPTCHA", "verify you are human", "Attention Required"?
-│  └─► setup_session (headed; human solves challenge) → check_session → RETRY
-│
-├─ CircuitBreakerOpenError?
-│  └─► STOP ≥ 30s → inspect app.jsonl for the repeated root cause
-│      → fix cause → resume slowly (1 task, verify, continue)
-│
-├─ NetworkTimeoutError / 5xx challenge text?
-│  └─► back off 10–30s → RETRY (completion is event-driven; no timeout cap)
-│      → still failing? run `qwen-web-arwaky doctor`, verify connectivity
-│
-├─ ResponseDetectionTimeoutError?
-│  └─► Check last lifecycle event in logs:
-│      • stopped before SEND_CLICKED → injection/send problem → retry, then `update`
-│      • stopped after DISPATCH_ACKNOWLEDGED → model side slow → keep waiting;
-│        only the 4-hour no-terminal-event circuit breaker stops the run
-│
-├─ Upload/File errors?
-│  └─► verify: exists · regular file · readable · ≤ 100 MB · .pdf/.md/.txt
-│      → RETRY once → if still failing, convert content to consolidated .md
-│
-├─ BrowserLaunchError / PromptInjectionError / ModelSwitchError?
-│  └─► `qwen-web-arwaky doctor` → `qwen-web-arwaky update` (package + Chromium sync) → RETRY
-│
-└─ MCP VALIDATION_ERROR / FILE_NOT_FOUND?
-   └─► read `error.field` + `error.hint`; correct arguments; do NOT retry unchanged
-```
-
-### 4.3 Session recovery procedure (canonical order)
-
-```
-1. check_session                          # cheap, headless validation
-2. valid?  ── yes ──► proceed
-        └── no ──► setup_session          # headed browser; user logs in;
-                                          # closing the browser triggers validation
-3. repeated CAPTCHA or corrupt profile?
-   ──► delete_session(confirm: true)      # wipes qwen_session/ (path-safety checked)
-   ──► setup_session                      # fresh profile
-4. check_session                          # MUST pass before resuming batch work
-```
-
-Session facts for agents:
-- Session lives in the OS data dir (`~/.local/share/qwen-web/qwen_session` on Linux,
-  `~/Library/Application Support/qwen-web` on macOS, `%LOCALAPPDATA%\qwen-web` on Windows).
-- `setup_session` reuses an already-valid session without opening a browser.
-- Directory permissions (`0700`) and Chromium lock files self-heal on every launch.
-- `delete_session` refuses unsafe paths and requires explicit `confirm: true`.
-
----
-
-## 5. Best Practices for Power Users & Autonomous Agents
-
-### 5.1 Choosing the right surface
-
-| Surface | Use when | Notes |
+| Action | MCP Tool | CLI Command (`qwa` / `qwen-web-arwaky`) |
 | :--- | :--- | :--- |
-| **MCP tools** | Agent-loop integration (Claude Desktop, Cursor, Antigravity, Gemini CLI) | Structured JSON envelopes, `retryable` hints, per-field validation errors |
-| **CLI subcommands** | CI/CD, shell scripts, cron, chained pipelines | `--json` for parsing; deterministic exit codes |
-| **Interactive TUI** | Human-supervised debugging | Live log streaming, file picker, one-keystroke run/login/init/reset |
+| Direct text prompt | `process_direct_prompt` | `qwa prompt-direct -t "<prompt>" [-o <out>]` |
+| Prompt file only | `process_prompt_file_only` | `qwa prompt-only -i <prompt.md> [-o <out>]` |
+| Prompt with attachment | `process_prompt_with_attachment` | `qwa prompt-with-attachment -i <prompt.md> -a <file> [-o <out>]` |
+| Check session health | `check_session` | `qwa doctor` |
+| Manual login / CAPTCHA | `setup_session` | `qwa login` |
+| Reset session | `delete_session` | — |
+| Initialize workspace | `init_workspace` | `qwa init` |
 
-MCP client registration (Claude Desktop / Cursor style):
+> **File conventions:** Place inputs under `.qwen-web/input/` and outputs under `.qwen-web/output/`. Always append a timestamp to output filenames (e.g., `arch_review_$(date +%Y%m%d_%H%M%S).md` in CLI or `YYYYMMDD_HHMMSS` in MCP) to prevent overwriting results from previous runs.
 
+---
+
+## 2. Usage by Use Case
+
+### Use Case 1: Quick Inline Prompt / Question
+Use for fast queries, factual explanations, or one-off code generation where no external files are needed.
+
+**MCP:**
 ```json
 {
-  "mcpServers": {
-    "qwen-web": {
-      "command": "qwen-web-arwaky",
-      "args": ["mcp"]
-    }
-  }
+  "prompt": "Explain the difference between optimistic and pessimistic locking in 3 concise bullet points with a brief Python example.",
+  "headless": true
 }
 ```
 
-### 5.2 Combining CLI + MCP in one workflow
-
-1. **Bootstrap (once per machine, human-supervised):**
-   `qwen-web-arwaky doctor` → `qwen-web-arwaky login` → `qwen-web-arwaky init`
-2. **Autonomous steady state (agent via MCP):**
-   `check_session` → `process_*` tools → verify `.meta.json` → chain next task.
-3. **Recovery (agent escalates to CLI/human):**
-   `setup_session` for CAPTCHA; `qwen-web-arwaky update` for UI drift; `doctor --json` for diagnostics.
-
-### 5.3 File attachment strategy
-
-- **Consolidated code exports (`.md`)** are the highest-value attachment: one file,
-  exact filenames preserved, parsed fast. Prefer exporting the whole module into one
-  Markdown bundle over many small files (one attachment per run).
-- **PDF** for specs/PRDs/contracts; **TXT/MD** for logs, diffs, and data.
-- Keep attachments **≤ 100 MB**; split or summarize beyond that.
-- Upload verification matches the **exact filename** in the Qwen DOM — avoid exotic
-  characters in filenames; whitespace-normalized exact names parse most reliably.
-- Parsing may take up to 120s for large documents — the send gate waits automatically;
-  never "fix" a slow start by killing the run before 120s.
-
-### 5.4 Operational hygiene for autonomous loops
-
-1. **Pre-flight:** `check_session` once per agent session start, not per task.
-2. **Serialize** all executions (single persistent browser profile per machine).
-3. **Verify outputs:** success string or `success: true` envelope **and**
-   `output_chars > 0` in `.meta.json`; treat `ERROR [...]` result strings as failures.
-4. **Respect backoff:** on any `retryable: false` error, stop and surface the `hint`
-   to the user instead of looping.
-5. **Log forensics:** `app.jsonl` (JSONL events) + `status.json` (machine-readable run
-   state) live in the OS state dir (`~/.local/state/qwen-web/log` on Linux).
-6. **Keep the engine current:** `qwen-web-arwaky update --check` regularly; run
-7. **Headless discipline:** keep `headless: true` for all production tasks; headed
-   browsers are exclusively for `login` / `setup_session` / CAPTCHA resolution.
-
-### 5.5 Orphan processes & safe cleanup (read before killing anything)
-
-- **Never `pkill -9`/`kill -9` a qwen run as a first resort.** Hard-killing the CLI
-  does **not** close the Playwright Chromium it spawned — the browser keeps running
-  as an orphan, holds the shared `qwen_session` profile lock, and breaks every
-  subsequent run (`TargetClosedError`, hung dispatch, silent no-op). This is the
-  single most common cause of "it worked before, now it hangs".
-- **Symptoms of an orphan:** a new run starts but the page never acts; `EVENT_*`
-  stops right after `DISPATCH_ACKNOWLEDGED`; a second Chromium process lingers after
-  the CLI already exited; `TargetClosedError: Page.wait_for_timeout`.
-- **Safe cleanup order:**
-  1. Prefer letting the run finish — completion is event-driven; the only
-     automatic stop is the 4-hour no-terminal-event safety circuit breaker.
-  2. Prefer in-app cancellation (TUI **Cancel Run**; MCP has no cancel — wait).
-  3. Only as a last resort, kill the **exact PID** of the CLI process
-     (`kill <pid>`, not `pkill -9 -f`), then verify with
-     `ps aux | grep -E "chrome.*qwen_session"` that no orphan Chromium remains;
-     kill remaining orphan Chromium PIDs individually.
-  4. After any hard kill, **wait 2–3s** and confirm zero lingering
-     `chrome.*qwen_session` processes before starting the next run.
-- **Always run one pipeline at a time** on the shared profile; concurrent launches
-  collide and look identical to orphan-related hangs.
-
-### 5.6 Quick troubleshooting table
-
-| Symptom | Likely cause | Fix |
-| :--- | :--- | :--- |
-| Run dies at `EVENT_LOGIN_VERIFIED` gate | Expired cookies | `setup_session` |
-| Long run returns partial/short text | Challenge page captured | Read output; apply §5.2 tree |
-| "Default model not active" | Model picker drift | Retry; `update`; verify account access to `Qwen3.8-Max` |
-| Attachment never sends | Backend parse slow / toast | Wait ≥120s; retry; shrink file |
-| Nothing happens, no logs | Chromium missing | `doctor`; `python3 -m playwright install chromium` |
-| Two runs collide | Concurrent launches | Serialize — one pipeline at a time |
+**CLI:**
+```bash
+qwa prompt-direct -t "Explain optimistic vs pessimistic locking" -o .qwen-web/output/locking_$(date +%Y%m%d_%H%M%S).md --headless
+```
 
 ---
 
-*End of skill guide. Emit complete requests, verify every envelope, and let the
-terminal lifecycle event—not elapsed time—decide when output is complete.*
+### Use Case 2: Complex Task from a Prompt File
+Use for multi-step instructions, complex refactor specs, or long prompts authored in a Markdown file.
+
+**MCP:**
+```json
+{
+  "input_file": ".qwen-web/input/refactor_task.md",
+  "output_file": ".qwen-web/output/refactor_result_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-only -i .qwen-web/input/refactor_task.md -o .qwen-web/output/refactor_result_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 3: Code Audit or Document Analysis with Attachment
+Use when the prompt requires analyzing a codebase export, technical document, log file, or PDF spec (supported: `.pdf`, `.md`, `.txt` up to 100 MB).
+
+**MCP:**
+```json
+{
+  "prompt_file": ".qwen-web/input/audit_spec.md",
+  "attachment_file": ".qwen-web/input/codebase_export.md",
+  "output_file": ".qwen-web/output/audit_findings_20260911_133000.md",
+  "headless": true
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-with-attachment -i .qwen-web/input/audit_spec.md -a .qwen-web/input/codebase_export.md -o .qwen-web/output/audit_findings_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 4: Standard Reviews Using Built-in Role Templates
+Instead of writing a custom prompt file, you can pass a built-in role template name directly as the prompt input:
+- `backend`: Security, performance, error handling, code quality, and maintainability.
+- `architect`: Layer boundaries, architecture violations, scalability, and data flow.
+- `frontend`: Usability, responsive layout, component quality, and design tokens.
+- `analyst`: Requirements clarity, business logic flow, and testability.
+
+**MCP:**
+```json
+{
+  "prompt_file": "backend",
+  "attachment_file": "src/api/auth.py",
+  "output_file": ".qwen-web/output/auth_review_20260911_133000.md"
+}
+```
+
+**CLI:**
+```bash
+qwa prompt-with-attachment -i backend -a src/api/auth.py -o .qwen-web/output/auth_review_$(date +%Y%m%d_%H%M%S).md --headless
+qwa prompt-with-attachment -i architect -a README.md -o .qwen-web/output/arch_review_$(date +%Y%m%d_%H%M%S).md --headless
+```
+
+---
+
+### Use Case 5: Session Setup & Authentication
+Use to verify login status or authenticate a new browser session when cookies expire.
+
+1. **Check session health:**
+   - MCP: call `check_session`
+   - CLI: `qwa doctor`
+2. **Login / Re-authenticate (opens visible browser for login / CAPTCHA):**
+   - MCP: call `setup_session`
+   - CLI: `qwa login`
+3. **Reset session profile (if corrupted):**
+   - MCP: `delete_session` with `{"confirm": true}`
+
+---
+
+### Use Case 6: Workspace Initialization
+Use when provisioning `.qwen-web/` workspace directories and sample configuration in a new project.
+
+**MCP:**
+```json
+{
+  "target_dir": "."
+}
+```
+
+**CLI:**
+```bash
+qwa init
+```
+
+---
+
+## 3. Prompt Engineering for Complete, Un-Truncated Output
+
+To ensure Qwen produces complete code without placeholders or omitted sections:
+
+1. **Specify an explicit Output Contract:** Define exact required section titles and expected markdown formatting.
+2. **Forbid truncation explicitly:** Include this clause in your prompt:
+   > *"Output every file COMPLETE and VERBATIM inside fenced code blocks with language tags. Never use ellipses (`...`), placeholder comments (`// rest unchanged`), or omit code."*
+3. **Reason first, code second:** Request an analysis or plan before the implementation code so the model thinks before writing.
+4. **Put large context into attachments:** Keep the prompt file focused on instructions; provide code, logs, and schemas as attachments.
+5. **Add a self-verification step:** Instruct the model to verify that no placeholders exist and all requested items are satisfied before completing.
+
+---
+
+## 4. Error Handling & Recovery
+
+| Error / Condition | Cause | Action |
+| :--- | :--- | :--- |
+| `AuthRequiredError` / `AUTH_REQUIRED` | Session expired or login needed | Call `setup_session` (MCP) or run `qwa login` (CLI) to re-authenticate. |
+| `OutputValidationError` (CAPTCHA) | Bot verification challenge | Run `setup_session` or `qwa login` to solve challenge manually. |
+| `NetworkTimeoutError` | Temporary network latency | Retry the request; if persistent, verify internet connection via `qwa doctor`. |
+| `FileValidationError` / `FILE_NOT_FOUND` | Missing, unreadable, or file > 100 MB | Verify file path, permissions, and ensure file size is under 100 MB. |
+| `CircuitBreakerOpenError` | Repeated consecutive failures | Wait 30 seconds before sending next request. |
+| `VALIDATION_ERROR` (MCP) | Invalid tool parameter | Check error `field` in response and correct the argument payload. |
 """


### PR DESCRIPTION
## Summary

- **Removed Internal Mechanics**: Stripped all deep internal engine and architectural explanations (React Fiber tree traversal, DOM tree walker, Playwright keystroke injection details, layered AES architecture diagrams, lifecycle event sequence, orphan process PID management).
- **Use-Case-Driven Guide**: Reorganized the skill guide strictly around concrete, practical use cases for both MCP tools and CLI commands.
- **Timestamped Outputs**: Added recommendations and examples across CLI and MCP usages to include timestamps in output filenames (e.g. `arch_review_$(date +%Y%m%d_%H%M%S).md` / `YYYYMMDD_HHMMSS`) to avoid overwriting previous execution results.
- **Synchronized Artifacts**: Updated `taxonomy_skill_constant.py`, `.agents/skills/qwen-web/SKILL.md`, and root `SKILL.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the qwen-web skill guide from an internal-architecture reference into a use-case-driven guide. The old guide documented engine internals like React Fiber traversal and lifecycle events; the new one centers on six practical use cases for MCP tools and CLI commands, and every output example now includes a timestamp in the filename so repeated runs don't overwrite prior results.

- Removes deep internal documentation (React Fiber walking, DOM tree fallback, keystroke injection, AES layers, lifecycle event chains, orphan PID cleanup) from all three copies of the guide.
- Adds timestamp patterns like `arch_review_$(date +%Y%m%d_%H%M%S).md` (CLI) and `YYYYMMDD_HHMMSS` (MCP) to all output examples.
- Bumps skill version from 5.2.0 to 6.0.0 and renames `trigger_keywords` to `triggers` in the frontmatter.
- Syncs the same content across `.agents/skills/qwen-web/SKILL.md`, root `SKILL.md`, and `modules/shared/src/taxonomy_skill_constant.py`.

<sup>Written for commit 410dcce2f150fc9837456849844a6f152f423f80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the Qwen Web skill guide with a concise, use-case-focused reference.
  * Added expanded MCP and CLI command quick references, including session checks, login, reset, and workspace setup.
  * Added six practical usage examples with JSON and CLI invocations.
  * Added guidance for producing complete, untruncated output.
  * Added a structured error-handling and recovery reference.
  * Updated skill metadata to version 6.0.0 with new triggers and entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->