### PR TITLE
feat(init): add .qwen-web/jobs symlink to workspace provisioner

### DIFF
--- a/modules/core/src/capabilities_workspace_provisioner.py
+++ b/modules/core/src/capabilities_workspace_provisioner.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from modules.shared.src.contract_core_protocol import IWorkspaceProtocol
-from modules.shared.src.taxonomy_core_constant import DEFAULT_LOG, DEFAULT_OUTPUT, DEFAULT_SESSION
+from modules.shared.src.taxonomy_core_constant import DEFAULT_JOBS_DIR, DEFAULT_LOG, DEFAULT_OUTPUT, DEFAULT_SESSION
 from modules.shared.src.taxonomy_core_vo import FilePath
 from modules.shared.src.taxonomy_skill_constant import EMBEDDED_SKILL_MD
 
@@ -39,6 +39,7 @@ class WorkspaceProvisioner(IWorkspaceProtocol):
         target_path = Path(str(target_dir)).resolve()
 
         # Step 1: Ensure XDG directories exist
+        DEFAULT_JOBS_DIR.mkdir(parents=True, exist_ok=True)
         DEFAULT_OUTPUT.mkdir(parents=True, exist_ok=True)
         DEFAULT_LOG.mkdir(parents=True, exist_ok=True)
 
@@ -88,6 +89,7 @@ class WorkspaceProvisioner(IWorkspaceProtocol):
             )
 
         links: dict[str, Any] = {
+            "jobs": DEFAULT_JOBS_DIR,
             "log": DEFAULT_LOG,
             "output": DEFAULT_OUTPUT,
             "qwen_session": DEFAULT_SESSION,


### PR DESCRIPTION
Workspace init now creates a symlink for the jobs directory alongside log, output, and qwen_session. This exposes per-job JSONL logs under .qwen-web/jobs/ so users can inspect task-level run history without navigating to XDG_STATE_HOME directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workspace init now creates a `.qwen-web/jobs` symlink alongside `log`, `output`, and `qwen_session`, exposing per-job JSONL logs for easier inspection without navigating to XDG_STATE_HOME.

<sup>Written for commit 37cbd4c3cef72cc754be50f5f664c0c57c8f9531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace setup now creates a default jobs directory.
  * Added a workspace link for easier access to the jobs directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->