### PR TITLE
fix(tui): close browser context on slot cancel

### DIFF
--- a/modules/cli/src/surface_cli_tui_workers.py
+++ b/modules/cli/src/surface_cli_tui_workers.py
@@ -152,6 +152,11 @@ class _TuiWorkersMixin:
         self._update_slot_status(slot_id, "⚠ CANCELLING…")
         self._set_slot_tab_title(slot_id, f"Slot {slot_id} ⚠")
         self._slot_generation[slot_id] = self._slot_generation.get(slot_id, 0) + 1
+        # Close active browser contexts so Playwright operations unblock
+        with contextlib.suppress(Exception):
+            self._attachment.request_cancel()
+        with contextlib.suppress(Exception):
+            self._file_only.request_cancel()
         worker.cancel()
         self._slot_workers[slot_id] = None
         self._log_msg(f"[bold {THEME['warn']}]CANCELLED:[/] Slot {slot_id} stopped by user.", slot_id)

--- a/modules/core/src/agent_attachment_prompt_orchestrator.py
+++ b/modules/core/src/agent_attachment_prompt_orchestrator.py
@@ -80,8 +80,10 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
         with self._bctx_lock:
             bctx = self._active_bctx
         if bctx is not None:
-            with contextlib.suppress(Exception):
-                bctx.close()
+            close_fn = getattr(bctx, "close", None)
+            if callable(close_fn):
+                with contextlib.suppress(Exception):
+                    close_fn()
 
     def process_prompt_with_attachment(
         self,

--- a/modules/core/src/agent_attachment_prompt_orchestrator.py
+++ b/modules/core/src/agent_attachment_prompt_orchestrator.py
@@ -6,6 +6,8 @@ Supports folder-to-attachment compilation (folder -> single markdown file).
 
 from __future__ import annotations
 
+import contextlib
+import threading
 import time
 from pathlib import Path
 
@@ -68,6 +70,18 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
         self._observability = observability
         self._flow = flow
         self._folder_adapter = folder_adapter
+        self._cancel_event = threading.Event()
+        self._active_bctx: object | None = None
+        self._bctx_lock = threading.Lock()
+
+    def request_cancel(self) -> None:
+        """Request cancellation of any active browser session."""
+        self._cancel_event.set()
+        with self._bctx_lock:
+            bctx = self._active_bctx
+        if bctx is not None:
+            with contextlib.suppress(Exception):
+                bctx.close()
 
     def process_prompt_with_attachment(
         self,
@@ -82,6 +96,7 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
         compiled to a single markdown file before upload.
         """
         ctx = RunContext()
+        self._cancel_event.clear()
         try:
             p_path = Path(prompt_file).resolve()
             if not p_path.exists():
@@ -106,10 +121,18 @@ class AttachmentPromptOrchestrator(IAttachmentPromptAggregate):
 
             t0 = time.time()
             with self._browser.browser_session(cfg) as bctx:
-                page = bctx.pages[0] if bctx.pages else bctx.new_page()
-                text = self._execute_attachment_on_page(
-                    page, p_path, att_path, cfg.request_timeout, cfg, emitter, state
-                )
+                with self._bctx_lock:
+                    self._active_bctx = bctx
+                try:
+                    if self._cancel_event.is_set():
+                        raise RuntimeError("Cancelled by user")
+                    page = bctx.pages[0] if bctx.pages else bctx.new_page()
+                    text = self._execute_attachment_on_page(
+                        page, p_path, att_path, cfg.request_timeout, cfg, emitter, state
+                    )
+                finally:
+                    with self._bctx_lock:
+                        self._active_bctx = None
             dur = time.time() - t0
             save_orchestrator_output(self._saver, out_path, p_path, text, dur, ctx, emitter=emitter)
             return ResponseText(f"Successfully processed {p_path.name} with attachment {att_path.name} -> {out_path}")

--- a/modules/core/src/agent_prompt_file_orchestrator.py
+++ b/modules/core/src/agent_prompt_file_orchestrator.py
@@ -72,8 +72,10 @@ class PromptFileOrchestrator(IPromptFileAggregate):
         with self._bctx_lock:
             bctx = self._active_bctx
         if bctx is not None:
-            with contextlib.suppress(Exception):
-                bctx.close()
+            close_fn = getattr(bctx, "close", None)
+            if callable(close_fn):
+                with contextlib.suppress(Exception):
+                    close_fn()
 
     def process_prompt_file_only(
         self,

--- a/modules/core/src/agent_prompt_file_orchestrator.py
+++ b/modules/core/src/agent_prompt_file_orchestrator.py
@@ -5,6 +5,8 @@ Orchestrates prompt execution from local prompt file (.md) without attachment.
 
 from __future__ import annotations
 
+import contextlib
+import threading
 import time
 from pathlib import Path
 
@@ -60,6 +62,18 @@ class PromptFileOrchestrator(IPromptFileAggregate):
         self._saver = saver
         self._observability = observability
         self._flow = flow
+        self._cancel_event = threading.Event()
+        self._active_bctx: object | None = None
+        self._bctx_lock = threading.Lock()
+
+    def request_cancel(self) -> None:
+        """Request cancellation of any active browser session."""
+        self._cancel_event.set()
+        with self._bctx_lock:
+            bctx = self._active_bctx
+        if bctx is not None:
+            with contextlib.suppress(Exception):
+                bctx.close()
 
     def process_prompt_file_only(
         self,
@@ -69,6 +83,7 @@ class PromptFileOrchestrator(IPromptFileAggregate):
     ) -> ResponseText:
         """Pipeline 2: Process a prompt file from disk without attachment."""
         ctx = RunContext()
+        self._cancel_event.clear()
         try:
             p_path, out_path = resolve_pipeline_output_path(prompt_file, output_file)
             cfg = build_app_config(
@@ -82,8 +97,16 @@ class PromptFileOrchestrator(IPromptFileAggregate):
 
             t0 = time.time()
             with self._browser.browser_session(cfg) as bctx:
-                page = bctx.pages[0] if bctx.pages else bctx.new_page()
-                text = self._execute_file_on_page(page, p_path, cfg.request_timeout, cfg, emitter, state)
+                with self._bctx_lock:
+                    self._active_bctx = bctx
+                try:
+                    if self._cancel_event.is_set():
+                        raise RuntimeError("Cancelled by user")
+                    page = bctx.pages[0] if bctx.pages else bctx.new_page()
+                    text = self._execute_file_on_page(page, p_path, cfg.request_timeout, cfg, emitter, state)
+                finally:
+                    with self._bctx_lock:
+                        self._active_bctx = None
             dur = time.time() - t0
             save_orchestrator_output(self._saver, out_path, p_path, text, dur, ctx, emitter=emitter)
             return ResponseText(f"Successfully processed {p_path.name} -> {out_path}")


### PR DESCRIPTION
## Problem

TUI cancel slot button doesn't actually stop the browser. `worker.cancel()` raises `CancelledError` in the Python thread, but Playwright sync API runs in C-level code — the exception can't interrupt `page.goto()` / `page.fill()`. The UI shows CANCELLED but the Chromium process keeps running.

## Fix

Store active `BrowserContext` reference in orchestrators and close it on `request_cancel()`. This causes Playwright operations to raise, unblocking the worker thread.

### Changes

- **AttachmentPromptOrchestrator**: add `_cancel_event`, `_active_bctx`, `request_cancel()`
- **PromptFileOrchestrator**: same pattern  
- **TUI `_do_cancel_slot`**: call `request_cancel()` before `worker.cancel()`

### Testing

- Ruff: all checks passed
- AES linter: no new violations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI cancel slot button so it actually stops the running browser session; previously the UI showed CANCELLED but the Chromium process kept running because `worker.cancel()` cannot interrupt Playwright's blocking C-level calls.

**Changes**
- `AttachmentPromptOrchestrator` and `PromptFileOrchestrator` now track the active `BrowserContext` and expose `request_cancel()`, which closes the context so Playwright operations raise and unblock the worker.
- The TUI cancel handler calls `request_cancel()` before `worker.cancel()`, safely suppressing any errors when the context can't be closed.
- Cancellation is checked before execution begins, and already-cancelled runs are rejected.

<sup>Written for commit c16ef334f2c967bf9a24a63be718fc38efb04bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation behavior for active browser operations.
  * Cancelling a task now promptly closes its active browser session, helping prevent pending operations from blocking shutdown.
  * Cancellation requests are handled safely even when a browser session cannot be closed normally.
  * Already-cancelled runs are rejected before execution begins.
  * Cancellation state and active session tracking are reliably reset between executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->