### PR TITLE
fix(browser): navigate to chat.qwen.ai eagerly on launch

### DIFF
--- a/modules/core/src/capabilities_browser_adapter.py
+++ b/modules/core/src/capabilities_browser_adapter.py
@@ -147,7 +147,19 @@ class BrowserAdapter(IBrowserProtocol):
         its own DOM readiness checks, so navigation uses ``commit`` and treats
         the later DOMContentLoaded wait as best-effort. Up to 4 attempts with
         exponential backoff (2s, 4s, 8s) handle transient network failures.
+
+        If the page is already on chat.qwen.ai (e.g. from eager navigation in
+        browser_session), the goto is skipped and only DOM readiness is awaited.
         """
+        # Fast path: eager navigation in browser_session already landed us here.
+        if "chat.qwen.ai" in (page.url or ""):
+            log.debug("browser_skip_goto_already_on_chat", url=page.url)
+            try:
+                page.wait_for_load_state("domcontentloaded", timeout=load_timeout_ms)
+            except Error as err:
+                log.warning("Load state wait failed, proceeding: %s", err)
+            return
+
         max_attempts = 4
         backoff_ms = [2000, 4000, 8000]
         last_error: Error | None = None
@@ -490,6 +502,21 @@ class BrowserAdapter(IBrowserProtocol):
                 with sync_playwright() as p:
                     ctx = self._launch_context(p, kwargs)
                     context_started = True
+
+                    # Eagerly navigate the initial about:blank page to CHAT_URL
+                    # so the browser starts loading while route/diagnostics setup
+                    # and orchestrator init happen in parallel.
+                    if ctx.pages:
+                        try:
+                            ctx.pages[0].goto(
+                                CHAT_URL,
+                                wait_until="commit",
+                                timeout=NAVIGATION_TIMEOUT_MS,
+                            )
+                            log.debug("browser_eager_navigate_ok", url=CHAT_URL)
+                        except Error as exc:
+                            log.warning("browser_eager_navigate_failed, will retry in navigate_to_chat: %s", exc)
+
                     if mode != "login":
                         ctx.route(
                             "**/*.{png,jpg,jpeg,gif,webp,mp4,mp3,woff,woff2,ttf,otf}",


### PR DESCRIPTION
## Problem
Browser opens to `about:blank` (Playwright default), stays blank until orchestrator calls `navigate_to_chat`. The blank page delay is visible and delays chat.qwen.ai loading.

## Solution
- Add eager navigation in `browser_session` right after context creation — page starts loading immediately
- Route/diagnostics setup and orchestrator init happen in parallel with page load
- Add fast-path in `_goto_chat` to skip redundant goto when already on chat.qwen.ai

## Changes
- `capabilities_browser_adapter.py`: Eager `page.goto(CHAT_URL)` in `browser_session`, skip-if-already-on-chat in `_goto_chat`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts loading chat.qwen.ai immediately when the browser session starts, instead of waiting for the orchestrator to call `navigate_to_chat`. The initial blank page is gone and the chat page loads in parallel with route/diagnostics setup and orchestrator init.

- Adds an eager `page.goto(CHAT_URL)` right after the browser context is created.
- Adds a fast-path in `_goto_chat` that skips navigation when already on chat.qwen.ai, only waiting for DOM readiness.
- If eager navigation fails, it logs a warning and the later `_goto_chat` call retries as before.

<sup>Written for commit 42d4573f167dcf699e1d9a738c540c421b921b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

