### PR TITLE
fix(tui): guard slot button ID parsing against modal buttons

### DIFF
--- a/modules/cli/src/surface_cli_tui_handlers.py
+++ b/modules/cli/src/surface_cli_tui_handlers.py
@@ -50,8 +50,10 @@ class _TuiHandlersMixin:
         button_id = event.button.id or ""
         for prefix, handler in (("btn-run-", self._run_slot), ("btn-cancel-", self._cancel_slot)):
             if button_id.startswith(prefix):
-                handler(int(button_id.removeprefix(prefix)))
-                return
+                suffix = button_id.removeprefix(prefix)
+                if suffix.isdigit():
+                    handler(int(suffix))
+                    return
         for field, picker in (("prompt", False), ("file", True), ("output", False)):
             prefix = f"btn-browse-{field}-"
             if button_id.startswith(prefix):


### PR DESCRIPTION
### Problem
In `surface_cli_tui_handlers.py`, clicking the cancel button in confirmation modals (`btn-cancel-modal`) matched the `btn-cancel-` prefix and tried to parse `int('modal')`, crashing the TUI with `ValueError: invalid literal for int() with base 10: 'modal'`.

### Solution
Add an `is_digit()` check before parsing the numeric slot ID, ignoring non-numeric suffixes like `modal`.

### Validation
- `lint-arwaky-cli scan`: 0 violations
- `ruff check modules/`: passed
- `mypy modules/`: passed
- `pytest tests/unit_surface_cli_tui_app.py`: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI crashing when clicking the cancel button in confirmation modals by ignoring non-numeric button ID suffixes like `modal` instead of trying to parse them as slot IDs.

<sup>Written for commit da411488e4b16cdc9976ab08f90c59129e03c61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rakaarwaky/qwen-web-arwaky/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

